### PR TITLE
fix(ratewise): pwa 離線快取策略修正與記憶體洩漏修復

### DIFF
--- a/.changeset/fix-pwa-offline-cache.md
+++ b/.changeset/fix-pwa-offline-cache.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+PWA 離線快取策略修正：JS/CSS 改用 CacheFirst、移除冗餘 offline-fallback route、修復 UpdatePrompt setInterval 記憶體洩漏

--- a/apps/ratewise/src/components/UpdatePrompt.tsx
+++ b/apps/ratewise/src/components/UpdatePrompt.tsx
@@ -11,12 +11,13 @@
  * - 完整無障礙支援（ARIA、鍵盤操作）
  * - 響應式設計（手機、平板、桌面）
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 import { logger } from '../utils/logger';
 
 export function UpdatePrompt() {
   const [show, setShow] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // 使用 vite-plugin-pwa 官方 React Hook
   // [context7:/vite-pwa/vite-plugin-pwa:2025-12-29]
@@ -29,7 +30,7 @@ export function UpdatePrompt() {
       // Service Worker 已註冊，設定定期更新檢查（每小時）
       if (r) {
         void r.update();
-        setInterval(
+        intervalRef.current = setInterval(
           () => {
             void r.update();
           },
@@ -42,6 +43,15 @@ export function UpdatePrompt() {
       logger.error('Service Worker registration error', errorObject);
     },
   });
+
+  // 清除 interval 防止記憶體洩漏
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
 
   // 手動更新：用戶點擊「更新」按鈕時執行
   const handleUpdate = () => {

--- a/apps/ratewise/src/components/__tests__/UpdatePrompt.test.tsx
+++ b/apps/ratewise/src/components/__tests__/UpdatePrompt.test.tsx
@@ -23,6 +23,39 @@
 import { describe, it, expect } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
+describe('UpdatePrompt - setInterval 洩漏防護', () => {
+  // 🔴 RED: onRegistered 中的 setInterval 應被儲存，以便元件卸載時清除
+  it('should store interval ID for cleanup (no memory leak)', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const componentPath = path.resolve(__dirname, '../UpdatePrompt.tsx');
+    const sourceCode = await fs.readFile(componentPath, 'utf-8');
+
+    // setInterval 的回傳值必須被儲存（不是直接呼叫後丟棄）
+    // 正確：const intervalId = setInterval(...)  或 useRef 儲存
+    // 錯誤：setInterval(() => { ... }, 60000) 沒有儲存回傳值
+
+    // 檢查 setInterval 是否有賦值給變數或 ref
+    const hasStoredInterval =
+      /(?:const|let|var)\s+\w+\s*=\s*setInterval/.test(sourceCode) ||
+      /\.current\s*=\s*setInterval/.test(sourceCode);
+
+    expect(hasStoredInterval).toBe(true);
+  });
+
+  it('should clear interval on cleanup', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const componentPath = path.resolve(__dirname, '../UpdatePrompt.tsx');
+    const sourceCode = await fs.readFile(componentPath, 'utf-8');
+
+    // 必須有 clearInterval 呼叫
+    expect(sourceCode).toContain('clearInterval');
+  });
+});
+
 describe('UpdatePrompt Component - 粉彩雲朵配色 (BDD)', () => {
   describe('🔴 RED: 粉彩雲朵配色源碼驗證', () => {
     it('should use pastel cloud background gradient (purple-50 via-blue-50 to-purple-100)', async () => {


### PR DESCRIPTION
## Summary

- **JS/CSS 快取策略修正**: `NetworkFirst` → `CacheFirst`，Vite hash-based 檔名是 immutable，不需每次網路驗證
- **移除冗餘 offline-fallback route**: `offline.html` 已由 `precacheAndRoute` 管理，額外 runtime route 浪費 Safari iOS 50MB 快取空間
- **修復 setInterval 記憶體洩漏**: `UpdatePrompt` 中 `setInterval` 未儲存 ID，元件卸載時無法清除，改用 `useRef` + `clearInterval`

## Test plan

- [x] Unit tests: 1344/1344 passed（含新增 4 個測試）
- [x] TypeScript: `pnpm typecheck` 通過
- [x] ESLint: `pnpm lint` 通過
- [x] Prettier: `pnpm format` 通過
- [x] Build: `pnpm build` 成功，`sw.js` 不含 `offline-fallback` cache name
- [x] E2E PWA: 15/15 passed（離線快取、SW 註冊、offline.html precache、網路恢復）