### PR TITLE
fix(ratewise): animation consistency, offline indicator, comment cleanup

### DIFF
--- a/.changeset/fix-animation-offline-comments.md
+++ b/.changeset/fix-animation-offline-comments.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復頁面切換動畫為一致 crossfade、離線指示器 session 不重複、清理冗長技術債註解

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,6 +717,20 @@ docker logs <container-id>
 
 ---
 
+## PWA 離線快取策略（2026-02-10 驗證通過）
+
+**關鍵設定**：
+
+1. `globPatterns` 必須含 `json`：`vite-react-ssg` 產生 `static-loader-data-manifest-*.json`，React Router client-side navigation 依賴此檔案。缺失時離線 SPA 導覽全部失敗。
+2. `globIgnores` 排除 `rates/**/*.json`、SEO 檔案（sitemap/robots/llms/manifest）。
+3. 使用 `injectManifest` 策略，支援 `setCatchHandler` 離線 fallback。
+4. `rollupFormat: 'iife'`，避免 ES module 在部分瀏覽器評估失敗。
+5. `OfflineIndicator` 僅完全離線時顯示，10 秒自動關閉，同次 session 不再重複。
+
+**Agent 操作注意**：新增頁面或靜態資源格式時，檢查 `globPatterns` 與 `globIgnores` 是否正確。離線測試必須在 `pnpm build && pnpm preview` 環境執行。
+
+---
+
 ## 9. 版本管理規範（SSOT）
 
 ### Monorepo 版本管理策略

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,24 @@ try {
 
 ---
 
+## PWA 離線快取策略
+
+### 關鍵要點
+
+1. **globPatterns 必須包含 json**：`vite-react-ssg` 建置產生 `static-loader-data-manifest-*.json`，React Router 的 client-side navigation 依賴此檔案。若未預快取，離線時所有 SPA 頁面導覽將失敗（Load failed）。
+2. **globIgnores 排除非必要 json**：`rates/**/*.json`、`sitemap.xml`、`robots.txt`、`manifest.webmanifest` 不需預快取。
+3. **injectManifest 策略**：使用 `injectManifest` 而非 `generateSW`，以支援 `setCatchHandler` 離線 fallback。
+4. **IIFE 格式**：Service Worker 使用 `rollupFormat: 'iife'`，避免 ES module 在部分瀏覽器評估失敗。
+5. **離線指示器**：`OfflineIndicator` 僅在完全離線時顯示，10 秒自動關閉，同次 session 不再重複。
+
+### 常見陷阱
+
+- **新增頁面時**：確認路由已在 `routes.tsx` 註冊，SSG 會自動產生對應的 data manifest。
+- **新增靜態資源格式時**：檢查 `globPatterns` 是否涵蓋該副檔名。
+- **測試離線功能**：必須在 `pnpm build && pnpm preview` 環境測試，開發模式不啟用 Service Worker。
+
+---
+
 ## 版本管理規範（SSOT）
 
 ### 版本號生成策略

--- a/apps/ratewise/src/components/AppLayout.tsx
+++ b/apps/ratewise/src/components/AppLayout.tsx
@@ -1,11 +1,7 @@
 /**
  * AppLayout - 主要應用佈局組件
  * 整合 Header、側邊欄、底部導覽與內容區域
- *
- * 頁面切換動畫：
- * - 使用 motion/react AnimatePresence 實現左右滑動效果
- * - 根據導覽順序判斷滑動方向（減少暈動感）
- * - 支援 prefers-reduced-motion 無障礙需求
+ * 頁面切換使用輕量 crossfade 動畫，支援 prefers-reduced-motion
  */
 
 import React from 'react';
@@ -105,55 +101,10 @@ function Header() {
   );
 }
 
-/**
- * 取得路由對應的索引（用於判斷頁面切換方向）
- * 未知路由預設為 0
- */
-function getRouteIndex(pathname: string): number {
-  // 移除 base path 前綴以匹配 routeIndex
-  const basePath = import.meta.env.BASE_URL?.replace(/\/$/, '') ?? '';
-  const normalizedPath = pathname.replace(basePath, '') || '/';
-  return pageTransition.routeIndex[normalizedPath] ?? 0;
-}
-
-/**
- * 根據導覽順序判斷頁面切換方向
- * 1: 向右導覽（新頁從右進、舊頁往左出）
- * -1: 向左導覽（新頁從左進、舊頁往右出）
- */
-function getTransitionDirection(currentIndex: number, previousIndex: number): 1 | -1 {
-  return currentIndex >= previousIndex ? 1 : -1;
-}
-
-const pageTransitionVariants = {
-  enter: (direction: 1 | -1) => ({
-    opacity: 0,
-    x: direction * pageTransition.offsetX,
-  }),
-  center: {
-    opacity: 1,
-    x: 0,
-  },
-  exit: (direction: 1 | -1) => ({
-    opacity: 0,
-    x: -direction * pageTransition.offsetX,
-  }),
-} as const;
-
 /** 主應用佈局 - 支援 iOS PWA 安全區域與響應式側邊欄 */
 export function AppLayout() {
   const location = useLocation();
-  const currentIndex = getRouteIndex(location.pathname);
-  const prevIndexRef = React.useRef(currentIndex);
-  // eslint-disable-next-line react-hooks/refs -- 需以「前一次索引」推導當次轉場方向，避免方向延遲一拍
-  const direction = getTransitionDirection(currentIndex, prevIndexRef.current);
 
-  // 更新前一個路由索引，供下一次 render 計算方向
-  React.useEffect(() => {
-    prevIndexRef.current = currentIndex;
-  }, [currentIndex]);
-
-  // 偵測使用者是否偏好減少動畫
   const prefersReducedMotion =
     typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -177,14 +128,13 @@ export function AppLayout() {
               className="flex-1 min-h-0 min-w-0 w-full relative overflow-y-auto overflow-x-hidden pb-[calc(56px+env(safe-area-inset-bottom,0px))] md:pb-0 [-webkit-overflow-scrolling:touch] overscroll-y-contain"
             >
               <RouteErrorBoundary>
-                <AnimatePresence mode="wait" initial={false} custom={direction}>
+                <AnimatePresence mode="wait" initial={false}>
                   <motion.div
                     key={location.pathname}
-                    variants={pageTransitionVariants}
-                    custom={direction}
-                    initial={prefersReducedMotion ? false : 'enter'}
-                    animate="center"
-                    exit={prefersReducedMotion ? { opacity: 0 } : 'exit'}
+                    variants={pageTransition.variants}
+                    initial={prefersReducedMotion ? false : 'initial'}
+                    animate="animate"
+                    exit="exit"
                     transition={prefersReducedMotion ? { duration: 0 } : pageTransition.transition}
                     className="min-h-full"
                   >

--- a/apps/ratewise/src/components/__tests__/AppLayout.transition-direction.test.tsx
+++ b/apps/ratewise/src/components/__tests__/AppLayout.transition-direction.test.tsx
@@ -4,7 +4,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppLayout } from '../AppLayout';
-import { pageTransition } from '../../config/animations';
 
 vi.mock('../SideNavigation', () => ({
   SideNavigation: () => <div data-testid="side-navigation" />,
@@ -26,69 +25,29 @@ vi.mock('../RouteErrorBoundary', () => ({
   RouteErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-vi.mock('motion/react', () => {
-  interface MotionDivProps extends React.HTMLAttributes<HTMLDivElement> {
-    children?: React.ReactNode;
-    custom?: 1 | -1;
-    variants?: Record<string, unknown>;
-    initial?: unknown;
-    exit?: unknown;
-    transition?: unknown;
-  }
-
-  const resolveVariant = (
-    variant: unknown,
-    variants: Record<string, unknown> | undefined,
-    custom: 1 | -1 | undefined,
-  ): Record<string, unknown> | null => {
-    if (variant === false || variant == null) {
-      return null;
-    }
-
-    const variantDefinition = typeof variant === 'string' && variants ? variants[variant] : variant;
-
-    if (typeof variantDefinition === 'function') {
-      return variantDefinition(custom) as Record<string, unknown>;
-    }
-
-    return typeof variantDefinition === 'object'
-      ? (variantDefinition as Record<string, unknown>)
-      : null;
-  };
-
-  return {
-    AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-    motion: {
-      div: ({
-        children,
-        custom,
-        variants,
-        initial,
-        exit,
-        transition: _transition,
-        ...rest
-      }: MotionDivProps) => {
-        const initialState = resolveVariant(initial, variants, custom);
-        const exitState = resolveVariant(exit, variants, custom);
-
-        const initialX =
-          typeof initialState?.['x'] === 'number' ? (initialState['x'] as number) : '';
-        const exitX = typeof exitState?.['x'] === 'number' ? (exitState['x'] as number) : '';
-
-        return (
-          <div
-            data-testid="page-transition"
-            data-initial-x={String(initialX)}
-            data-exit-x={String(exitX)}
-            {...rest}
-          >
-            {children}
-          </div>
-        );
-      },
-    },
-  };
-});
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      variants: _variants,
+      initial: _initial,
+      exit: _exit,
+      transition: _transition,
+      ...rest
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      children?: React.ReactNode;
+      variants?: unknown;
+      initial?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+    }) => (
+      <div data-testid="page-transition" {...rest}>
+        {children}
+      </div>
+    ),
+  },
+}));
 
 function RouteContent() {
   const navigate = useNavigate();
@@ -107,12 +66,8 @@ function RouteContent() {
   );
 }
 
-function getInitialX(): number {
-  return Number(screen.getByTestId('page-transition').getAttribute('data-initial-x'));
-}
-
-describe('AppLayout Transition Direction', () => {
-  it('前進再返回時，應該立即使用正確的切換方向', () => {
+describe('AppLayout 頁面切換', () => {
+  it('導覽時應正確渲染 transition wrapper 與內容', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <Routes>
@@ -125,14 +80,12 @@ describe('AppLayout Transition Direction', () => {
     );
 
     expect(screen.getByTestId('current-path')).toHaveTextContent('/');
-    expect(getInitialX()).toBe(pageTransition.offsetX);
+    expect(screen.getByTestId('page-transition')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'to-multi' }));
     expect(screen.getByTestId('current-path')).toHaveTextContent('/multi');
-    expect(getInitialX()).toBe(pageTransition.offsetX);
 
     fireEvent.click(screen.getByRole('button', { name: 'to-home' }));
     expect(screen.getByTestId('current-path')).toHaveTextContent('/');
-    expect(getInitialX()).toBe(-pageTransition.offsetX);
   });
 });

--- a/apps/ratewise/src/config/animations.ts
+++ b/apps/ratewise/src/config/animations.ts
@@ -195,30 +195,14 @@ export const activeHighlight = {
   itemActiveClass: 'cursor-default',
 } as const;
 
-/**
- * 頁面切換動畫配置
- *
- * 輕量化方案：僅使用 opacity + translateX 實現高級 App 的頁面滑動效果
- * 使用 GPU 加速屬性（transform + opacity），不觸發 layout reflow
- *
- * 導覽順序：單幣別(0) → 多幣別(1) → 收藏(2) → 設定(3)
- * 向右導覽（index 增大）：新頁面從右邊滑入，舊頁面向左滑出
- * 向左導覽（index 減小）：新頁面從左邊滑入，舊頁面向右滑出
- */
+/** 頁面切換動畫 - 輕量 crossfade（GPU 加速，不觸發 reflow） */
 export const pageTransition = {
-  /** 過渡配置 */
-  transition: { duration: 0.25, ease: [0.4, 0, 0.2, 1] } as Transition,
-
-  /** 滑動偏移量（px），保持輕微以避免暈動症 */
-  offsetX: 40,
-
-  /** 路由索引映射（用於判斷滑動方向） */
-  routeIndex: {
-    '/': 0,
-    '/multi': 1,
-    '/favorites': 2,
-    '/settings': 3,
-  } as Record<string, number>,
+  transition: { duration: 0.15, ease: [0.4, 0, 0.2, 1] } as Transition,
+  variants: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+  } as Variants,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- 頁面切換動畫從左右滑動改為一致的 crossfade（消除設定頁雙擊問題與左右晃動）
- 離線指示器 session 持久化：關閉後同次 session 不再重複顯示
- 清理 vite.config.ts 40+ 條冗長 `[fix:YYYY-MM-DD]` 註解，改為簡短繁體中文
- CLAUDE.md / AGENTS.md 新增 PWA 離線快取策略段落

## Changes

| 檔案 | 變更 |
|------|------|
| `AppLayout.tsx` | 移除 direction/routeIndex 邏輯，改用 crossfade variants |
| `animations.ts` | `pageTransition` 簡化為 opacity-only variants |
| `OfflineIndicator.tsx` | 新增 `sessionDismissed` flag，關閉後不再重複 |
| `vite.config.ts` | 清理 40+ 條技術債註解 |
| `CLAUDE.md` | 新增 PWA 離線快取策略段落 |
| `AGENTS.md` | 新增 PWA 離線快取策略段落 |

## Test plan

- [x] typecheck 通過
- [x] lint 通過
- [x] 1387 個單元測試全部通過
- [x] 瀏覽器手動測試：四頁導覽單擊即切換
- [x] console 零錯誤
- [x] 淨減 288 行程式碼

Made with [Cursor](https://cursor.com)