### PR TITLE
fix(ratewise): 修復 PWA 骨架屏永久卡住與下拉強制刷新失效

### DIFF
--- a/.changeset/fix-pwa-skeleton-stuck-pull-to-refresh.md
+++ b/.changeset/fix-pwa-skeleton-stuck-pull-to-refresh.md
@@ -1,0 +1,10 @@
+---
+'@app/ratewise': patch
+---
+
+修復 PWA 骨架屏卡住與下拉強制刷新失效問題
+
+- AppLayout: 接線 usePullToRefresh + PullToRefreshIndicator，使用者可下拉強制清快取並重載
+- SkeletonLoader: 新增 10 秒 watchdog，客戶端卡住時自動轉為錯誤復原 UI（強制重新載入 + 聯絡資訊）
+- sw.ts: 新增 FORCE_HARD_RESET message handler，客戶端可命令 SW 清除所有快取後回報重載
+- swUtils.ts: performFullRefresh 改為優先透過 SW 訊息清快取（forceHardReset），確保 SW 與 client 兩端快取均被清除；3 秒 timeout 兜底強制重載

--- a/.changeset/fix-swutils-timeout-cache-clear.md
+++ b/.changeset/fix-swutils-timeout-cache-clear.md
@@ -1,0 +1,8 @@
+---
+'@app/ratewise': patch
+---
+
+修正 forceHardReset timeout fallback 未清快取的回歸
+
+舊版 SW 無 FORCE_HARD_RESET handler 時，3 秒 timeout 僅重載未清快取，
+導致使用者重整到同一批舊快取。修正：timeout 改為先清 Cache Storage 再重載。

--- a/apps/ratewise/src/components/AppLayout.tsx
+++ b/apps/ratewise/src/components/AppLayout.tsx
@@ -10,11 +10,14 @@ import { ToastProvider } from './Toast';
 import { RouteErrorBoundary } from './RouteErrorBoundary';
 import { OfflineIndicator } from './OfflineIndicator';
 import { UpdatePrompt } from './UpdatePrompt';
+import { PullToRefreshIndicator } from './PullToRefreshIndicator';
 
 import { getResolvedLanguage } from '../i18n';
 import { navigationTokens } from '../config/design-tokens';
 import { getTopLevelTransitionDirection, pageTransition } from '../config/animations';
 import { RouteAnalytics } from '@shared/analytics';
+import { usePullToRefresh } from '../hooks/usePullToRefresh';
+import { performFullRefresh } from '../utils/swUtils';
 
 /** Logo 組件 */
 function Logo() {
@@ -91,9 +94,12 @@ export function AppLayout() {
   const location = useLocation();
   const [previousPathname, setPreviousPathname] = React.useState(location.pathname);
   const [hasMounted, setHasMounted] = React.useState(false);
+  const mainRef = React.useRef<HTMLElement>(null);
 
   const prefersReducedMotion =
     typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const { pullDistance, isRefreshing, canTrigger } = usePullToRefresh(mainRef, performFullRefresh);
 
   React.useEffect(() => {
     setHasMounted(true);
@@ -129,9 +135,15 @@ export function AppLayout() {
 
             {/* 內容區域 - 支援 iOS Safari 慣性滾動 */}
             <main
+              ref={mainRef}
               data-scroll-container="main"
               className="flex-1 min-h-0 min-w-0 w-full relative overflow-y-auto overflow-x-hidden pb-[calc(56px+env(safe-area-inset-bottom,0px))] md:pb-0 [-webkit-overflow-scrolling:touch] overscroll-y-contain"
             >
+              <PullToRefreshIndicator
+                pullDistance={pullDistance}
+                isRefreshing={isRefreshing}
+                canTrigger={canTrigger}
+              />
               <RouteErrorBoundary>
                 {/* enter-only：key 變化觸發 remount，新頁面從方向滑入淡入 */}
                 <motion.div

--- a/apps/ratewise/src/components/SkeletonLoader.tsx
+++ b/apps/ratewise/src/components/SkeletonLoader.tsx
@@ -13,10 +13,65 @@
  * 重要：SkeletonLoader 僅渲染內容骨架，不包含 AppLayout 結構
  *       因為它作為 ClientOnly fallback 已在 AppLayout 內部渲染
  *
+ * Watchdog（2026-03-07）：
+ * - 客戶端顯示超過 SKELETON_TIMEOUT_MS 後自動轉為錯誤復原 UI
+ * - 避免 SW 快取過期、chunk 載入失敗導致永遠卡在骨架屏
+ * - 提供「強制重新載入」按鈕 + 聯絡資訊，確保使用者永遠有操作出口
+ *
  * @see https://web.dev/articles/cls
  * @see https://www.smashingmagazine.com/2020/04/skeleton-screens-react/
- * @updated 2026-01-26 - 移除 AppLayout 結構，避免 Hydration mismatch
  */
+
+import { useEffect, useState } from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { performFullRefresh } from '../utils/swUtils';
+import { APP_INFO } from '../config/app-info';
+import { SupportContactLinks } from './SupportContactLinks';
+
+/** 骨架屏超時閾值（毫秒）。超過此時間仍在顯示表示 app 初始化失敗。 */
+const SKELETON_TIMEOUT_MS = 10_000;
+
+/**
+ * 骨架屏卡住時的復原 UI
+ * 提供強制重新載入按鈕與聯絡資訊，確保使用者永遠有出口。
+ */
+function SkeletonTimeoutFallback() {
+  const [isReloading, setIsReloading] = useState(false);
+
+  const handleReload = () => {
+    setIsReloading(true);
+    void performFullRefresh();
+  };
+
+  return (
+    <div className="p-6 flex items-center justify-center min-h-[60vh]">
+      <div className="bg-surface rounded-2xl shadow-xl p-8 max-w-sm w-full space-y-5 text-center">
+        <AlertCircle className="mx-auto text-warning" size={40} />
+        <div>
+          <h2 className="text-lg font-bold text-text mb-2">應用程式載入逾時</h2>
+          <p className="text-sm text-text-muted">
+            載入時間超過預期，可能是快取過期或網路問題。請強制重新載入以取得最新版本。
+          </p>
+        </div>
+        <button
+          onClick={handleReload}
+          disabled={isReloading}
+          className="w-full flex items-center justify-center gap-2 py-3 bg-primary hover:bg-primary-hover disabled:opacity-60 text-white font-semibold rounded-xl shadow-lg transition"
+        >
+          <RefreshCw size={18} className={isReloading ? 'animate-spin' : ''} />
+          {isReloading ? '重新載入中...' : '強制重新載入（清除快取）'}
+        </button>
+        <SupportContactLinks title="若問題持續發生，請聯絡作者：" description="" />
+        <p className="text-xs text-text-muted">
+          也可嘗試：設定 → 清除瀏覽器快取，或聯絡{' '}
+          <a href={`mailto:${APP_INFO.email}`} className="underline">
+            {APP_INFO.email}
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}
 
 /**
  * 主頁面骨架屏
@@ -24,8 +79,23 @@
  *
  * @description 僅渲染內容骨架，不包含 Header/BottomNav（由 AppLayout 提供）
  *              作為 ClientOnly fallback，必須與最終渲染結構匹配
+ *              內建 watchdog：客戶端顯示超過 10 秒自動轉為錯誤復原 UI
  */
 export const SkeletonLoader = () => {
+  const [isTimedOut, setIsTimedOut] = useState(false);
+
+  useEffect(() => {
+    // SSR 環境不執行（useEffect 僅在 client 執行）
+    const timer = setTimeout(() => {
+      setIsTimedOut(true);
+    }, SKELETON_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (isTimedOut) {
+    return <SkeletonTimeoutFallback />;
+  }
+
   return (
     <div className="p-4 md:p-6" role="status" aria-live="polite">
       {/* SEO 靜態內容 - 對爬蟲可見，inline style 確保 CSS 載入前即隱藏，避免 CLS */}

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -36,6 +36,31 @@ cleanupOutdatedCaches();
 void self.skipWaiting();
 clientsClaim();
 
+// FORCE_HARD_RESET：客戶端（骨架屏超時、使用者手動下拉）可傳送此訊息。
+// SW 清除所有快取並通知 client 重新載入，確保使用者永遠能脫離卡住狀態。
+self.addEventListener('message', (event: ExtendableMessageEvent) => {
+  const data = event.data as { type?: string } | null;
+  if (data?.type !== 'FORCE_HARD_RESET') return;
+
+  event.waitUntil(
+    (async () => {
+      console.warn('[SW] FORCE_HARD_RESET 收到，清除所有快取並通知 client 重載');
+      try {
+        const cacheNames = await caches.keys();
+        await Promise.all(cacheNames.map((name) => caches.delete(name)));
+        console.warn(`[SW] 已清除 ${String(cacheNames.length)} 個快取`);
+      } catch (err) {
+        console.error('[SW] 清除快取失敗:', err);
+      }
+      // 通知所有 client 重新載入
+      const clients = await self.clients.matchAll({ type: 'window' });
+      for (const client of clients) {
+        client.postMessage({ type: 'SW_HARD_RESET_DONE' });
+      }
+    })(),
+  );
+});
+
 // 離線探測專用路徑：永遠走網路，避免快取誤判在線。
 registerRoute(
   ({ url }: { url: URL }) => url.pathname.endsWith('/__network_probe__'),

--- a/apps/ratewise/src/utils/swUtils.ts
+++ b/apps/ratewise/src/utils/swUtils.ts
@@ -103,9 +103,61 @@ export async function forceServiceWorkerUpdate(): Promise<boolean> {
 }
 
 /**
+ * 傳送 FORCE_HARD_RESET 訊息給 SW，讓 SW 清除所有快取後重載。
+ *
+ * 優先使用 SW message（讓 SW 從內部清除快取），
+ * 若 SW 不存在則直接由 client 清除快取。
+ * SW 回覆 SW_HARD_RESET_DONE 時頁面重載，或 3 秒 timeout 後強制重載。
+ *
+ * @returns Promise<void>
+ */
+export async function forceHardReset(): Promise<void> {
+  logger.info('[swUtils] forceHardReset: starting');
+
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    window.location.reload();
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    const sw = registration?.active ?? registration?.installing ?? registration?.waiting;
+
+    if (sw) {
+      // 等待 SW 回覆後重載，最多 3 秒
+      const reloadOnMessage = (event: MessageEvent) => {
+        if ((event.data as { type?: string })?.type === 'SW_HARD_RESET_DONE') {
+          navigator.serviceWorker.removeEventListener('message', reloadOnMessage);
+          window.location.reload();
+        }
+      };
+      navigator.serviceWorker.addEventListener('message', reloadOnMessage);
+      sw.postMessage({ type: 'FORCE_HARD_RESET' });
+
+      // Fallback: 3 秒後若 SW 未回覆仍重載
+      setTimeout(() => {
+        navigator.serviceWorker.removeEventListener('message', reloadOnMessage);
+        window.location.reload();
+      }, 3000);
+      return;
+    }
+  } catch (error) {
+    logger.warn('[swUtils] forceHardReset: SW message failed, fallback to direct clear', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Fallback：直接由 client 清除快取
+  await clearAllServiceWorkerCaches();
+  window.location.reload();
+}
+
+/**
  * 完整的刷新流程：清除快取 + 檢查更新 + 重新載入
  *
- * 用於下拉刷新等場景，確保用戶獲得最新內容
+ * 用於下拉刷新等場景，確保用戶獲得最新內容。
+ * 優先透過 SW 訊息清除快取（forceHardReset），
+ * 確保 SW 快取與 client 端快取均被清除。
  *
  * @returns Promise<void>
  */
@@ -113,18 +165,9 @@ export async function performFullRefresh(): Promise<void> {
   logger.info('Starting full refresh flow');
 
   try {
-    // 1. 清除所有 Service Worker 快取
-    const clearedCount = await clearAllServiceWorkerCaches();
-    logger.debug('Caches cleared', { count: clearedCount });
-
-    // 2. 主動檢查並更新 Service Worker
-    await forceServiceWorkerUpdate();
-
-    // 3. 重新載入頁面
-    window.location.reload();
+    await forceHardReset();
   } catch (error) {
     logger.error('Full refresh flow failed', error as Error);
-    // 即使出錯，仍然重新載入頁面
     window.location.reload();
   }
 }

--- a/apps/ratewise/src/utils/swUtils.ts
+++ b/apps/ratewise/src/utils/swUtils.ts
@@ -134,10 +134,12 @@ export async function forceHardReset(): Promise<void> {
       navigator.serviceWorker.addEventListener('message', reloadOnMessage);
       sw.postMessage({ type: 'FORCE_HARD_RESET' });
 
-      // Fallback: 3 秒後若 SW 未回覆仍重載
+      // Fallback: 3 秒後若 SW 未回覆（舊版 SW 無 handler）仍清快取後重載
       setTimeout(() => {
         navigator.serviceWorker.removeEventListener('message', reloadOnMessage);
-        window.location.reload();
+        void clearAllServiceWorkerCaches().finally(() => {
+          window.location.reload();
+        });
       }, 3000);
       return;
     }


### PR DESCRIPTION
## 問題根源

生產環境 PWA 有兩個嚴重問題：

1. **骨架屏永久卡住**：`ClientOnly fallback={<SkeletonLoader />}` 沒有任何超時機制。當 SW 快取過期、chunk 載入失敗、或 JS 初始化異常時，使用者看到骨架屏後毫無出路，只能強制關掉 App。
2. **下拉強制刷新無效**：`usePullToRefresh` hook 與 `PullToRefreshIndicator` 元件早已實作完成，但**從未接線到 AppLayout**。使用者下拉完全沒有反應。

## 修復內容

- **AppLayout**: 接線 `usePullToRefresh` + `PullToRefreshIndicator`，使用者下拉觸發 `performFullRefresh`（清快取 + 重載）
- **SkeletonLoader**: 新增 10 秒 watchdog `useEffect`，超時自動轉為錯誤復原 UI，提供「強制重新載入（清除快取）」按鈕與聯絡資訊
- **sw.ts**: 新增 `FORCE_HARD_RESET` message handler，client 可命令 SW 清除所有快取後回覆 `SW_HARD_RESET_DONE`
- **swUtils.ts**: `performFullRefresh` 改由 `forceHardReset` 主導，優先透過 SW 訊息清快取（確保 SW 側快取完整清除），3 秒 timeout 兜底強制重載

## 防禦鏈

```
使用者 → 下拉 → usePullToRefresh → performFullRefresh → forceHardReset
                                                       → SW: FORCE_HARD_RESET → 清所有 cache → SW_HARD_RESET_DONE → reload

骨架屏 > 10s → SkeletonTimeoutFallback → 強制重新載入按鈕（同上鏈）
                                        → 聯絡資訊（Threads / GitHub Issues / Email）

任何 JS 崩潰 → ErrorBoundary → 重新載入按鈕 + 聯絡資訊（已有）
路由 chunk 失敗 → RouteErrorBoundary → 清快取重載（已有）
```

## Test plan

- [ ] 下拉至超過 100px 後放開，應觸發清快取 + 重載（看 Network 請求）
- [ ] 手動 mock `ClientOnly` fallback 停留超過 10s，應出現「應用程式載入逾時」錯誤 UI
- [ ] DevTools → Application → Service Workers → 傳送 `{type: "FORCE_HARD_RESET"}` 訊息，應清空所有 Cache Storage
- [ ] 點擊「強制重新載入」，應清快取並重載頁面
- [ ] TypeScript + ESLint + Prettier 全通過

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)