### PR TITLE
fix(ratewise): 在跳過 legacy 遷移前驗證持久化 schema

### DIFF
--- a/.changeset/validate-persisted-schema.md
+++ b/.changeset/validate-persisted-schema.md
@@ -1,0 +1,11 @@
+---
+'@app/ratewise': patch
+---
+
+在跳過 legacy 遷移前驗證持久化 schema
+
+- 新增 `buildSanitizePatch`：hydrate 後驗證 favorites/fromCurrency/toCurrency/mode 欄位
+- 修復：`ratewise-converter` 存在但含不合法資料（舊 CurrencyPair 格式、損毀代碼）時，
+  先前不做任何驗證直接暴露給下游，導致 `CURRENCY_DEFINITIONS[code]` 可能拋出執行期錯誤
+- `onRehydrateStorage` 依序執行：`__validateAndSanitize` → `__migrateFromLegacy`
+- 新增 7 個 schema 驗證單元測試（converterStore 共 26 tests）

--- a/apps/ratewise/src/stores/__tests__/converterStore.test.ts
+++ b/apps/ratewise/src/stores/__tests__/converterStore.test.ts
@@ -6,6 +6,7 @@
  * - 簡化後的 isFavorite(code) 簽名
  * - swapCurrencies
  * - localStorage 舊 key 遷移邏輯
+ * - hydrate 後的 schema 驗證與狀態修復
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -251,6 +252,98 @@ describe('converterStore', () => {
       useConverterStore.getState().__migrateFromLegacy?.();
 
       expect(useConverterStore.getState().favorites).toEqual(['JPY', 'USD']);
+    });
+  });
+
+  // ── hydrated state schema validation ─────────────────────────────────────
+  describe('hydrated state schema validation (__validateAndSanitize)', () => {
+    it('過濾 favorites 中不合法的貨幣代碼（舊 CurrencyPair 物件格式）', () => {
+      // 模擬舊版 favorites 為 CurrencyPair[]（物件陣列）被 hydrate 進 store
+      useConverterStore.setState({
+        favorites: [
+          { from: 'USD', to: 'JPY' },
+          'JPY',
+        ] as unknown as import('../../features/ratewise/types').CurrencyCode[],
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      // 物件型別無效，應被過濾；'JPY' 為合法代碼，應保留
+      expect(useConverterStore.getState().favorites).toEqual(['JPY']);
+    });
+
+    it('favorites 含純無效字串代碼時，過濾後為空陣列', () => {
+      useConverterStore.setState({
+        favorites: [
+          'NOT_A_CODE',
+          'INVALID',
+        ] as unknown as import('../../features/ratewise/types').CurrencyCode[],
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      expect(useConverterStore.getState().favorites).toEqual([]);
+    });
+
+    it('favorites 為非陣列型別時，重置為預設收藏', () => {
+      useConverterStore.setState({
+        favorites: 'corrupted' as unknown as import('../../features/ratewise/types').CurrencyCode[],
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      // 非陣列無法修復，回退預設值
+      const { favorites } = useConverterStore.getState();
+      expect(Array.isArray(favorites)).toBe(true);
+      expect(favorites.length).toBeGreaterThan(0);
+    });
+
+    it('fromCurrency 為非有效代碼時，重置為 DEFAULT_FROM_CURRENCY', () => {
+      useConverterStore.setState({
+        fromCurrency: 'INVALID' as unknown as import('../../features/ratewise/types').CurrencyCode,
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      // 不合法代碼應重置為預設值（TWD）
+      expect(useConverterStore.getState().fromCurrency).toBe('TWD');
+    });
+
+    it('toCurrency 為非有效代碼時，重置為 DEFAULT_TO_CURRENCY', () => {
+      useConverterStore.setState({
+        toCurrency: 'BROKEN' as unknown as import('../../features/ratewise/types').CurrencyCode,
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      expect(useConverterStore.getState().toCurrency).toBe('JPY');
+    });
+
+    it('mode 為非法值時，重置為 single', () => {
+      useConverterStore.setState({
+        mode: 'invalid_mode' as unknown as 'single' | 'multi',
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      expect(useConverterStore.getState().mode).toBe('single');
+    });
+
+    it('所有欄位合法時，不修改 store 狀態', () => {
+      useConverterStore.setState({
+        fromCurrency: 'USD',
+        toCurrency: 'JPY',
+        mode: 'multi',
+        favorites: ['USD', 'EUR'],
+      });
+
+      useConverterStore.getState().__validateAndSanitize?.();
+
+      const state = useConverterStore.getState();
+      expect(state.fromCurrency).toBe('USD');
+      expect(state.toCurrency).toBe('JPY');
+      expect(state.mode).toBe('multi');
+      expect(state.favorites).toEqual(['USD', 'EUR']);
     });
   });
 });

--- a/apps/ratewise/src/stores/converterStore.ts
+++ b/apps/ratewise/src/stores/converterStore.ts
@@ -76,6 +76,48 @@ interface ConverterState {
 
   /** 供單元測試呼叫；亦由 onRehydrateStorage 在內部觸發 */
   __migrateFromLegacy: () => void;
+  /** hydrate 後驗證並修復不合法的欄位；由 onRehydrateStorage 自動觸發，亦可由單元測試直接呼叫 */
+  __validateAndSanitize: () => void;
+}
+
+// ── Schema 驗證輔助函式 ───────────────────────────────────────────────────────
+
+type PersistentFields = Pick<ConverterState, 'fromCurrency' | 'toCurrency' | 'mode' | 'favorites'>;
+
+/**
+ * 驗證 hydrate 後的狀態欄位是否符合當前 schema 契約。
+ * 若有欄位不合法（例如舊版 CurrencyPair 格式、損毀資料），回傳修復用的 patch；
+ * 所有欄位均合法時回傳 null。
+ */
+function buildSanitizePatch(state: ConverterState): Partial<PersistentFields> | null {
+  const patch: Partial<PersistentFields> = {};
+  let dirty = false;
+
+  if (!isCurrencyCode(state.fromCurrency as string)) {
+    patch.fromCurrency = DEFAULT_FROM_CURRENCY;
+    dirty = true;
+  }
+  if (!isCurrencyCode(state.toCurrency as string)) {
+    patch.toCurrency = DEFAULT_TO_CURRENCY;
+    dirty = true;
+  }
+  if (state.mode !== 'single' && state.mode !== 'multi') {
+    patch.mode = 'single';
+    dirty = true;
+  }
+  if (!Array.isArray(state.favorites)) {
+    patch.favorites = [...DEFAULT_FAVORITES] as CurrencyCode[];
+    dirty = true;
+  } else if (
+    (state.favorites as unknown[]).some((c) => typeof c !== 'string' || !isCurrencyCode(c))
+  ) {
+    patch.favorites = (state.favorites as unknown[]).filter(
+      (c): c is CurrencyCode => typeof c === 'string' && isCurrencyCode(c),
+    );
+    dirty = true;
+  }
+
+  return dirty ? patch : null;
 }
 
 // ── 遷移輔助函式 ─────────────────────────────────────────────────────────────
@@ -177,6 +219,11 @@ export const useConverterStore = create<ConverterState>()(
           removeLegacyKeys();
         }
       },
+
+      __validateAndSanitize: () => {
+        const patch = buildSanitizePatch(get());
+        if (patch) set(patch);
+      },
     }),
     {
       name: 'ratewise-converter',
@@ -189,6 +236,9 @@ export const useConverterStore = create<ConverterState>()(
       }),
       onRehydrateStorage: () => (_state, error) => {
         if (error) return;
+        // 修復不合法的持久化欄位（例如舊版 CurrencyPair 格式、損毀代碼）
+        useConverterStore.getState().__validateAndSanitize();
+        // 舊版個別 key 的一次性遷移
         useConverterStore.getState().__migrateFromLegacy();
       },
     },


### PR DESCRIPTION
## Summary

- 新增 `buildSanitizePatch`：hydrate 後驗證 `favorites`/`fromCurrency`/`toCurrency`/`mode` 欄位，過濾舊 `CurrencyPair` 物件格式與損毀代碼
- 修復：`ratewise-converter` key 存在但含不合法資料時，先前直接暴露給下游，`CURRENCY_DEFINITIONS[code]` 可能拋出執行期錯誤
- `onRehydrateStorage` 依序執行：`__validateAndSanitize` → `__migrateFromLegacy`（驗證優先，遷移其次）
- 新增 7 個 schema 驗證單元測試（converterStore 共 26 tests）

## Test plan

- [x] 26 unit tests passing（`pnpm --filter @app/ratewise vitest run`）
- [x] TypeScript typecheck clean
- [x] Pre-push build passes
- [x] `favorites` 含 `CurrencyPair` 物件 → 過濾後僅保留合法 `CurrencyCode` 字串
- [x] `favorites` 全部無效字串 → 過濾為 `[]`
- [x] `favorites` 為非陣列型別 → 重置為 `DEFAULT_FAVORITES`
- [x] `fromCurrency`/`toCurrency` 無效代碼 → 重置為預設值
- [x] `mode` 非法值 → 重置為 `'single'`
- [x] 所有欄位合法時 → store 狀態不變

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)