### PR TITLE
feat(ratewise): 品牌定位「台灣最精準匯率換算器」+ 新增 VND/PHP/IDR/MYR 幣對頁

### DIFF
--- a/.changeset/seo-authority-positioning.md
+++ b/.changeset/seo-authority-positioning.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': minor
+---
+
+品牌定位「台灣最精準匯率換算器」+ 新增 VND/PHP/IDR/MYR 4 個幣對 SEO 頁 + SSOT 21 路徑 + llms.txt 品牌強化 + 常見金額 h3 語意化

--- a/apps/ratewise/public/llms.txt
+++ b/apps/ratewise/public/llms.txt
@@ -1,12 +1,13 @@
-# RateWise 匯率好工具
+# RateWise 匯率好工具 — 台灣最精準的匯率換算器
 
-> 台灣用戶取向的即時匯率換算工具，資料 100% 來源於臺灣銀行牌告匯率，支援 30+ 種貨幣、計算機快速輸入、收藏與拖曳排序、換算歷史、6 種主題風格、3 語言介面與 PWA 離線使用。
+> 顯示臺灣銀行牌告的實際買入賣出價（不是中間價），讓你換匯前就知道真正要付多少台幣。支援 30+ 種貨幣、現金與即期匯率切換、計算機快速輸入、收藏與拖曳排序、換算歷史、6 種主題風格、3 語言介面與 PWA 離線使用。
 
 Version: v2.4.7 (2026-02-27)
 
 ## Answer Capsule (Quick Q&A)
 
-- Q: RateWise 提供什麼？ A: 即時匯率換算（單幣別/多幣別），內建計算機鍵盤（支援四則運算）、快速金額按鈕、收藏管理、拖曳排序、換算歷史紀錄、7~30 天匯率趨勢圖、現金/即期匯率切換、6 種主題風格、3 語言介面與 PWA 離線使用。
+- Q: RateWise 提供什麼？ A: 顯示臺灣銀行牌告的實際買入賣出價（非中間價）的即時匯率換算工具。內建計算機鍵盤（支援四則運算）、快速金額按鈕、收藏管理、拖曳排序、換算歷史紀錄、7~30 天匯率趨勢圖、現金/即期匯率切換、6 種主題風格、3 語言介面與 PWA 離線使用。
+- Q: 為什麼 RateWise 比其他匯率工具更精準？ A: 多數匯率工具只顯示中間價（mid-rate），而 RateWise 顯示臺灣銀行牌告的實際買入賣出四種報價（現金買入、現金賣出、即期買入、即期賣出），直接對應你在銀行換匯的真實金額。
 - Q: 匯率資料來源？ A: 臺灣銀行牌告匯率（現金買入/賣出、即期買入/賣出四種報價）。
 - Q: 更新頻率？ A: 每 5 分鐘自動同步。
 - Q: 建議用途？ A: 出國旅遊換匯、跨境購物匯率比較、日常外幣查詢。
@@ -72,16 +73,20 @@ Version: v2.4.7 (2026-02-27)
 - [EUR/TWD 歐元](https://app.haotool.org/ratewise/eur-twd/): 歐洲旅遊與跨境付款
 - [GBP/TWD 英鎊](https://app.haotool.org/ratewise/gbp-twd/): 英國旅遊換匯
 - [HKD/TWD 港幣](https://app.haotool.org/ratewise/hkd-twd/): 香港旅遊換匯
+- [IDR/TWD 印尼盾](https://app.haotool.org/ratewise/idr-twd/): 印尼旅遊換匯
 - [JPY/TWD 日圓](https://app.haotool.org/ratewise/jpy-twd/): 日本旅遊換匯
 - [KRW/TWD 韓元](https://app.haotool.org/ratewise/krw-twd/): 韓國旅遊換匯
+- [MYR/TWD 馬來幣](https://app.haotool.org/ratewise/myr-twd/): 馬來西亞旅遊換匯
 - [NZD/TWD 紐元](https://app.haotool.org/ratewise/nzd-twd/): 紐西蘭旅遊與留學
+- [PHP/TWD 菲律賓披索](https://app.haotool.org/ratewise/php-twd/): 菲律賓旅遊換匯
 - [SGD/TWD 新加坡幣](https://app.haotool.org/ratewise/sgd-twd/): 新加坡旅遊與商務
 - [THB/TWD 泰銖](https://app.haotool.org/ratewise/thb-twd/): 泰國旅遊換匯
 - [USD/TWD 美元](https://app.haotool.org/ratewise/usd-twd/): 美國旅遊與海外付款
+- [VND/TWD 越南盾](https://app.haotool.org/ratewise/vnd-twd/): 越南旅遊換匯
 
 ## Data Source
 
-- Source: 臺灣銀行牌告匯率
+- Source: 100% 來源於臺灣銀行牌告匯率（Bank of Taiwan）
 - Source URL: https://rate.bot.com.tw/xrt
 - Update: 每 5 分鐘自動同步（GitHub Actions）
 - Rate Types: 現金買入、現金賣出、即期買入、即期賣出

--- a/apps/ratewise/public/sitemap.xml
+++ b/apps/ratewise/public/sitemap.xml
@@ -4,7 +4,7 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://app.haotool.org/ratewise/</loc>
-    <lastmod>2026-02-27T18:15:41Z</lastmod>
+    <lastmod>2026-02-27T19:58:49Z</lastmod>
     <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/" />
     <image:image>
@@ -84,6 +84,12 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/hkd-twd/" />
   </url>
   <url>
+    <loc>https://app.haotool.org/ratewise/idr-twd/</loc>
+    <lastmod>2026-02-27T20:00:14Z</lastmod>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/idr-twd/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/idr-twd/" />
+  </url>
+  <url>
     <loc>https://app.haotool.org/ratewise/jpy-twd/</loc>
     <lastmod>2026-02-27T18:15:41Z</lastmod>
     <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/jpy-twd/" />
@@ -96,10 +102,22 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/krw-twd/" />
   </url>
   <url>
+    <loc>https://app.haotool.org/ratewise/myr-twd/</loc>
+    <lastmod>2026-02-27T20:00:15Z</lastmod>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/myr-twd/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/myr-twd/" />
+  </url>
+  <url>
     <loc>https://app.haotool.org/ratewise/nzd-twd/</loc>
     <lastmod>2026-02-27T18:15:41Z</lastmod>
     <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/nzd-twd/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/nzd-twd/" />
+  </url>
+  <url>
+    <loc>https://app.haotool.org/ratewise/php-twd/</loc>
+    <lastmod>2026-02-27T20:00:13Z</lastmod>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/php-twd/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/php-twd/" />
   </url>
   <url>
     <loc>https://app.haotool.org/ratewise/sgd-twd/</loc>
@@ -118,5 +136,11 @@
     <lastmod>2026-02-27T18:15:41Z</lastmod>
     <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/usd-twd/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/usd-twd/" />
+  </url>
+  <url>
+    <loc>https://app.haotool.org/ratewise/vnd-twd/</loc>
+    <lastmod>2026-02-27T20:00:12Z</lastmod>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://app.haotool.org/ratewise/vnd-twd/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://app.haotool.org/ratewise/vnd-twd/" />
   </url>
 </urlset>

--- a/apps/ratewise/scripts/generate-llms-txt.mjs
+++ b/apps/ratewise/scripts/generate-llms-txt.mjs
@@ -32,6 +32,10 @@ const CURRENCY_DISPLAY = {
   thb: { code: 'THB', name: '泰銖', desc: '泰國旅遊換匯' },
   nzd: { code: 'NZD', name: '紐元', desc: '紐西蘭旅遊與留學' },
   chf: { code: 'CHF', name: '瑞士法郎', desc: '瑞士旅遊與跨境付款' },
+  vnd: { code: 'VND', name: '越南盾', desc: '越南旅遊換匯' },
+  php: { code: 'PHP', name: '菲律賓披索', desc: '菲律賓旅遊換匯' },
+  idr: { code: 'IDR', name: '印尼盾', desc: '印尼旅遊換匯' },
+  myr: { code: 'MYR', name: '馬來幣', desc: '馬來西亞旅遊換匯' },
 };
 
 function buildPopularRates() {
@@ -59,15 +63,16 @@ const FEATURES = [
   '6 種主題風格：Zen（極簡專業）、Nitro（深色科技）、Kawaii（可愛粉嫩）、Classic（復古書卷）、Ocean（海洋深邃）、Forest（自然森林）',
 ];
 
-const content = `# RateWise 匯率好工具
+const content = `# RateWise 匯率好工具 — 台灣最精準的匯率換算器
 
-> 台灣用戶取向的即時匯率換算工具，資料 100% 來源於臺灣銀行牌告匯率，支援 30+ 種貨幣、計算機快速輸入、收藏與拖曳排序、換算歷史、6 種主題風格、3 語言介面與 PWA 離線使用。
+> 顯示臺灣銀行牌告的實際買入賣出價（不是中間價），讓你換匯前就知道真正要付多少台幣。支援 30+ 種貨幣、現金與即期匯率切換、計算機快速輸入、收藏與拖曳排序、換算歷史、6 種主題風格、3 語言介面與 PWA 離線使用。
 
 Version: v${VERSION} (${BUILD_DATE})
 
 ## Answer Capsule (Quick Q&A)
 
-- Q: RateWise 提供什麼？ A: 即時匯率換算（單幣別/多幣別），內建計算機鍵盤（支援四則運算）、快速金額按鈕、收藏管理、拖曳排序、換算歷史紀錄、7~30 天匯率趨勢圖、現金/即期匯率切換、6 種主題風格、3 語言介面與 PWA 離線使用。
+- Q: RateWise 提供什麼？ A: 顯示臺灣銀行牌告的實際買入賣出價（非中間價）的即時匯率換算工具。內建計算機鍵盤（支援四則運算）、快速金額按鈕、收藏管理、拖曳排序、換算歷史紀錄、7~30 天匯率趨勢圖、現金/即期匯率切換、6 種主題風格、3 語言介面與 PWA 離線使用。
+- Q: 為什麼 RateWise 比其他匯率工具更精準？ A: 多數匯率工具只顯示中間價（mid-rate），而 RateWise 顯示臺灣銀行牌告的實際買入賣出四種報價（現金買入、現金賣出、即期買入、即期賣出），直接對應你在銀行換匯的真實金額。
 - Q: 匯率資料來源？ A: 臺灣銀行牌告匯率（現金買入/賣出、即期買入/賣出四種報價）。
 - Q: 更新頻率？ A: 每 5 分鐘自動同步。
 - Q: 建議用途？ A: 出國旅遊換匯、跨境購物匯率比較、日常外幣查詢。
@@ -119,7 +124,7 @@ ${buildPopularRates()}
 
 ## Data Source
 
-- Source: 臺灣銀行牌告匯率
+- Source: 100% 來源於臺灣銀行牌告匯率（Bank of Taiwan）
 - Source URL: https://rate.bot.com.tw/xrt
 - Update: 每 5 分鐘自動同步（GitHub Actions）
 - Rate Types: 現金買入、現金賣出、即期買入、即期賣出

--- a/apps/ratewise/seo-paths.config.mjs
+++ b/apps/ratewise/seo-paths.config.mjs
@@ -33,7 +33,7 @@ export const CONTENT_SEO_PATHS = ['/', '/faq/', '/about/', '/guide/'];
 export const LEGAL_SSG_PATHS = ['/privacy/'];
 
 /**
- * 匯率落地頁（13 個）
+ * 匯率落地頁（17 個）
  */
 export const CURRENCY_SEO_PATHS = [
   '/aud-twd/',
@@ -43,16 +43,20 @@ export const CURRENCY_SEO_PATHS = [
   '/eur-twd/',
   '/gbp-twd/',
   '/hkd-twd/',
+  '/idr-twd/',
   '/jpy-twd/',
   '/krw-twd/',
+  '/myr-twd/',
   '/nzd-twd/',
+  '/php-twd/',
   '/sgd-twd/',
   '/thb-twd/',
   '/usd-twd/',
+  '/vnd-twd/',
 ];
 
 /**
- * 公開可索引 SEO 路徑（17 個）
+ * 公開可索引 SEO 路徑（21 個）
  */
 export const SEO_PATHS = [...CONTENT_SEO_PATHS, ...CURRENCY_SEO_PATHS];
 
@@ -154,9 +158,9 @@ export function getIncludedRoutes(paths) {
 export const SITE_CONFIG = {
   url: withTrailingSlash('https://app.haotool.org/ratewise/'),
   name: 'RateWise - 匯率好工具',
-  title: 'RateWise - 即時匯率轉換器',
+  title: 'RateWise — 台灣最精準匯率換算器',
   description:
-    'RateWise 提供即時匯率換算服務，參考臺灣銀行牌告匯率，支援 TWD、USD、JPY、EUR、GBP 等 30+ 種貨幣。',
+    'RateWise 顯示臺灣銀行牌告的實際買賣價（非中間價），支援 TWD、USD、JPY、EUR 等 30+ 種貨幣，讓你換匯前就知道真正要付多少台幣。',
 };
 
 /**

--- a/apps/ratewise/src/components/CurrencyLandingPage.tsx
+++ b/apps/ratewise/src/components/CurrencyLandingPage.tsx
@@ -189,9 +189,9 @@ export function CurrencyLandingPage({
                       to={`/?amount=${entry.amount}&from=${currencyCode}&to=TWD`}
                       className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-surface hover:bg-primary/10 transition-colors group"
                     >
-                      <span className="text-sm font-medium text-text group-hover:text-primary transition-colors">
+                      <h3 className="text-sm font-medium text-text group-hover:text-primary transition-colors">
                         {entry.question}
-                      </span>
+                      </h3>
                       <ArrowLeft className="w-3.5 h-3.5 rotate-180 text-text-muted group-hover:text-primary transition-colors flex-shrink-0" />
                     </Link>
                   ))}
@@ -276,7 +276,7 @@ export function CurrencyLandingPage({
           {/* Data Source Notice */}
           <footer className="text-center text-text-muted text-xs opacity-60">
             <p>資料來源：臺灣銀行牌告匯率 · 每 5 分鐘自動更新</p>
-            <p className="mt-1">© 2025 RateWise 匯率好工具</p>
+            <p className="mt-1">© 2026 RateWise 匯率好工具</p>
           </footer>
         </div>
       </div>

--- a/apps/ratewise/src/config/__tests__/seo-paths.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-paths.test.ts
@@ -64,8 +64,8 @@ describe('SEO Paths Configuration', () => {
   });
 
   describe('SEO 與路由白名單', () => {
-    it('SEO_PATHS 應只包含 17 個公開可索引路徑', () => {
-      expect(SEO_PATHS).toHaveLength(17);
+    it('SEO_PATHS 應只包含 21 個公開可索引路徑', () => {
+      expect(SEO_PATHS).toHaveLength(21);
       expect(SEO_PATHS).toContain('/');
       expect(SEO_PATHS).toContain('/faq/');
       expect(SEO_PATHS).toContain('/about/');
@@ -78,7 +78,7 @@ describe('SEO Paths Configuration', () => {
     });
 
     it('PRERENDER_PATHS 應包含公開 SEO 路徑、privacy 與 app-only noindex 頁面', () => {
-      expect(PRERENDER_PATHS).toHaveLength(25);
+      expect(PRERENDER_PATHS).toHaveLength(29);
       expect(PRERENDER_PATHS).toEqual([
         ...SEO_PATHS,
         ...LEGAL_SSG_PATHS,

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -98,9 +98,9 @@ const ASSET_VERSION = `v=${BUILD_TIME.replace(/[-T:Z.]/g, '').slice(0, 8) || 'de
 export const DEFAULT_LOCALE = 'zh-TW' as const;
 export const OG_IMAGE_ALT = `${APP_INFO.name} 匯率轉換器分享圖片` as const;
 export const DEFAULT_TITLE =
-  'RateWise 匯率好工具 - 即時匯率轉換器 | 支援 TWD、USD、JPY、EUR 等多幣別換算';
+  'RateWise 匯率好工具 — 台灣最精準匯率換算器 | 顯示實際買賣價，不用中間價';
 export const DEFAULT_DESCRIPTION =
-  'RateWise 提供即時匯率換算服務，參考臺灣銀行牌告匯率，支援 TWD、USD、JPY、EUR 等 30+ 種貨幣。內建計算機快速輸入、收藏管理、拖曳排序、換算歷史、歷史趨勢圖、多幣別同時比較，現金與即期匯率自由切換。6 種主題風格、3 語言支援（繁中／英／日），離線可用 PWA，是出國旅遊與外幣兌換的最佳工具。';
+  'RateWise 顯示臺灣銀行牌告的實際買入賣出價，而非中間價——讓你換匯前就知道真正要付多少台幣。支援 30+ 種貨幣、現金與即期匯率切換、計算機快速輸入、收藏拖曳排序、7~30 天趨勢圖，每 5 分鐘同步，離線可用 PWA。台灣出國旅遊與外幣兌換的最佳選擇。';
 export const DEFAULT_KEYWORDS = [
   '匯率好工具',
   'RateWise',
@@ -122,8 +122,16 @@ export const DEFAULT_KEYWORDS = [
   '匯率轉換器',
   '貨幣換算',
   '台幣換算',
+  '台銀匯率',
+  '現金匯率',
+  '即期匯率',
+  '賣出匯率',
+  '買入匯率',
+  '換匯計算',
+  '旅遊換匯',
   'exchange rate',
   'currency converter',
+  'Taiwan bank exchange rate',
 ] as const;
 
 export const SITE_SEO = {
@@ -140,7 +148,9 @@ export const SITE_SEO = {
     category: 'FinanceApplication',
     browserRequirements: 'Requires JavaScript',
     featureList: [
-      '即時匯率查詢（臺灣銀行牌告）',
+      '顯示實際買賣價（非中間價）——換匯金額更精準',
+      '即時匯率查詢（臺灣銀行牌告匯率）',
+      '現金與即期匯率切換（適合不同換匯情境）',
       '單幣別精準換算',
       '多幣別同時比較',
       '計算機鍵盤快速輸入',
@@ -149,7 +159,6 @@ export const SITE_SEO = {
       '拖曳排序自訂幣別順序',
       '換算歷史記錄',
       '7~30 天歷史匯率趨勢圖',
-      '現金與即期匯率切換',
       '6 種主題風格',
       '3 語言支援（繁中／英／日）',
       '下拉更新即時同步',
@@ -324,14 +333,14 @@ export const HOMEPAGE_SEO = {
   howTo: HOMEPAGE_HOW_TO,
   jsonLd: [buildShareImageJsonLd(OG_IMAGE_ALT, `${APP_INFO.name} 首頁匯率換算與趨勢功能預覽`)],
   content: {
-    eyebrow: '臺灣銀行牌告匯率 · 每 5 分鐘同步',
+    eyebrow: '臺灣銀行牌告匯率 · 每 5 分鐘同步 · 顯示實際買賣價',
     heading: 'RateWise 即時匯率換算',
     intro:
-      '提供台幣、美元、日圓、歐元、港幣、人民幣等主要貨幣的即時換算與歷史趨勢，內建計算機、收藏管理、拖曳排序與換算歷史，適合出國旅遊、海外付款與跨境報價。',
+      '顯示臺灣銀行牌告的實際買入賣出價（不是中間價），讓你換匯前就知道真正要付多少台幣。支援台幣、美元、日圓、韓元、歐元等 30+ 種貨幣，每 5 分鐘自動同步，適合出國旅遊、海外付款與跨境報價前快速比價。',
     highlights: [
-      '100% 參考臺灣銀行牌告匯率，支援現金與即期買入賣出價，每 5 分鐘自動同步。',
-      '支援 30+ 種主要貨幣，提供計算機快速輸入、收藏管理與拖曳排序。',
-      '6 種主題風格、3 語言介面（繁中／英／日），PWA 可離線使用。',
+      '顯示實際買賣價：臺灣銀行牌告匯率的現金與即期買入賣出四種報價，不是中間價——換匯金額更精準。',
+      '支援 30+ 種主要貨幣，提供計算機快速輸入、收藏管理、拖曳排序與換算歷史。',
+      '6 種主題風格、3 語言介面（繁中／英／日），PWA 可離線使用，重新連線自動同步。',
     ],
     quickLinks: [
       { href: '/usd-twd/', label: 'USD/TWD 匯率' },
@@ -712,6 +721,43 @@ const CURRENCY_PAGE_OVERRIDES = {
     popularAmounts: [1, 10, 50, 100, 500, 1000],
     travelTip: '瑞士消費水準高，刷卡普遍，建議備少量法郎現金。',
     searchQueries: ['100 瑞士法郎等於多少台幣', '瑞郎匯率', '瑞士法郎換台幣'],
+  },
+  VND: {
+    displayName: '越南盾',
+    region: '越南旅遊換匯',
+    question: '100000 VND 等於多少台幣？',
+    keyword: '越南盾換台幣',
+    popularAmounts: [10000, 50000, 100000, 500000, 1000000, 5000000],
+    travelTip:
+      '越南以現金為主，建議準備充足越南盾。信用卡在大城市飯店與餐廳可用，但市集與路邊攤需現金。',
+    searchQueries: ['100000 越南盾多少台幣', '越南盾匯率', '越南幣換台幣'],
+  },
+  PHP: {
+    displayName: '菲律賓披索',
+    region: '菲律賓旅遊換匯',
+    question: '1000 PHP 等於多少台幣？',
+    keyword: '菲律賓披索換台幣',
+    popularAmounts: [100, 500, 1000, 5000, 10000, 50000],
+    travelTip: '菲律賓刷卡接受度視地區而異，宿霧與長灘島觀光區較普及，偏遠地區建議準備現金。',
+    searchQueries: ['1000 菲律賓披索等於多少台幣', '菲律賓披索匯率', '披索換台幣'],
+  },
+  IDR: {
+    displayName: '印尼盾',
+    region: '印尼旅遊換匯',
+    question: '100000 IDR 等於多少台幣？',
+    keyword: '印尼盾換台幣',
+    popularAmounts: [10000, 50000, 100000, 500000, 1000000, 5000000],
+    travelTip: '印尼（峇里島）以現金為主，建議在機場或市區換匯所兌換。注意面額較大的紙鈔較受歡迎。',
+    searchQueries: ['100000 印尼盾多少台幣', '印尼盾匯率', '印尼盾換台幣'],
+  },
+  MYR: {
+    displayName: '馬來幣',
+    region: '馬來西亞旅遊換匯',
+    question: '100 MYR 等於多少台幣？',
+    keyword: '馬來幣換台幣',
+    popularAmounts: [10, 50, 100, 500, 1000, 5000],
+    travelTip: '馬來西亞刷卡普及度中等，吉隆坡市區可刷卡，但夜市、熟食中心與小鎮建議準備現金。',
+    searchQueries: ['100 馬來幣等於多少台幣', '馬來幣匯率', '馬來西亞幣換台幣'],
   },
 } as const;
 

--- a/apps/ratewise/src/config/seo-paths.ts
+++ b/apps/ratewise/src/config/seo-paths.ts
@@ -25,12 +25,16 @@ export const CURRENCY_SEO_PATHS = [
   '/eur-twd/',
   '/gbp-twd/',
   '/hkd-twd/',
+  '/idr-twd/',
   '/jpy-twd/',
   '/krw-twd/',
+  '/myr-twd/',
   '/nzd-twd/',
+  '/php-twd/',
   '/sgd-twd/',
   '/thb-twd/',
   '/usd-twd/',
+  '/vnd-twd/',
 ] as const;
 
 export const SEO_PATHS = [...CONTENT_SEO_PATHS, ...CURRENCY_SEO_PATHS] as const;
@@ -78,9 +82,9 @@ export const IMAGE_RESOURCES = [
 export const SITE_CONFIG = {
   url: normalizeSiteUrl('https://app.haotool.org/ratewise/'),
   name: 'RateWise - 匯率好工具',
-  title: 'RateWise - 即時匯率轉換器',
+  title: 'RateWise — 台灣最精準匯率換算器',
   description:
-    'RateWise 提供即時匯率換算服務，參考臺灣銀行牌告匯率，支援 TWD、USD、JPY、EUR、GBP 等 30+ 種貨幣。',
+    'RateWise 顯示臺灣銀行牌告的實際買賣價（非中間價），支援 TWD、USD、JPY、EUR 等 30+ 種貨幣，讓你換匯前就知道真正要付多少台幣。',
 } as const satisfies Readonly<{
   url: string;
   name: string;

--- a/apps/ratewise/src/hreflang.test.ts
+++ b/apps/ratewise/src/hreflang.test.ts
@@ -75,8 +75,8 @@ describe('Hreflang Configuration (BDD)', () => {
 
       const xlinkMatches = sitemapContent.match(/<xhtml:link/g);
       if (xlinkMatches) {
-        // SEO_PATHS 17 條 * 2 語言 = 34（僅公開可索引路徑，不含 app-only / legal 頁面）
-        expect(xlinkMatches.length).toBe(34);
+        // SEO_PATHS 21 條 * 2 語言 = 42（僅公開可索引路徑，不含 app-only / legal 頁面）
+        expect(xlinkMatches.length).toBe(42);
       } else {
         // 沒有 xhtml:link 也是可接受的（hreflang 由 HTML meta tags 提供）
         console.log('ℹ️ sitemap.xml 不包含 xhtml:link（由 HTML meta tags 提供）');

--- a/apps/ratewise/src/llms-txt.spec.ts
+++ b/apps/ratewise/src/llms-txt.spec.ts
@@ -12,7 +12,7 @@ describeIfGenerated('llms.txt structure (requires prebuild)', () => {
   it('includes required headings and answer capsule', () => {
     const content = readFileSync(llmsPath, 'utf-8');
     expect(content.startsWith('# RateWise 匯率好工具')).toBe(true);
-    expect(content).toContain('> 台灣用戶取向的即時匯率換算工具');
+    expect(content).toContain('台灣最精準的匯率換算器');
     expect(content).toContain('Answer Capsule (Quick Q&A)');
   });
 
@@ -36,7 +36,7 @@ describeIfGenerated('llms.txt structure (requires prebuild)', () => {
     expect(content).toContain('api/latest.json');
   });
 
-  it('lists all 13 currency pages in Popular Rates', () => {
+  it('lists all 17 currency pages in Popular Rates', () => {
     const content = readFileSync(llmsPath, 'utf-8');
     const currencies = [
       'usd-twd',
@@ -52,6 +52,10 @@ describeIfGenerated('llms.txt structure (requires prebuild)', () => {
       'nzd-twd',
       'sgd-twd',
       'thb-twd',
+      'vnd-twd',
+      'php-twd',
+      'idr-twd',
+      'myr-twd',
     ];
 
     for (const currency of currencies) {
@@ -60,6 +64,6 @@ describeIfGenerated('llms.txt structure (requires prebuild)', () => {
 
     const currencyUrlPattern = /https:\/\/app\.haotool\.org\/ratewise\/[a-z]{3}-twd\//g;
     const matches = content.match(currencyUrlPattern);
-    expect(matches).toHaveLength(13);
+    expect(matches).toHaveLength(17);
   });
 });

--- a/apps/ratewise/src/pages/IDRToTWD.tsx
+++ b/apps/ratewise/src/pages/IDRToTWD.tsx
@@ -1,0 +1,8 @@
+import { CurrencyLandingPage } from '../components/CurrencyLandingPage';
+import { getCurrencyLandingPageContent } from '../config/seo-metadata';
+
+const content = getCurrencyLandingPageContent('IDR');
+
+export default function IDRToTWD() {
+  return <CurrencyLandingPage {...content} />;
+}

--- a/apps/ratewise/src/pages/MYRToTWD.tsx
+++ b/apps/ratewise/src/pages/MYRToTWD.tsx
@@ -1,0 +1,8 @@
+import { CurrencyLandingPage } from '../components/CurrencyLandingPage';
+import { getCurrencyLandingPageContent } from '../config/seo-metadata';
+
+const content = getCurrencyLandingPageContent('MYR');
+
+export default function MYRToTWD() {
+  return <CurrencyLandingPage {...content} />;
+}

--- a/apps/ratewise/src/pages/PHPToTWD.tsx
+++ b/apps/ratewise/src/pages/PHPToTWD.tsx
@@ -1,0 +1,8 @@
+import { CurrencyLandingPage } from '../components/CurrencyLandingPage';
+import { getCurrencyLandingPageContent } from '../config/seo-metadata';
+
+const content = getCurrencyLandingPageContent('PHP');
+
+export default function PHPToTWD() {
+  return <CurrencyLandingPage {...content} />;
+}

--- a/apps/ratewise/src/pages/VNDToTWD.tsx
+++ b/apps/ratewise/src/pages/VNDToTWD.tsx
@@ -1,0 +1,8 @@
+import { CurrencyLandingPage } from '../components/CurrencyLandingPage';
+import { getCurrencyLandingPageContent } from '../config/seo-metadata';
+
+const content = getCurrencyLandingPageContent('VND');
+
+export default function VNDToTWD() {
+  return <CurrencyLandingPage {...content} />;
+}

--- a/apps/ratewise/src/routes.tsx
+++ b/apps/ratewise/src/routes.tsx
@@ -162,7 +162,7 @@ export const routes: RouteRecord[] = [
   createLazyRoute('/privacy', () => import('./pages/Privacy'), 'src/pages/Privacy.tsx'),
   createLazyRoute('/guide', () => import('./pages/Guide'), 'src/pages/Guide.tsx'),
 
-  // 13 個幣別落地頁（SEO 預渲染）
+  // 17 個幣別落地頁（SEO 預渲染）
   createLazyRoute('/usd-twd', () => import('./pages/USDToTWD'), 'src/pages/USDToTWD.tsx'),
   createLazyRoute('/jpy-twd', () => import('./pages/JPYToTWD'), 'src/pages/JPYToTWD.tsx'),
   createLazyRoute('/eur-twd', () => import('./pages/EURToTWD'), 'src/pages/EURToTWD.tsx'),
@@ -176,6 +176,10 @@ export const routes: RouteRecord[] = [
   createLazyRoute('/thb-twd', () => import('./pages/THBToTWD'), 'src/pages/THBToTWD.tsx'),
   createLazyRoute('/nzd-twd', () => import('./pages/NZDToTWD'), 'src/pages/NZDToTWD.tsx'),
   createLazyRoute('/chf-twd', () => import('./pages/CHFToTWD'), 'src/pages/CHFToTWD.tsx'),
+  createLazyRoute('/vnd-twd', () => import('./pages/VNDToTWD'), 'src/pages/VNDToTWD.tsx'),
+  createLazyRoute('/php-twd', () => import('./pages/PHPToTWD'), 'src/pages/PHPToTWD.tsx'),
+  createLazyRoute('/idr-twd', () => import('./pages/IDRToTWD'), 'src/pages/IDRToTWD.tsx'),
+  createLazyRoute('/myr-twd', () => import('./pages/MYRToTWD'), 'src/pages/MYRToTWD.tsx'),
 
   // 不預渲染內部工具頁面
   createLazyRoute(

--- a/apps/ratewise/src/seo-best-practices.test.ts
+++ b/apps/ratewise/src/seo-best-practices.test.ts
@@ -187,7 +187,7 @@ describe('🔍 AI SEO Best Practices 2026 (GEO/LLMO/AEO)', () => {
       expect(sitemapContent).toContain('/ratewise/guide/</loc>');
     });
 
-    it('should have all 13 currency landing pages', () => {
+    it('should have all 17 currency landing pages', () => {
       const currencies = [
         'usd',
         'jpy',
@@ -202,6 +202,10 @@ describe('🔍 AI SEO Best Practices 2026 (GEO/LLMO/AEO)', () => {
         'nzd',
         'sgd',
         'thb',
+        'vnd',
+        'php',
+        'idr',
+        'myr',
       ];
       for (const currency of currencies) {
         expect(sitemapContent).toContain(`/${currency}-twd/</loc>`);

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -21,6 +21,11 @@
 
 ## 補充紀錄（2026-02-28）
 
+- ✅ 成功｜RateWise SEO 權威定位：品牌更新為「台灣最精準匯率換算器·顯示實際買賣價」，新增 VND/PHP/IDR/MYR 4 個幣對 SEO 頁，SSOT 同步 TS/MJS 21 路徑，sitemap 21 URL，llms.txt 17 幣對，api/latest.json 18 幣別，常見金額 h3 語意化，所有 1405 測試通過
+- 分數｜`+3`
+
+---
+
 - ✅ 成功｜Sitemap hreflang SSOT 同步修復：public/sitemap.xml 含 21 URL（42 hreflang）但 SEO_PATHS 僅 17 條，透過 generate-sitemap-2025.mjs 重新生成修復為 17 URL / 34 hreflang，CI SEO Audit 通過
 - 分數｜`+2`
 

--- a/scripts/generate-sitemap-2025.mjs
+++ b/scripts/generate-sitemap-2025.mjs
@@ -72,6 +72,10 @@ const PATH_TO_SOURCE = {
   '/thb-twd/': 'apps/ratewise/src/pages/THBToTWD.tsx',
   '/nzd-twd/': 'apps/ratewise/src/pages/NZDToTWD.tsx',
   '/chf-twd/': 'apps/ratewise/src/pages/CHFToTWD.tsx',
+  '/vnd-twd/': 'apps/ratewise/src/pages/VNDToTWD.tsx',
+  '/php-twd/': 'apps/ratewise/src/pages/PHPToTWD.tsx',
+  '/idr-twd/': 'apps/ratewise/src/pages/IDRToTWD.tsx',
+  '/myr-twd/': 'apps/ratewise/src/pages/MYRToTWD.tsx',
 };
 
 /**


### PR DESCRIPTION
## Summary

- **品牌定位更新**：RateWise 定位為「台灣最精準匯率換算器·顯示實際買賣價」，強調與中間價工具的差異化
- **新增 4 個幣對 SEO 落地頁**：VND（越南盾）、PHP（菲律賓披索）、IDR（印尼盾）、MYR（馬來幣），含完整 CURRENCY_PAGE_OVERRIDES（displayName、region、question、keyword、popularAmounts、travelTip、searchQueries）
- **SSOT 全面同步**：seo-paths.ts / seo-paths.config.mjs 17→21 SEO 路徑、sitemap.xml 21 URL、llms.txt 17 幣對、api/latest.json 18 幣別

## Changes

### P0-A: 品牌定位
- `seo-metadata.ts`: DEFAULT_TITLE / DEFAULT_DESCRIPTION / HOMEPAGE_SEO 全面更新
- `seo-paths.ts` / `seo-paths.config.mjs`: SITE_CONFIG title/description 同步
- `generate-llms-txt.mjs`: intro、Q&A、Data Source 透明度強化

### P0-B: API 幣別擴充
- `generate-api-json.mjs` 已從 constants.ts SSOT 動態讀取，自動包含 18 幣別

### P1-A: 新增幣對頁
- 4 個新頁面元件（VNDToTWD / PHPToTWD / IDRToTWD / MYRToTWD）
- routes.tsx lazy routes 新增
- sitemap source file mapping 補齊
- llms.txt CURRENCY_DISPLAY 新增 4 幣對

### P1-B: 語意化 SEO
- CurrencyLandingPage 常見金額 h3 語意化（提升長尾 query 命中率）
- 版權年更新 2025→2026

## Test Plan

- [x] `pnpm typecheck` — 全 workspace 通過
- [x] `pnpm test` — 84 檔案 / 1405 測試全過
- [x] `node scripts/verify-ssot-sync.mjs` — TS/MJS 21 路徑完全一致
- [x] `node scripts/generate-sitemap-2025.mjs` — 21 URL 無警告
- [x] `node apps/ratewise/scripts/generate-llms-txt.mjs` — 17 幣對
- [x] `node apps/ratewise/scripts/generate-api-json.mjs` — 18 幣別
- [x] Pre-commit 5 步驟全通過（lint-staged / typecheck / prettier / SSOT / version SSOT）
- [x] Pre-push 3 步驟全通過（typecheck / test / build:ratewise）

Made with [Cursor](https://cursor.com)