### PR TITLE
feat(settings): 重構設定頁 IA 新增支援與資訊區塊

### DIFF
--- a/apps/ratewise/src/config/__tests__/app-info.test.ts
+++ b/apps/ratewise/src/config/__tests__/app-info.test.ts
@@ -1,0 +1,51 @@
+/**
+ * App Info SSOT Test Suite
+ *
+ * 測試應用程式基本資訊 SSOT 模組
+ */
+
+import { describe, it, expect } from 'vitest';
+import { APP_INFO, getCopyrightYears, getCopyrightNotice } from '../app-info';
+
+describe('app-info', () => {
+  describe('APP_INFO constants', () => {
+    it('should have name defined', () => {
+      expect(APP_INFO.name).toBe('RateWise');
+    });
+
+    it('should have author defined', () => {
+      expect(APP_INFO.author).toBe('HaoTool');
+    });
+
+    it('should have valid email format', () => {
+      expect(APP_INFO.email).toMatch(/^[\w.-]+@[\w.-]+\.\w+$/);
+    });
+
+    it('should have valid GitHub URL', () => {
+      expect(APP_INFO.github).toMatch(/^https:\/\/github\.com\//);
+    });
+
+    it('should have license defined', () => {
+      expect(APP_INFO.license).toBe('GPL-3.0');
+    });
+
+    it('should have copyright years defined', () => {
+      expect(APP_INFO.copyrightStartYear).toBe(2025);
+      expect(APP_INFO.copyrightEndYear).toBe(2026);
+    });
+  });
+
+  describe('getCopyrightYears', () => {
+    it('should return formatted year range', () => {
+      const years = getCopyrightYears();
+      expect(years).toBe('2025-2026');
+    });
+  });
+
+  describe('getCopyrightNotice', () => {
+    it('should return formatted copyright notice', () => {
+      const notice = getCopyrightNotice();
+      expect(notice).toBe('© 2025-2026 RateWise');
+    });
+  });
+});

--- a/apps/ratewise/src/config/app-info.ts
+++ b/apps/ratewise/src/config/app-info.ts
@@ -1,0 +1,59 @@
+/**
+ * App Information - Single Source of Truth
+ *
+ * 應用程式基本資訊 SSOT 模組
+ * 所有作者、聯繫、授權資訊從此模組導入
+ */
+
+export const APP_INFO = {
+  /** 應用程式名稱 */
+  name: 'RateWise',
+
+  /** 應用程式副標題 */
+  subtitle: '匯率好工具',
+
+  /** 開發者/組織名稱 */
+  author: 'HaoTool',
+
+  /** 聯繫信箱 */
+  email: 'haotool.org@gmail.com',
+
+  /** GitHub 倉庫 URL */
+  github: 'https://github.com/haotool/app',
+
+  /** 授權類型 */
+  license: 'GPL-3.0',
+
+  /** 版權起始年份 */
+  copyrightStartYear: 2025,
+
+  /** 版權結束年份（當前年份） */
+  copyrightEndYear: 2026,
+
+  /** 網站 URL */
+  siteUrl: 'https://app.haotool.org/ratewise/',
+} as const;
+
+/**
+ * 取得版權年份字串
+ * @returns 格式化的版權年份，如 "2025-2026" 或 "2025"
+ */
+export function getCopyrightYears(): string {
+  const start = APP_INFO.copyrightStartYear;
+  const end = APP_INFO.copyrightEndYear;
+  // 使用 Number() 轉換避免 TypeScript 字面類型比較錯誤
+  if (Number(start) === Number(end)) {
+    return String(start);
+  }
+  return `${start}-${end}`;
+}
+
+/**
+ * 取得完整版權聲明
+ * @returns 格式化的版權聲明
+ */
+export function getCopyrightNotice(): string {
+  return `© ${getCopyrightYears()} ${APP_INFO.name}`;
+}
+
+export type AppInfo = typeof APP_INFO;

--- a/apps/ratewise/src/i18n/locales/en.ts
+++ b/apps/ratewise/src/i18n/locales/en.ts
@@ -129,9 +129,14 @@ const en = {
     appVersion: 'App Version',
     designSystem: 'Design System',
     techStack: 'Tech Stack',
-    copyright: '© 2026 RateWise. Built with Design Token SSOT',
+    copyright: '© 2025-2026 RateWise',
     sixStylesSST: '6 Styles SSOT',
     reactTailwind: 'React + Tailwind',
+    // Support & Info section
+    supportInfo: 'Support & Info',
+    faq: 'FAQ',
+    aboutUs: 'About Us',
+    openSource: 'Open Source',
   },
 
   // Styles

--- a/apps/ratewise/src/i18n/locales/ja.ts
+++ b/apps/ratewise/src/i18n/locales/ja.ts
@@ -128,9 +128,14 @@ const ja = {
     appVersion: 'アプリバージョン',
     designSystem: 'デザインシステム',
     techStack: '技術スタック',
-    copyright: '© 2026 RateWise. Built with Design Token SSOT',
+    copyright: '© 2025-2026 RateWise',
     sixStylesSST: '6 Styles SSOT',
     reactTailwind: 'React + Tailwind',
+    // サポートと情報セクション
+    supportInfo: 'サポートと情報',
+    faq: 'よくある質問',
+    aboutUs: '私たちについて',
+    openSource: 'オープンソース',
   },
 
   // Styles

--- a/apps/ratewise/src/i18n/locales/zh-TW.ts
+++ b/apps/ratewise/src/i18n/locales/zh-TW.ts
@@ -128,9 +128,14 @@ const zhTW = {
     appVersion: '應用程式版本',
     designSystem: '設計系統',
     techStack: '技術棧',
-    copyright: '© 2026 RateWise. Built with Design Token SSOT',
+    copyright: '© 2025-2026 RateWise',
     sixStylesSST: '6 Styles SSOT',
     reactTailwind: 'React + Tailwind',
+    // 支援與資訊區塊
+    supportInfo: '支援與資訊',
+    faq: '常見問題',
+    aboutUs: '關於我們',
+    openSource: '開放原始碼',
   },
 
   // Styles

--- a/apps/ratewise/src/pages/About.tsx
+++ b/apps/ratewise/src/pages/About.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { SEOHelmet } from '../components/SEOHelmet';
 import { Breadcrumb } from '../components/Breadcrumb';
 import { getDisplayVersion } from '../config/version';
+import { APP_INFO, getCopyrightYears } from '../config/app-info';
 
 export default function About() {
   return (
@@ -19,7 +20,7 @@ export default function About() {
           { name: '關於我們', item: '/about/' },
         ]}
       />
-      <main className="min-h-screen bg-page-gradient">
+      <main className="min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8 max-w-4xl">
           {/* Header */}
           <div className="mb-8">
@@ -238,10 +239,10 @@ export default function About() {
                 <p className="text-text-muted">
                   如有任何問題或建議，歡迎透過{' '}
                   <a
-                    href="mailto:haotool.org@gmail.com"
+                    href={`mailto:${APP_INFO.email}`}
                     className="text-primary hover:text-primary/80 underline"
                   >
-                    haotool.org@gmail.com
+                    {APP_INFO.email}
                   </a>{' '}
                   與我們聯繫。
                 </p>
@@ -251,10 +252,10 @@ export default function About() {
                 <p className="text-text-muted">
                   若發現安全漏洞，請透過{' '}
                   <a
-                    href="mailto:haotool.org@gmail.com"
+                    href={`mailto:${APP_INFO.email}`}
                     className="text-primary hover:text-primary/80 underline"
                   >
-                    haotool.org@gmail.com
+                    {APP_INFO.email}
                   </a>{' '}
                   回報，我們會在 48 小時內回應。
                 </p>
@@ -262,9 +263,9 @@ export default function About() {
               <div>
                 <h3 className="text-lg font-semibold text-primary mb-2">開放原始碼</h3>
                 <p className="text-text-muted">
-                  RateWise 是開放原始碼專案，歡迎在{' '}
+                  {APP_INFO.name} 是開放原始碼專案，歡迎在{' '}
                   <a
-                    href="https://github.com/haotool/app"
+                    href={APP_INFO.github}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-primary hover:text-primary/80 underline"
@@ -279,8 +280,10 @@ export default function About() {
 
           {/* Footer */}
           <div className="text-center text-text-muted text-sm">
-            <p>© 2024-2026 RateWise. 採用 GPL-3.0 授權。</p>
-            <p className="mt-2">最後更新：2026-02-01 | 版本：{getDisplayVersion()}</p>
+            <p>
+              © {getCopyrightYears()} {APP_INFO.name}. 採用 {APP_INFO.license} 授權。
+            </p>
+            <p className="mt-2">版本：{getDisplayVersion()}</p>
           </div>
         </div>
       </main>

--- a/apps/ratewise/src/pages/FAQ.tsx
+++ b/apps/ratewise/src/pages/FAQ.tsx
@@ -5,6 +5,7 @@
 import { Link } from 'react-router-dom';
 import { SEOHelmet } from '../components/SEOHelmet';
 import { Breadcrumb } from '../components/Breadcrumb';
+import { APP_INFO } from '../config/app-info';
 
 /** FAQ 純文字資料 - 用於 JSON-LD schema */
 const FAQ_JSONLD_DATA = [
@@ -190,7 +191,7 @@ export default function FAQ() {
         ]}
         faq={FAQ_JSONLD_DATA}
       />
-      <main className="min-h-screen bg-page-gradient">
+      <main className="min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8 max-w-4xl">
           {/* Header */}
           <div className="mb-8">
@@ -256,10 +257,10 @@ export default function FAQ() {
             <p className="text-text-muted">
               如果您有其他問題或建議，歡迎透過
               <a
-                href="mailto:haotool.org@gmail.com"
+                href={`mailto:${APP_INFO.email}`}
                 className="text-primary hover:text-primary/80 underline ml-1"
               >
-                haotool.org@gmail.com
+                {APP_INFO.email}
               </a>
               與我們聯繫。
             </p>

--- a/apps/ratewise/src/pages/Settings.tsx
+++ b/apps/ratewise/src/pages/Settings.tsx
@@ -19,7 +19,17 @@
  * @version 4.0.0
  */
 
-import { Palette, Globe, Database, ShieldAlert, Check } from 'lucide-react';
+import {
+  Palette,
+  Globe,
+  Database,
+  ShieldAlert,
+  Check,
+  HelpCircle,
+  ChevronRight,
+  ExternalLink,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'motion/react';
 import { useAppTheme } from '../hooks/useAppTheme';
@@ -27,6 +37,7 @@ import { STYLE_OPTIONS } from '../config/themes';
 import { LANGUAGE_OPTIONS, getResolvedLanguage, type SupportedLanguage } from '../i18n';
 import { getDisplayVersion } from '../config/version';
 import { transitions, segmentedSwitch } from '../config/animations';
+import { APP_INFO } from '../config/app-info';
 
 export default function Settings() {
   const { t, i18n } = useTranslation();
@@ -208,31 +219,47 @@ export default function Settings() {
           </div>
         </section>
 
-        {/* 關於區塊 */}
+        {/* 支援與資訊區塊 */}
         <section className="mb-6">
-          <div className="card p-5">
-            <div className="space-y-3 text-sm">
-              <div className="flex justify-between items-center">
-                <span className="opacity-60">{t('settings.appVersion')}</span>
-                <span className="font-bold font-mono">{getDisplayVersion()}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="opacity-60">{t('settings.designSystem')}</span>
-                <span className="font-bold">{t('settings.sixStylesSST')}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="opacity-60">{t('settings.techStack')}</span>
-                <span className="font-bold">{t('settings.reactTailwind')}</span>
-              </div>
-            </div>
+          <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
+            <HelpCircle className="w-3.5 h-3.5" />
+            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+              {t('settings.supportInfo')}
+            </h3>
+          </div>
 
-            <div className="mt-4 pt-4 border-t border-black/5">
-              <p className="text-[10px] opacity-40 text-center font-medium">
-                {t('settings.copyright')}
-              </p>
-            </div>
+          <div className="card overflow-hidden divide-y divide-border">
+            <Link
+              to="/faq"
+              className="w-full px-5 py-4 flex items-center justify-between group hover:bg-primary/5 transition-colors"
+            >
+              <span className="text-sm font-medium">{t('settings.faq')}</span>
+              <ChevronRight className="w-4 h-4 opacity-40 group-hover:opacity-100 transition-opacity" />
+            </Link>
+            <Link
+              to="/about"
+              className="w-full px-5 py-4 flex items-center justify-between group hover:bg-primary/5 transition-colors"
+            >
+              <span className="text-sm font-medium">{t('settings.aboutUs')}</span>
+              <ChevronRight className="w-4 h-4 opacity-40 group-hover:opacity-100 transition-opacity" />
+            </Link>
+            <a
+              href={APP_INFO.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full px-5 py-4 flex items-center justify-between group hover:bg-primary/5 transition-colors"
+            >
+              <span className="text-sm font-medium">{t('settings.openSource')}</span>
+              <ExternalLink className="w-4 h-4 opacity-40 group-hover:opacity-100 transition-opacity" />
+            </a>
           </div>
         </section>
+
+        {/* 版本資訊 */}
+        <footer className="text-center mt-8 pb-4">
+          <p className="text-[10px] opacity-40">{t('settings.copyright')}</p>
+          <p className="text-xs font-mono opacity-60 mt-1">{getDisplayVersion()}</p>
+        </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- 新增 `config/app-info.ts` SSOT 模組集中管理應用程式基本資訊
- 設定頁新增「支援與資訊」區塊，包含 FAQ、關於我們、開放原始碼連結
- 簡化版本顯示移至頁尾
- 統一 About/FAQ 頁面使用 SSOT 取代硬編碼
- 修正版權年份為 2025-2026（專案始於 2025 年）
- 新增 app-info 單元測試（8 tests）
- 更新 i18n 三語言 settings keys

## Changes

### 新增檔案
- `apps/ratewise/src/config/app-info.ts` - 應用程式資訊 SSOT
- `apps/ratewise/src/config/__tests__/app-info.test.ts` - 單元測試

### 修改檔案
- `apps/ratewise/src/pages/Settings.tsx` - 新增支援與資訊區塊
- `apps/ratewise/src/pages/About.tsx` - 使用 SSOT，統一背景色
- `apps/ratewise/src/pages/FAQ.tsx` - 使用 SSOT，統一背景色
- `apps/ratewise/src/i18n/locales/*.ts` - 新增 i18n keys

## Test Plan

- [x] TypeScript 編譯通過
- [x] ESLint 檢查通過
- [x] 單元測試通過（1325 tests）
- [x] 瀏覽器測試驗證設定頁、FAQ、About 頁面
- [x] 主題切換測試（Zen/Nitro）