### PR TITLE
fix(routing): 修復子路徑部署的路由和 CSP 配置

### DIFF
--- a/apps/ratewise/src/App.tsx
+++ b/apps/ratewise/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
   return (
     <ErrorBoundary>
       <SEOHelmet />
-      <Router>
+      <Router basename="/ratewise">
         <Routes>
           <Route path="/" element={<CurrencyConverter />} />
           <Route path="/faq" element={<FAQ />} />

--- a/apps/ratewise/src/main.tsx
+++ b/apps/ratewise/src/main.tsx
@@ -74,7 +74,7 @@ logger.info('Application mounted successfully');
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
-      .register('/sw.js')
+      .register('/ratewise/sw.js')
       .then((registration) => {
         logger.info('SW registered', { scope: registration.scope });
       })

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
   const buildTime = new Date().toISOString();
 
   return {
+    base: '/ratewise/',
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
       __BUILD_TIME__: JSON.stringify(buildTime),

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,8 @@ http {
         
         # Content Security Policy (CSP) - 防止 XSS 攻擊
         # 生產環境使用嚴格策略，允許 inline scripts 用於 PWA 和 React
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://raw.githubusercontent.com https://cdn.jsdelivr.net; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+        # 允許 Cloudflare Insights (static.cloudflareinsights.com)
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://raw.githubusercontent.com https://cdn.jsdelivr.net https://cloudflareinsights.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
         
         # HTTP Strict Transport Security (HSTS) - 強制 HTTPS
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;


### PR DESCRIPTION
問題：
1. React Router 無法匹配 /ratewise/ 路徑
2. Vite 靜態資源路徑錯誤
3. Cloudflare Insights 被 CSP 阻擋

修復：
- App.tsx: 新增 BrowserRouter basename="/ratewise"
- vite.config.ts: 新增 base: '/ratewise/' 配置
- main.tsx: 更新 Service Worker 路徑為 /ratewise/sw.js
- nginx.conf: CSP 新增 https://static.cloudflareinsights.com

根因：
應用部署在 app.haotool.org/ratewise/ 子路徑，
但 React Router 和 Vite 未配置 base path

驗證：
✅ 本地 preview 測試通過（http://localhost:4173/ratewise/）
✅ 路由正常工作（/, /faq, /about）
✅ TypeScript 編譯通過
✅ 生產建置成功

參考：
- [context7:remix-run/react-router:BrowserRouter.basename]
- [context7:vitejs/vite:base-config]

Fixes: 路由 404 錯誤
Fixes: CSP 阻擋 Cloudflare Insights
