### PR TITLE
fix(health-check): dev 模式跳過 Worker 標頭檢查避免假陽性

### DIFF
--- a/apps/ratewise/public/manifest.webmanifest
+++ b/apps/ratewise/public/manifest.webmanifest
@@ -12,43 +12,43 @@
   "categories": ["finance", "utilities", "productivity"],
   "icons": [
     {
-      "src": "icons/ratewise-icon-192x192.png?v=20260306",
+      "src": "icons/ratewise-icon-192x192.png?v=20260307",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/ratewise-icon-256x256.png?v=20260306",
+      "src": "icons/ratewise-icon-256x256.png?v=20260307",
       "sizes": "256x256",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/ratewise-icon-384x384.png?v=20260306",
+      "src": "icons/ratewise-icon-384x384.png?v=20260307",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/ratewise-icon-512x512.png?v=20260306",
+      "src": "icons/ratewise-icon-512x512.png?v=20260307",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/ratewise-icon-1024x1024.png?v=20260306",
+      "src": "icons/ratewise-icon-1024x1024.png?v=20260307",
       "sizes": "1024x1024",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/ratewise-icon-maskable-512x512.png?v=20260306",
+      "src": "icons/ratewise-icon-maskable-512x512.png?v=20260307",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "icons/ratewise-icon-maskable-1024x1024.png?v=20260306",
+      "src": "icons/ratewise-icon-maskable-1024x1024.png?v=20260307",
       "sizes": "1024x1024",
       "type": "image/png",
       "purpose": "any maskable"
@@ -56,35 +56,35 @@
   ],
   "screenshots": [
     {
-      "src": "screenshots/mobile-home.png?v=20260306",
+      "src": "screenshots/mobile-home.png?v=20260307",
       "sizes": "1080x1920",
       "type": "image/png",
       "form_factor": "narrow",
       "label": "RateWise 首頁 - 即時匯率換算與趨勢圖"
     },
     {
-      "src": "screenshots/mobile-converter-active.png?v=20260306",
+      "src": "screenshots/mobile-converter-active.png?v=20260307",
       "sizes": "1080x1920",
       "type": "image/png",
       "form_factor": "narrow",
       "label": "貨幣轉換 - 輸入金額即時顯示匯率結果"
     },
     {
-      "src": "screenshots/mobile-features.png?v=20260306",
+      "src": "screenshots/mobile-features.png?v=20260307",
       "sizes": "1080x1920",
       "type": "image/png",
       "form_factor": "narrow",
       "label": "常見問題與功能介紹"
     },
     {
-      "src": "screenshots/desktop-converter.png?v=20260306",
+      "src": "screenshots/desktop-converter.png?v=20260307",
       "sizes": "1920x1080",
       "type": "image/png",
       "form_factor": "wide",
       "label": "桌面版 - 完整匯率轉換介面與趨勢圖表"
     },
     {
-      "src": "screenshots/desktop-features.png?v=20260306",
+      "src": "screenshots/desktop-features.png?v=20260307",
       "sizes": "1920x1080",
       "type": "image/png",
       "form_factor": "wide",

--- a/apps/ratewise/scripts/health-check.mjs
+++ b/apps/ratewise/scripts/health-check.mjs
@@ -324,13 +324,17 @@ async function runHealthChecks(baseUrl) {
     );
   }
 
-  // 5. Cloudflare Worker 部署驗證
-  console.log(`\n${colors.gray}[Worker 驗證] Cloudflare Security Headers Worker${colors.reset}`);
-
-  const workerResult = await workerDeployCheck(baseUrl, '3.7');
-  results.push({ url: 'Worker deployment', ...workerResult });
-  if (!workerResult.success) {
-    log(colors.yellow, '⚠', '  → 修復：cd security-headers && npx wrangler deploy');
+  // 5. Cloudflare Worker 部署驗證（僅 prod 環境；localhost 無此標頭為正常）
+  const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(new URL(baseUrl).hostname);
+  if (!isLocalhost) {
+    console.log(`\n${colors.gray}[Worker 驗證] Cloudflare Security Headers Worker${colors.reset}`);
+    const workerResult = await workerDeployCheck(baseUrl, '3.7');
+    results.push({ url: 'Worker deployment', ...workerResult });
+    if (!workerResult.success) {
+      log(colors.yellow, '⚠', '  → 修復：cd security-headers && npx wrangler deploy');
+    }
+  } else {
+    log(colors.gray, '–', '[Worker 驗證] 跳過（dev 模式，localhost 無 X-Security-Policy-Version）');
   }
 
   // 6. 靜態資源檢查


### PR DESCRIPTION
## Summary

- `localhost` 無 `X-Security-Policy-Version` header，`workerDeployCheck()` 在 dev 模式永遠失敗（假陽性）
- 以 `isLocalhost` 偵測 hostname（`localhost` / `127.0.0.1` / `::1`），dev 模式跳過 Worker 驗證並印出說明訊息
- prod 模式邏輯不受影響

## Root Cause (P2 Codex Review)

`runHealthChecks()` 無條件呼叫 `workerDeployCheck()`，但 dev 環境的 Cloudflare Worker 不存在，導致：
- dev 健康檢查永遠顯示 Worker 未部署
- CI 或本地 `node scripts/health-check.mjs dev` 輸出誤導性紅燈

## Test plan

- [ ] `node apps/ratewise/scripts/health-check.mjs dev` → Worker 驗證行顯示「跳過（dev 模式）」
- [ ] `node apps/ratewise/scripts/health-check.mjs prod` → Worker 驗證正常執行並檢查 header
- [ ] `node --check apps/ratewise/scripts/health-check.mjs` → 語法驗證通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)