### PR TITLE
chore: 移除未使用的 isCacheKey/isUserDataKey 函數

### DIFF
--- a/apps/ratewise/src/features/ratewise/storage-keys.ts
+++ b/apps/ratewise/src/features/ratewise/storage-keys.ts
@@ -47,6 +47,7 @@ export const CACHE_KEYS = [STORAGE_KEYS.EXCHANGE_RATES] as const;
 
 /**
  * 用戶數據類型的 Keys (不可清除)
+ * 註: 這些 keys 由 versionManager.ts 在清除快取時保留
  */
 export const USER_DATA_KEYS = [
   STORAGE_KEYS.CURRENCY_CONVERTER_MODE,
@@ -55,17 +56,3 @@ export const USER_DATA_KEYS = [
   STORAGE_KEYS.TO_CURRENCY,
   STORAGE_KEYS.RATE_TYPE,
 ] as const;
-
-/**
- * 檢查 key 是否為快取類型
- */
-export function isCacheKey(key: string): boolean {
-  return CACHE_KEYS.includes(key as (typeof CACHE_KEYS)[number]);
-}
-
-/**
- * 檢查 key 是否為用戶數據類型
- */
-export function isUserDataKey(key: string): boolean {
-  return USER_DATA_KEYS.includes(key as (typeof USER_DATA_KEYS)[number]);
-}


### PR DESCRIPTION
## 變更摘要

### 🎯 目的
移除 `storage-keys.ts` 中未使用的死代碼，提升測試覆蓋率。

### 📝 變更內容
- 刪除 `isCacheKey()` 函數 (未被任何地方使用)
- 刪除 `isUserDataKey()` 函數 (未被任何地方使用)
- 保留 `USER_DATA_KEYS` 常數 (被 versionManager.ts 註解引用)

### 📊 測試覆蓋率變化
| 檔案 | 變更前 | 變更後 |
|-----|-------|-------|
| storage-keys.ts | 60% | 100% |
| 整體覆蓋率 | 87.82% | 87.93% |

### ✅ 驗證
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過 (0 errors)
- [x] `pnpm test` 通過 (604/604)

### 📚 依據
- [LINUS_GUIDE.md:簡潔執念] - 移除死代碼，保持簡潔
- Linus 三問驗證: 這是真問題 (死代碼降低覆蓋率)、有更簡單的方法 (直接刪除)、不會破壞任何功能