### PR TITLE
fix(ratewise): 離線時禁止清除 SW 快取保護 PWA 離線功能

### DIFF
--- a/.changeset/fix-offline-guard-cache-clear.md
+++ b/.changeset/fix-offline-guard-cache-clear.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+fix(ratewise): 離線狀態下禁止清除 SW 快取，保護 PWA 離線功能

--- a/apps/ratewise/src/hooks/__tests__/usePullToRefresh.test.ts
+++ b/apps/ratewise/src/hooks/__tests__/usePullToRefresh.test.ts
@@ -567,4 +567,80 @@ describe('usePullToRefresh', () => {
       expect(TRIGGER_THRESHOLD).toBe(100);
     });
   });
+
+  describe('§ 8 離線防護', () => {
+    function setOnline(value: boolean) {
+      Object.defineProperty(window.navigator, 'onLine', {
+        writable: true,
+        configurable: true,
+        value,
+      });
+    }
+
+    afterEach(() => {
+      setOnline(true);
+    });
+
+    it('離線時達到門檻後不呼叫 onRefresh', () => {
+      setOnline(false);
+      window.scrollY = 0;
+
+      const { result } = renderHook(() => usePullToRefresh(containerRef, onRefresh));
+
+      act(() => {
+        container.dispatchEvent(
+          new TouchEvent('touchstart', { touches: [{ clientY: 0 } as Touch] }),
+        );
+      });
+
+      act(() => {
+        container.dispatchEvent(
+          new TouchEvent('touchmove', {
+            touches: [{ clientY: 600 } as Touch],
+            cancelable: true,
+          }),
+        );
+      });
+
+      // Verify threshold reached
+      expect(result.current.pullDistance).toBeGreaterThanOrEqual(TRIGGER_THRESHOLD);
+
+      act(() => {
+        container.dispatchEvent(new TouchEvent('touchend'));
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it('在線時達到門檻後正常呼叫 onRefresh', () => {
+      setOnline(true);
+      window.scrollY = 0;
+
+      const { result } = renderHook(() => usePullToRefresh(containerRef, onRefresh));
+
+      act(() => {
+        container.dispatchEvent(
+          new TouchEvent('touchstart', { touches: [{ clientY: 0 } as Touch] }),
+        );
+      });
+
+      act(() => {
+        container.dispatchEvent(
+          new TouchEvent('touchmove', {
+            touches: [{ clientY: 600 } as Touch],
+            cancelable: true,
+          }),
+        );
+      });
+
+      // Verify threshold reached
+      expect(result.current.pullDistance).toBeGreaterThanOrEqual(TRIGGER_THRESHOLD);
+
+      act(() => {
+        container.dispatchEvent(new TouchEvent('touchend'));
+      });
+
+      expect(onRefresh).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/apps/ratewise/src/hooks/usePullToRefresh.ts
+++ b/apps/ratewise/src/hooks/usePullToRefresh.ts
@@ -192,10 +192,20 @@ export function usePullToRefresh(
         canTrigger,
         pullDistance,
         threshold: TRIGGER_THRESHOLD,
+        isOnline: navigator.onLine,
       });
 
       // Enable smooth transition back
       container.style.transition = 'transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1)';
+
+      // 離線時不觸發 onRefresh（避免清快取導致 PWA 離線功能失效）
+      if (!navigator.onLine) {
+        logger.warn('Pull-to-refresh: offline — skip refresh to preserve cache');
+        container.style.transform = 'translateY(0)';
+        setPullDistance(0);
+        setCanTrigger(false);
+        return;
+      }
 
       if (canTrigger && pullDistance >= TRIGGER_THRESHOLD) {
         // Trigger refresh

--- a/apps/ratewise/src/utils/__tests__/swUtils.test.ts
+++ b/apps/ratewise/src/utils/__tests__/swUtils.test.ts
@@ -1,0 +1,192 @@
+/**
+ * swUtils 離線防護測試
+ *
+ * 核心規則：離線狀態下絕不清除 SW 快取，
+ * 避免 PWA 離線功能失效。
+ *
+ * @created 2026-03-07
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { clearAllServiceWorkerCaches, forceHardReset, performFullRefresh } from '../swUtils';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function setOnline(value: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    writable: true,
+    configurable: true,
+    value,
+  });
+}
+
+function mockCaches(cacheNames: string[] = ['precache-v1', 'runtime']) {
+  const keysStub = vi.fn().mockResolvedValue(cacheNames);
+  const deleteStub = vi.fn().mockResolvedValue(true);
+
+  Object.defineProperty(window, 'caches', {
+    writable: true,
+    configurable: true,
+    value: { keys: keysStub, delete: deleteStub },
+  });
+
+  return { keysStub, deleteStub };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('swUtils', () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: reloadMock },
+    });
+
+    // default: online
+    setOnline(true);
+
+    // default: serviceWorker available but no registration
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      writable: true,
+      configurable: true,
+      value: {
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── clearAllServiceWorkerCaches ──────────────────────────────────────────
+
+  describe('clearAllServiceWorkerCaches', () => {
+    it('離線時跳過清除並回傳 0', async () => {
+      setOnline(false);
+      const { keysStub } = mockCaches();
+
+      const result = await clearAllServiceWorkerCaches();
+
+      expect(result).toBe(0);
+      expect(keysStub).not.toHaveBeenCalled();
+    });
+
+    it('在線時正常清除所有快取並回傳數量', async () => {
+      setOnline(true);
+      const { keysStub, deleteStub } = mockCaches(['cache-a', 'cache-b']);
+
+      const result = await clearAllServiceWorkerCaches();
+
+      expect(result).toBe(2);
+      expect(keysStub).toHaveBeenCalledOnce();
+      expect(deleteStub).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches API 不存在時直接回傳 0', async () => {
+      setOnline(true);
+      Object.defineProperty(window, 'caches', {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      });
+
+      const result = await clearAllServiceWorkerCaches();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  // ── forceHardReset ────────────────────────────────────────────────────────
+
+  describe('forceHardReset', () => {
+    it('離線時不清快取，直接重載', async () => {
+      setOnline(false);
+      const { deleteStub } = mockCaches();
+
+      await forceHardReset();
+
+      expect(deleteStub).not.toHaveBeenCalled();
+      expect(reloadMock).toHaveBeenCalledOnce();
+    });
+
+    it('在線且無 SW 時清除快取後重載', async () => {
+      setOnline(true);
+      const { deleteStub } = mockCaches(['precache-v1']);
+
+      await forceHardReset();
+
+      expect(deleteStub).toHaveBeenCalledOnce();
+      expect(reloadMock).toHaveBeenCalledOnce();
+    });
+
+    it('在線且有 active SW 時傳送 FORCE_HARD_RESET 訊息', async () => {
+      setOnline(true);
+      mockCaches();
+
+      const postMessage = vi.fn();
+      const swInstance = { postMessage, state: 'activated' };
+
+      Object.defineProperty(window.navigator, 'serviceWorker', {
+        writable: true,
+        configurable: true,
+        value: {
+          getRegistration: vi.fn().mockResolvedValue({ active: swInstance }),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        },
+      });
+
+      // Don't await full timeout — just verify postMessage is called
+      const promise = forceHardReset();
+
+      // Let microtasks run (getRegistration, postMessage)
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(postMessage).toHaveBeenCalledWith({ type: 'FORCE_HARD_RESET' });
+
+      // Cleanup: resolve via the SW_HARD_RESET_DONE message path or timeout
+      // (we don't need to wait for reload in this test)
+      promise.catch(() => {}); // prevent unhandled rejection if any
+    });
+  });
+
+  // ── performFullRefresh ────────────────────────────────────────────────────
+
+  describe('performFullRefresh', () => {
+    it('離線時不清快取，直接重載', async () => {
+      setOnline(false);
+      const { deleteStub } = mockCaches();
+
+      await performFullRefresh();
+
+      expect(deleteStub).not.toHaveBeenCalled();
+      expect(reloadMock).toHaveBeenCalledOnce();
+    });
+
+    it('在線時執行完整重置流程', async () => {
+      setOnline(true);
+      const { deleteStub } = mockCaches(['precache-v1']);
+
+      await performFullRefresh();
+
+      expect(deleteStub).toHaveBeenCalledOnce();
+      expect(reloadMock).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/apps/ratewise/src/utils/swUtils.ts
+++ b/apps/ratewise/src/utils/swUtils.ts
@@ -21,6 +21,12 @@ export async function clearAllServiceWorkerCaches(): Promise<number> {
     return 0;
   }
 
+  // 離線時絕不清除快取，避免 PWA 離線功能失效
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    logger.warn('[swUtils] Offline — skipping cache clear to preserve PWA offline capability');
+    return 0;
+  }
+
   try {
     const cacheNames = await caches.keys();
     const deletePromises = cacheNames.map((name) => caches.delete(name));
@@ -115,6 +121,13 @@ export async function forceHardReset(): Promise<void> {
   logger.info('[swUtils] forceHardReset: starting');
 
   if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    window.location.reload();
+    return;
+  }
+
+  // 離線時只重載（不清快取），保留 SW 快取讓 PWA 離線功能正常運作
+  if (!navigator.onLine) {
+    logger.warn('[swUtils] forceHardReset: offline — reload without cache clear');
     window.location.reload();
     return;
   }


### PR DESCRIPTION
## 問題

下拉重新整理觸發 \`performFullRefresh()\` → \`forceHardReset()\` → \`clearAllServiceWorkerCaches()\` 時，若使用者處於**離線狀態**，清除 SW 快取會讓 PWA 完全失去離線服務能力，導致頁面白屏/無法使用。

## 解法（TDD — 先寫測試再實作）

### 防護點

| 位置 | 行為 |
|------|------|
| `clearAllServiceWorkerCaches()` | `navigator.onLine=false` → skip，log warning，回傳 0 |
| `forceHardReset()` | 離線 → 直接 `reload()`，不清快取 |
| `usePullToRefresh` `handleTouchEnd` | 離線 → 重置拉動狀態，不呼叫 `onRefresh` |

### 測試覆蓋

- 新增 `src/utils/__tests__/swUtils.test.ts`（離線/在線兩種情境）
- `usePullToRefresh.test.ts` 補充 §8 離線防護（2 tests）
- 全套 1444 tests pass

## 驗證

- [x] `vitest run` 1444 passed (88 files)
- [x] `tsc --noEmit` 通過
- [x] ESLint、Prettier 通過
- [x] Pre-push hooks 通過

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)