### PR TITLE
fix(ratewise): SW precache 失敗策略細化：區分首次安裝與更新安裝

### DIFF
--- a/.changeset/fix-sw-precache-resilience.md
+++ b/.changeset/fix-sw-precache-resilience.md
@@ -3,5 +3,6 @@
 ---
 
 - sw.ts 新增 unhandledrejection handler 捕捉 bad-precaching-response
-- 偵測到 precache 安裝失敗時自動登出 SW，讓下次導覽重新安裝最新版本
+- 僅在無健康 active worker 時才登出（首次安裝失敗場景）
+- 若已有 active worker 仍在服務，保留其快取並讓瀏覽器下次自動重試新版安裝
 - 修復部署競態窗口導致用戶 SW 卡在安裝失敗迴圈的問題

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -12,12 +12,17 @@ import { ExpirationPlugin } from 'workbox-expiration';
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
 // SW 自我修復：捕捉 precache 安裝失敗（常見於部署競態窗口，資源短暫 404）。
-// 自動登出並讓瀏覽器在下次導覽時重新安裝，避免用戶卡在壞掉的 SW 迴圈。
+// 僅在無健康 active worker 時才登出（首次安裝失敗場景）；
+// 若已有 active worker 仍在服務，保留其快取並讓瀏覽器下次自動重試新版安裝。
 self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
   if (String(event.reason).includes('bad-precaching-response')) {
-    console.warn('[SW] Precache 失敗，自動登出以允許重新安裝');
     event.preventDefault();
-    void self.registration.unregister();
+    if (!self.registration.active) {
+      console.warn('[SW] 首次 precache 安裝失敗，自動登出以允許重新安裝');
+      void self.registration.unregister();
+    } else {
+      console.warn('[SW] 新版 precache 安裝失敗，保留現有 active worker，瀏覽器將自動重試');
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- 新增 `registration.active` 防護，細分兩種 precache 失敗場景
- 首次安裝失敗（無 active worker）：登出 SW，讓瀏覽器重新安裝
- 更新安裝失敗（已有 active worker）：保留現有快取，讓瀏覽器自動重試新版
- 避免有效 active worker 因新版 precache 競態失敗而被誤登出，導致用戶失去離線能力

## Test plan

- [ ] TypeScript 型別檢查通過
- [ ] 驗證首次安裝失敗場景：`registration.active` 為 null，SW 應登出
- [ ] 驗證更新安裝失敗場景：`registration.active` 存在，SW 應保留，console.warn 提示

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)