### PR TITLE
chore(deps): 更新 prettier 3.7.1 → 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lighthouse": "^13.0.1",
     "lint-staged": "^15.2.0",
     "pa11y": "^9.0.1",
-    "prettier": "^3.7.1",
+    "prettier": "^3.7.2",
     "seo-analyzer": "^3.2.0",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1(typescript@5.9.3)
       prettier:
-        specifier: ^3.7.1
-        version: 3.7.1
+        specifier: ^3.7.2
+        version: 3.7.2
       seo-analyzer:
         specifier: ^3.2.0
         version: 3.2.0
@@ -197,7 +197,7 @@ importers:
         version: 0.21.2(vite@7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(prettier@3.7.1)(react-dom@19.2.0(react@19.2.0))(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))
+        version: 0.8.9(prettier@3.7.2)(react-dom@19.2.0(react@19.2.0))(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.14
         version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@22.18.9)(jiti@1.21.7)(jsdom@24.1.3)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)
@@ -6160,8 +6160,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.7.1:
-    resolution: {integrity: sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==}
+  prettier@3.7.2:
+    resolution: {integrity: sha512-n3HV2J6QhItCXndGa3oMWvWFAgN1ibnS7R9mt6iokScBOC0Ul9/iZORmU2IWUMcyAQaMPjTlY3uT34TqocUxMA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -14917,7 +14917,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.7.1: {}
+  prettier@3.7.2: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -16528,7 +16528,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-react-ssg@0.8.9(prettier@3.7.1)(react-dom@19.2.0(react@19.2.0))(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)):
+  vite-react-ssg@0.8.9(prettier@3.7.2)(react-dom@19.2.0(react@19.2.0))(react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       fs-extra: 11.3.2
       html5parser: 2.0.2
@@ -16541,7 +16541,7 @@ snapshots:
       vite: 7.1.12(@types/node@22.18.9)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)
       yargs: 17.7.2
     optionalDependencies:
-      prettier: 3.7.1
+      prettier: 3.7.2
       react-router-dom: 6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## 變更說明

- Patch 版本升級，無破壞性變更
- 所有 lint/typecheck/format 檢查通過

## 驗證

- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm format --check` 通過

## 參考

- [context7:prettier/prettier:2025-11-29]