### PR TITLE
fix(deps): 降級 Node.js 到 22 LTS 以確保生產穩定性

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/update-exchange-rates-historical.yml
+++ b/.github/workflows/update-exchange-rates-historical.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Fetch Taiwan Bank exchange rates
         run: |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@9.10.0",
   "engines": {
-    "node": ">=24.0.0",
+    "node": ">=20.0.0 <25.0.0",
     "pnpm": "9.10.0"
   },
   "scripts": {


### PR DESCRIPTION
## 🎯 目標

修復 Node.js 版本選擇問題，確保生產環境穩定性。

## 📋 變更內容

- 更新 `package.json` engines.node 為 `>=20.0.0 <25.0.0`
- 更新所有 GitHub Actions workflows 使用 Node.js 22
- 影響檔案：
  - `package.json`
  - `.github/workflows/ci.yml`
  - `.github/workflows/pr-check.yml`
  - `.github/workflows/update-exchange-rates-historical.yml`

## 🔍 問題分析

**當前問題**：
- Node.js 24 目前為 "Current" 狀態，僅支援 6 個月
- 不適合生產環境使用

**解決方案**：
- Node.js 22 為 Active LTS
- 支援至 2027-04-30
- 適合長期生產使用

## ✅ 測試驗證

- [ ] CI/CD workflows 通過
- [ ] 本地建置成功
- [ ] 所有測試通過

## 📚 參考資料

- [Node.js Release Schedule](https://nodejs.org/en/about/previous-releases)
- [context7:/cli/cli:2025-10-14T01:15:52+08:00]
- 技術債審查: `docs/dev/TECH_DEBT_AUDIT_2025.md`

## 🏷️ 類型

- [x] 🐛 Bug Fix (P0 - 緊急修復)
- [ ] ✨ Feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor