### PR TITLE
fix(security): 修復生產 console 嚴重錯誤與安全標頭漂移

### DIFF
--- a/.changeset/fix-error-boundary-contact-links.md
+++ b/.changeset/fix-error-boundary-contact-links.md
@@ -1,0 +1,6 @@
+---
+'@app/ratewise': patch
+---
+
+- ErrorBoundary 新增 Threads / GitHub Issues / Email 三種聯絡管道
+- 所有聯絡資訊來自 app-info.ts SSOT，無硬編碼值

--- a/apps/ratewise/scripts/health-check.mjs
+++ b/apps/ratewise/scripts/health-check.mjs
@@ -75,6 +75,64 @@ function request(url, options = {}) {
 }
 
 /**
+ * 嚴格探測：不接受 3xx redirect（偵測 nginx alias trailing-slash 問題）
+ * 成功條件：HTTP 2xx（含 204）
+ */
+async function strictProbe(url, method = 'GET') {
+  const startTime = Date.now();
+  try {
+    const res = await request(url, { method });
+    const responseTime = Date.now() - startTime;
+    const ok = res.statusCode >= 200 && res.statusCode < 300;
+
+    if (ok) {
+      log(colors.green, '✓', `[${method}] ${url} → ${res.statusCode} (${responseTime}ms)`);
+    } else {
+      log(
+        colors.red,
+        '✗',
+        `[${method}] ${url} → ${res.statusCode} (expected 2xx, redirect indicates missing nginx exact-match rule)`,
+      );
+    }
+    return { success: ok, statusCode: res.statusCode, responseTime };
+  } catch (error) {
+    log(colors.red, '✗', `[${method}] ${url} → ${error.message}`);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Worker 部署驗證：檢查 X-Security-Policy-Version 標頭
+ * 缺少此標頭表示 Cloudflare Worker 未部署或路由未生效
+ */
+async function workerDeployCheck(url, expectedVersion) {
+  try {
+    const res = await request(url);
+    const version = res.headers['x-security-policy-version'];
+
+    if (!version) {
+      log(
+        colors.red,
+        '✗',
+        `Worker 未部署：${url} 缺少 X-Security-Policy-Version header（probe/csp-report 將 301/404）`,
+      );
+      return { success: false, reason: 'missing-header' };
+    }
+
+    if (expectedVersion && version !== expectedVersion) {
+      log(colors.yellow, '⚠', `Worker 版本漂移：期待 ${expectedVersion}，實際 ${version}`);
+      return { success: true, version, warning: 'version-mismatch' };
+    }
+
+    log(colors.green, '✓', `Worker 已部署：X-Security-Policy-Version: ${version}`);
+    return { success: true, version };
+  } catch (error) {
+    log(colors.red, '✗', `Worker 檢查失敗：${error.message}`);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
  * 淺層健康檢查：HTTP 狀態碼 + 回應時間
  *
  * 接受 200 或 301（尾斜線重定向是正常的）
@@ -243,7 +301,39 @@ async function runHealthChecks(baseUrl) {
   ]);
   results.push({ url: '/guide (HowTo)', ...guideResult });
 
-  // 4. 靜態資源檢查
+  // 4. 關鍵端點嚴格檢查（不接受 3xx redirect）
+  console.log(`\n${colors.gray}[嚴格探測] 關鍵端點 - 不允許 redirect${colors.reset}`);
+
+  const probeResult = await strictProbe(`${baseUrl}/__network_probe__?t=${Date.now()}`);
+  results.push({ url: '/__network_probe__', ...probeResult });
+  if (!probeResult.success) {
+    log(
+      colors.yellow,
+      '⚠',
+      '  → 修復：確認 nginx exact-match location = /ratewise/__network_probe__ 存在並已部署',
+    );
+  }
+
+  const cspReportResult = await strictProbe(`${baseUrl}/csp-report`, 'POST');
+  results.push({ url: '/csp-report (POST)', ...cspReportResult });
+  if (!cspReportResult.success) {
+    log(
+      colors.yellow,
+      '⚠',
+      '  → 修復：確認 nginx exact-match location = /ratewise/csp-report 存在並已部署',
+    );
+  }
+
+  // 5. Cloudflare Worker 部署驗證
+  console.log(`\n${colors.gray}[Worker 驗證] Cloudflare Security Headers Worker${colors.reset}`);
+
+  const workerResult = await workerDeployCheck(baseUrl, '3.7');
+  results.push({ url: 'Worker deployment', ...workerResult });
+  if (!workerResult.success) {
+    log(colors.yellow, '⚠', '  → 修復：cd security-headers && npx wrangler deploy');
+  }
+
+  // 6. 靜態資源檢查
   console.log(`\n${colors.gray}[淺層檢查] 靜態資源${colors.reset}`);
 
   const staticFiles = [

--- a/apps/ratewise/src/components/ErrorBoundary.test.tsx
+++ b/apps/ratewise/src/components/ErrorBoundary.test.tsx
@@ -238,8 +238,6 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     );
 
-    expect(
-      screen.getByText(/若問題持續發生，請嘗試清除瀏覽器快取或聯繫技術支援/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/若問題持續發生，請清除瀏覽器快取後重試/)).toBeInTheDocument();
   });
 });

--- a/apps/ratewise/src/components/ErrorBoundary.tsx
+++ b/apps/ratewise/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 import { logger } from '../utils/logger';
+import { APP_INFO } from '../config/app-info';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -123,8 +124,32 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             </button>
 
             <p className="text-xs text-text-muted text-center mt-4">
-              若問題持續發生，請嘗試清除瀏覽器快取或聯繫技術支援。
+              若問題持續發生，請清除瀏覽器快取後重試，或透過以下方式聯繫作者：
             </p>
+            <div className="flex justify-center gap-4 mt-2 flex-wrap">
+              <a
+                href={APP_INFO.threadsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs underline text-text-muted hover:text-text transition-colors"
+              >
+                Threads {APP_INFO.socialHandle}
+              </a>
+              <a
+                href={`${APP_INFO.github}/issues`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs underline text-text-muted hover:text-text transition-colors"
+              >
+                GitHub Issues
+              </a>
+              <a
+                href={`mailto:${APP_INFO.email}`}
+                className="text-xs underline text-text-muted hover:text-text transition-colors"
+              >
+                {APP_INFO.email}
+              </a>
+            </div>
           </div>
         </div>
       );

--- a/nginx.conf
+++ b/nginx.conf
@@ -410,6 +410,22 @@ http {
             return 301 $redirect_scheme://$host/ratewise/twitter-image.jpg;
         }
 
+        # [fix:2026-03-07] 網路探測端點 - exact match 優先於 alias/try_files 避免 301 trailing slash redirect
+        # Cloudflare Worker 部署時會在邊緣攔截並回傳 204；Worker 未部署時由 nginx 兜底
+        location = /ratewise/__network_probe__ {
+            add_header Cache-Control "no-store" always;
+            add_header X-Probe-Source "nginx-fallback" always;
+            return 204;
+        }
+
+        # [fix:2026-03-07] CSP 違規回報端點（ratewise 路由）
+        # Worker 優先處理；nginx 兜底避免 POST 跟隨 301 redirect 後 ERR_FAILED
+        location = /ratewise/csp-report {
+            access_log /var/log/nginx/csp-violations.log;
+            add_header Cache-Control "no-store" always;
+            return 204;
+        }
+
         # [FIX:2025-12-14] RateWise SPA 路由配置
         # 使用 alias 指向正確的 ratewise-app/ 目錄，與 nihonname 配置保持一致
         location /ratewise/ {

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -1,12 +1,13 @@
 /* global HTMLRewriter */
 
 /**
- * 安全標頭 Worker v3.6
+ * 安全標頭 Worker v3.7
  *
  * 本 Worker 為 HTTP 安全標頭的唯一來源（SSOT），統一管理所有路由的安全政策，
  * 無需修改應用程式原始碼。
  *
  * 變更記錄：
+ * - v3.7: CSP-Report-Only 新增 goog#html TrustedType，修復 Google Analytics 違規 console 噪音
  * - v3.6: 改用 HTMLRewriter 解析 inline script，避免以 regex 掃描 HTML 觸發 CodeQL `js/bad-tag-filter`
  *
  * 路由策略：
@@ -23,7 +24,7 @@
  */
 
 const HSTS = 'max-age=31536000; includeSubDomains; preload';
-const SECURITY_POLICY_VERSION = '3.6';
+const SECURITY_POLICY_VERSION = '3.7';
 
 /** 解析 HTML 中所有 inline script，回傳 CSP 所需的 SHA-256 hash token 陣列。 */
 async function computeInlineScriptHashes(html) {
@@ -153,7 +154,7 @@ export default {
 			newResponse.headers.set('Content-Security-Policy', csp);
 			newResponse.headers.set(
 				'Content-Security-Policy-Report-Only',
-				"require-trusted-types-for 'script'; trusted-types default ratewise#default 'allow-duplicates'; report-uri /ratewise/csp-report;",
+				"require-trusted-types-for 'script'; trusted-types default ratewise#default goog#html 'allow-duplicates'; report-uri /ratewise/csp-report;",
 			);
 			newResponse.headers.set(
 				'Permissions-Policy',


### PR DESCRIPTION
## 問題

三個生產環境 console 嚴重錯誤同時發生：

1. **`__network_probe__` 404** — nginx `alias + try_files \$uri \$uri/` 對無副檔名路徑觸發 301 trailing-slash redirect，瀏覽器跟隨後 404，`isOnline()` 永遠回傳 `false`，**離線指示器常駐顯示**，每 30 秒噴 404 console 錯誤
2. **`csp-report` POST ERR_FAILED** — 同上，POST 跟隨 301 後失敗
3. **`goog#html` TrustedType violation** — CSP-Report-Only 未列出 Google Analytics 內部建立的 `goog#html` policy

## 修復

- **nginx.conf**：新增 `location = /ratewise/__network_probe__`（exact-match，回傳 204），bypass alias/try_files redirect
- **nginx.conf**：新增 `location = /ratewise/csp-report`（exact-match，回傳 204），修復 POST ERR_FAILED
- **worker.js v3.7**：`trusted-types` 加入 `goog#html`，消除 GA console 噪音
- **ErrorBoundary**：新增 Threads / GitHub Issues / Email 聯絡管道（來源 `app-info.ts` SSOT，無硬編碼）
- **health-check.mjs**：新增 `strictProbe()`（不接受 3xx）與 `workerDeployCheck()`（驗證 Worker header）

## 驗證

- Worker v3.7 已部署並通過 curl 驗證：
  - `__network_probe__` → HTTP 204 ✅
  - `csp-report` POST → HTTP 204 ✅  
  - `X-Security-Policy-Version: 3.7` ✅
- ErrorBoundary 14 tests pass ✅
- TypeScript + Prettier + SSOT 全 hook 通過 ✅

## 測試計畫

- [ ] 瀏覽器 DevTools Console 確認無 `__network_probe__` 404
- [ ] 確認 `goog#html` TrustedType violation 不再出現
- [ ] 錯誤邊界 fallback UI 顯示三個聯絡連結