### PR TITLE
fix(ratewise): fix page transition blank flash

### DIFF
--- a/.changeset/fix-page-transition-blank.md
+++ b/.changeset/fix-page-transition-blank.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復頁面切換空白閃爍：移除 AnimatePresence mode="wait"，改用 enter-only 進場動畫

--- a/apps/ratewise/src/components/__tests__/AppLayout.transition-direction.test.tsx
+++ b/apps/ratewise/src/components/__tests__/AppLayout.transition-direction.test.tsx
@@ -26,25 +26,27 @@ vi.mock('../RouteErrorBoundary', () => ({
 }));
 
 vi.mock('motion/react', () => ({
-  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   motion: {
     div: ({
       children,
-      custom,
-      variants: _variants,
-      initial: _initial,
-      exit: _exit,
+      initial,
+      animate: _animate,
       transition: _transition,
       ...rest
     }: React.HTMLAttributes<HTMLDivElement> & {
       children?: React.ReactNode;
-      custom?: unknown;
-      variants?: unknown;
       initial?: unknown;
-      exit?: unknown;
+      animate?: unknown;
       transition?: unknown;
     }) => {
-      const direction = typeof custom === 'number' ? custom : 0;
+      /* 從 initial prop 提取 x 值推算方向 */
+      let direction = 0;
+      if (initial && typeof initial === 'object' && 'x' in initial) {
+        const x = (initial as { x?: string | number }).x;
+        if (typeof x === 'string') {
+          direction = parseFloat(x) > 0 ? 1 : parseFloat(x) < 0 ? -1 : 0;
+        }
+      }
       return (
         <div data-testid="page-transition" data-transition-direction={direction} {...rest}>
           {children}
@@ -86,7 +88,6 @@ describe('AppLayout 頁面切換', () => {
 
     expect(screen.getByTestId('current-path')).toHaveTextContent('/');
     expect(screen.getByTestId('page-transition')).toBeInTheDocument();
-    expect(screen.getByTestId('page-transition')).toHaveAttribute('data-transition-direction', '0');
 
     fireEvent.click(screen.getByRole('button', { name: 'to-multi' }));
     expect(screen.getByTestId('current-path')).toHaveTextContent('/multi');

--- a/apps/ratewise/src/config/animations.ts
+++ b/apps/ratewise/src/config/animations.ts
@@ -226,26 +226,15 @@ export function getTopLevelTransitionDirection(
 }
 
 /**
- * 頁面切換動畫：底導頁方向滑動 + 淡入淡出
+ * 頁面切換動畫：enter-only 進場動畫（無 exit）
  *
- * 動畫邏輯（與底部導覽指示條方向一致）：
- * - 向右切換（index 增加）：舊頁左滑出，新頁從右滑入
- * - 向左切換（index 減少）：舊頁右滑出，新頁從左滑入
- * - 非底導頁面：純淡入淡出
+ * 採用 enter-only 策略避免 AnimatePresence mode="wait" 的空白閃爍。
+ * 此為 iOS/Android tab bar 切換的業界標準做法。
+ *
+ * AppLayout 直接使用 transition + inline initial/animate props。
  */
 export const pageTransition = {
   transition: { duration: 0.15, ease: [0.25, 0.1, 0.25, 1] } as Transition,
-  variants: {
-    initial: (direction: TransitionDirection = 0) => ({
-      opacity: 0,
-      x: direction === 0 ? 0 : `${direction * 8}%`,
-    }),
-    animate: { opacity: 1, x: 0 },
-    exit: (direction: TransitionDirection = 0) => ({
-      opacity: 0,
-      x: direction === 0 ? 0 : `${direction * -8}%`,
-    }),
-  } as Variants,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- 移除 `AnimatePresence mode="wait"`，改用 enter-only 進場動畫
- 根本原因：`mode="wait"` 會在舊頁面 exit 動畫完成後才 mount 新頁面，造成 150ms 完全空白期（行動裝置上特別明顯）
- 修復方案：用 `key` 觸發 React remount + `motion.div` 的 `initial` → `animate` 進場動畫，無 exit = 無空白期
- 此為 iOS/Android tab bar 切換的業界標準做法

## Changes

- `AppLayout.tsx`：移除 `AnimatePresence`，改用 inline `initial`/`animate` props
- `animations.ts`：簡化 `pageTransition` 配置，移除不再使用的 `variants`/`exit`
- 更新對應單元測試

## Test plan

- [x] typecheck 通過
- [x] lint (max-warnings 0) 通過
- [x] 1393 測試全通過
- [x] 行動裝置視窗 (375x812) 快速 tab 切換測試，所有頁面皆有 content，無空白
- [x] 設定頁單次點擊即顯示


Made with [Cursor](https://cursor.com)