### PR TITLE
fix(ratewise): SW precache 失敗自我修復機制

### DIFF
--- a/.changeset/fix-sw-precache-resilience.md
+++ b/.changeset/fix-sw-precache-resilience.md
@@ -1,0 +1,7 @@
+---
+'@app/ratewise': patch
+---
+
+- sw.ts 新增 unhandledrejection handler 捕捉 bad-precaching-response
+- 偵測到 precache 安裝失敗時自動登出 SW，讓下次導覽重新安裝最新版本
+- 修復部署競態窗口導致用戶 SW 卡在安裝失敗迴圈的問題

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -11,6 +11,16 @@ import { ExpirationPlugin } from 'workbox-expiration';
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
+// SW 自我修復：捕捉 precache 安裝失敗（常見於部署競態窗口，資源短暫 404）。
+// 自動登出並讓瀏覽器在下次導覽時重新安裝，避免用戶卡在壞掉的 SW 迴圈。
+self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+  if (String(event.reason).includes('bad-precaching-response')) {
+    console.warn('[SW] Precache 失敗，自動登出以允許重新安裝');
+    event.preventDefault();
+    void self.registration.unregister();
+  }
+});
+
 // 預快取 Vite 產生的靜態資源。
 precacheAndRoute(self.__WB_MANIFEST);
 


### PR DESCRIPTION
## Summary

- `sw.ts` 新增 `unhandledrejection` handler 捕捉 `bad-precaching-response` 錯誤
- 偵測到 precache 安裝失敗時，自動登出 SW 並抑制 console 噪音
- 下次導覽瀏覽器將重新安裝最新 SW，解除用戶卡在安裝失敗迴圈的問題

## Root Cause 分析

**`bad-precaching-response: vendor-router-B_V2eAuT.js (404)`**

- 原因：部署競態窗口 — sw.js 與靜態資源短暫不同步（Zeabur 部署非原子性）
- 現況：資源已恢復 200 OK，但受影響用戶的 SW 陷入安裝失敗迴圈
- 無法用代碼控制部署順序，因此採用 SW 層的自我修復機制

**`goog#html TrustedType 違規`**

- 已由 `security-headers` Worker v3.7 修復（CSP-Report-Only 已加入 `goog#html`）
- 用戶看到的是舊 SW 快取的舊 CSP headers，將隨 SW 更新自然消失

## Fix 說明

```ts
// sw.ts — 業界標準 SW self-healing 模式
self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
  if (String(event.reason).includes('bad-precaching-response')) {
    console.warn('[SW] Precache 失敗，自動登出以允許重新安裝');
    event.preventDefault(); // 抑制 console 噪音
    void self.registration.unregister(); // 強制下次重新安裝
  }
});
```

## Test plan

- [ ] `pnpm typecheck` 通過
- [ ] `pnpm build:ratewise` 驗證 sw.js 含新 handler
- [ ] 開發者工具 Application → Service Workers 確認舊 SW 可自動清除

🤖 Generated with [Claude Code](https://claude.com/claude-code)