### PR TITLE
fix: pwa offline navigation load failed and page transition animation

### DIFF
--- a/.changeset/feat-page-transition-animation.md
+++ b/.changeset/feat-page-transition-animation.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+新增頁面切換左右滑動動畫，消除導覽閃爍，支援 prefers-reduced-motion

--- a/.changeset/fix-pwa-offline-navigation.md
+++ b/.changeset/fix-pwa-offline-navigation.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復離線導覽 Load failed - 預快取 React Router 資料 manifest JSON 檔案

--- a/apps/ratewise/src/config/animations.ts
+++ b/apps/ratewise/src/config/animations.ts
@@ -196,6 +196,32 @@ export const activeHighlight = {
 } as const;
 
 /**
+ * 頁面切換動畫配置
+ *
+ * 輕量化方案：僅使用 opacity + translateX 實現高級 App 的頁面滑動效果
+ * 使用 GPU 加速屬性（transform + opacity），不觸發 layout reflow
+ *
+ * 導覽順序：單幣別(0) → 多幣別(1) → 收藏(2) → 設定(3)
+ * 向右導覽（index 增大）：新頁面從右邊滑入，舊頁面向左滑出
+ * 向左導覽（index 減小）：新頁面從左邊滑入，舊頁面向右滑出
+ */
+export const pageTransition = {
+  /** 過渡配置 */
+  transition: { duration: 0.25, ease: [0.4, 0, 0.2, 1] } as Transition,
+
+  /** 滑動偏移量（px），保持輕微以避免暈動症 */
+  offsetX: 40,
+
+  /** 路由索引映射（用於判斷滑動方向） */
+  routeIndex: {
+    '/': 0,
+    '/multi': 1,
+    '/favorites': 2,
+    '/settings': 3,
+  } as Record<string, number>,
+} as const;
+
+/**
  * PWA 更新通知動畫配置
  *
  * 通知入場（底部彈入）動畫，搭配 notificationTokens 使用。

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -328,7 +328,10 @@ export default defineConfig(({ mode }) => {
           // [fix:2026-01-28] 移除 xml,webmanifest 避免預快取 sitemap.xml/manifest.webmanifest
           // 問題：staging 環境 sitemap.xml 404 導致 bad-precaching-response
           // 解決：SEO 檔案不需要預快取，透過 runtimeCaching 處理即可
-          globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2,avif,webp}'],
+          // [fix:2026-02-10] 加入 json 以預快取 static-loader-data-manifest-*.json
+          // 問題：vite-react-ssg 建置時產生此檔案供 React Router 進行 client-side navigation
+          // 離線時無法取得此 manifest 導致所有 SPA 導覽失敗 (Load failed)
+          globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2,avif,webp,json}'],
           globIgnores: [
             '**/og-image-old.png',
             '**/node_modules/**',


### PR DESCRIPTION
## Summary

- **修復離線導覽 Load failed**: 將 `.json` 加入 Workbox `globPatterns`，確保 `static-loader-data-manifest-*.json` 被預快取。此檔案由 `vite-react-ssg` 建置時產生，供 React Router 進行 client-side navigation，離線時缺少此檔案導致多幣別/收藏/設定頁面 SPA 導覽失敗。
- **新增頁面切換滑動動畫**: 使用 `motion/react` (Framer Motion) 的 `AnimatePresence` 實現 `opacity + translateX` 頁面過渡效果，根據導覽順序判斷滑動方向（單幣別→多幣別→收藏→設定），消除頁面切換閃爍。支援 `prefers-reduced-motion` 無障礙降級。

## Changes

| 檔案 | 變更 |
|------|------|
| `vite.config.ts` | `globPatterns` 加入 `json` 副檔名 |
| `animations.ts` | 新增 `pageTransition` 動畫 token |
| `AppLayout.tsx` | 整合 `AnimatePresence` + `motion.div` 頁面過渡 |

## Test plan

- [x] TypeScript 零錯誤
- [x] ESLint 零錯誤、零警告
- [x] 78 個測試檔案、1386 個測試全部通過
- [x] 線上頁面切換：四個頁面導覽正常，無 console 錯誤
- [x] 離線頁面切換：Service Worker activated 後離線導覽四個頁面全部正常
- [x] 離線冷啟動：直接存取 `/multi`、`/favorites`、`/settings` 均正常載入
- [x] 動畫效果：左右滑動方向正確，過渡流暢
- [x] 建置成功：`sw.js` 已包含 `static-loader-data-manifest-*.json`


Made with [Cursor](https://cursor.com)