### PR TITLE
perf(ratewise): SEO 最佳化 — E-E-A-T、標題階層、logo srcset、code-split

### DIFF
--- a/.changeset/seo-eeeat-codesplit.md
+++ b/.changeset/seo-eeeat-codesplit.md
@@ -1,0 +1,12 @@
+---
+'@app/ratewise': patch
+---
+
+SEO 最佳化：E-E-A-T 信號、標題階層、logo srcset、code-split
+
+- seo-metadata.ts：新增 `buildArticleJsonLd` helper，為 FAQ/Guide/About 頁加上 Article schema（`datePublished`、`dateModified`、`author`、`publisher`）
+- FAQ.tsx / About.tsx：傳入 `jsonLd` prop 啟用 Article structured data
+- Settings.tsx：H1 直接接 H3 的標題階層問題修復，所有 section 標題由 `h3` 改為 `h2`
+- AppLayout.tsx：logo 圖片加入 `srcset`（1x / 2x / 4x），alt 文字補完品牌全名
+- About.tsx：about 頁正文以「本工具」取代重複品牌名稱，降低關鍵字密度
+- routes.tsx：`MultiConverter`、`Favorites`、`Settings` 改為 `lazyWithRetry` 動態載入，減少初始 app.js 體積

--- a/apps/ratewise/src/components/AppLayout.tsx
+++ b/apps/ratewise/src/components/AppLayout.tsx
@@ -26,7 +26,8 @@ function Logo() {
   return (
     <img
       src={`${basePath}logo.png`}
-      alt="RateWise"
+      srcSet={`${basePath}logo.png 1x, ${basePath}icons/ratewise-icon-64x64.png 2x, ${basePath}icons/ratewise-icon-128x128.png 4x`}
+      alt="RateWise 匯率好工具"
       width={28}
       height={28}
       className="w-7 h-7 shrink-0"

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -276,6 +276,42 @@ export function buildShareImageJsonLd(name: string, description: string): JsonLd
   };
 }
 
+export function buildArticleJsonLd(
+  headline: string,
+  description: string,
+  url: string,
+  datePublished: string,
+): JsonLdBlock {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline,
+    description,
+    url: buildCanonicalUrl(url),
+    datePublished,
+    dateModified: BUILD_TIME,
+    author: {
+      '@type': 'Organization',
+      name: APP_INFO.author,
+      url: APP_INFO.organizationUrl,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: APP_INFO.author,
+      url: APP_INFO.organizationUrl,
+      logo: {
+        '@type': 'ImageObject',
+        url: buildAbsoluteAssetUrl('/icons/ratewise-icon-512x512.png'),
+      },
+    },
+    inLanguage: DEFAULT_LOCALE,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': buildCanonicalUrl(url),
+    },
+  };
+}
+
 export const HOMEPAGE_FAQ = [
   {
     question: 'RateWise 和其他匯率工具有什麼不同？',
@@ -486,7 +522,13 @@ export const FAQ_PAGE_SEO = {
     { name: '常見問題', item: '/faq/' },
   ],
   faq: [...FAQ_PAGE_ENTRIES],
-} as const satisfies SEOPageMetadata;
+  jsonLd: buildArticleJsonLd(
+    '常見問題 — RateWise 匯率好工具 FAQ 解答',
+    'RateWise 匯率好工具完整 FAQ：匯率來源、現金與即期差別、買入賣出怎麼看、DCC 動態貨幣轉換、刷卡匯率計算。',
+    '/faq/',
+    `${APP_INFO.copyrightStartYear}-01-01`,
+  ),
+} satisfies SEOPageMetadata;
 
 export const GUIDE_HOW_TO_STEPS = [
   {
@@ -554,8 +596,16 @@ export const GUIDE_PAGE_SEO = {
     totalTime: 'PT2M',
     steps: [...GUIDE_HOW_TO_STEPS],
   },
-  jsonLd: [buildShareImageJsonLd('RateWise 使用指南分享圖片', 'RateWise 使用指南與換算步驟預覽')],
-} as const satisfies SEOPageMetadata;
+  jsonLd: [
+    buildShareImageJsonLd('RateWise 使用指南分享圖片', 'RateWise 使用指南與換算步驟預覽'),
+    buildArticleJsonLd(
+      '使用指南 — 如何使用 RateWise 匯率好工具換算匯率',
+      '完整 8 步驟教學，快速學會使用 RateWise 進行單幣別和多幣別匯率換算，包含匯率類型切換、歷史趨勢查看與收藏功能。',
+      '/guide/',
+      `${APP_INFO.copyrightStartYear}-01-01`,
+    ),
+  ],
+} satisfies SEOPageMetadata;
 
 export const ABOUT_PAGE_FAQ = [
   {
@@ -589,7 +639,13 @@ export const ABOUT_PAGE_SEO = {
     { name: '關於我們', item: '/about/' },
   ],
   faq: [...ABOUT_PAGE_FAQ],
-} as const satisfies SEOPageMetadata;
+  jsonLd: buildArticleJsonLd(
+    '關於 RateWise 匯率好工具 - 資料來源與技術特色',
+    `RateWise 匯率好工具是專為台灣用戶設計的即時匯率 PWA 工具，資料來源為臺灣銀行官方牌告匯率，支援 ${SUPPORTED_CURRENCY_COUNT} 種貨幣換算與離線使用。`,
+    '/about/',
+    `${APP_INFO.copyrightStartYear}-01-01`,
+  ),
+} satisfies SEOPageMetadata;
 
 export const SELL_RATE_VS_MID_RATE_PAGE = {
   title: '賣出價與中間價差在哪？為什麼換匯不能只看中間價',

--- a/apps/ratewise/src/pages/About.tsx
+++ b/apps/ratewise/src/pages/About.tsx
@@ -22,6 +22,7 @@ export default function About() {
         description={ABOUT_PAGE_SEO.description}
         pathname={ABOUT_PAGE_SEO.pathname}
         breadcrumb={ABOUT_PAGE_SEO.breadcrumb}
+        jsonLd={ABOUT_PAGE_SEO.jsonLd}
       />
 
       <div className="min-h-screen">
@@ -61,8 +62,7 @@ export default function About() {
           <section className="card mb-6 p-6">
             <h2 className="mb-4 text-2xl font-bold text-text">我們的定位</h2>
             <p className="mb-4 leading-relaxed text-text-muted">
-              RateWise
-              的重點不是展示漂亮的中間價，而是協助你在換匯前快速判讀「實際比較接近會發生的金額」。
+              本工具的重點不是展示漂亮的中間價，而是協助你在換匯前快速判讀「實際比較接近會發生的金額」。
               當你拿台幣去買外幣時，真正影響成本的通常是銀行賣出價；當你把外幣換回台幣時，則要看銀行買入價。
             </p>
             <p className="leading-relaxed text-text-muted">

--- a/apps/ratewise/src/pages/FAQ.tsx
+++ b/apps/ratewise/src/pages/FAQ.tsx
@@ -22,6 +22,7 @@ export default function FAQ() {
         pathname={FAQ_PAGE_SEO.pathname}
         breadcrumb={FAQ_PAGE_SEO.breadcrumb}
         faq={FAQ_ENTRIES}
+        jsonLd={FAQ_PAGE_SEO.jsonLd}
       />
 
       <div className="min-h-screen">

--- a/apps/ratewise/src/pages/Settings.tsx
+++ b/apps/ratewise/src/pages/Settings.tsx
@@ -68,9 +68,9 @@ export default function Settings() {
         <section className="mb-8">
           <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
             <Palette className="w-3.5 h-3.5" />
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+            <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
               {t('settings.interfaceStyle')}
-            </h3>
+            </h2>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -133,9 +133,9 @@ export default function Settings() {
         <section className="mb-6">
           <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
             <Globe className="w-3.5 h-3.5" />
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+            <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
               {t('settings.language')}
-            </h3>
+            </h2>
           </div>
 
           <div className={segmentedSwitch.containerClass}>
@@ -180,9 +180,9 @@ export default function Settings() {
         <section className="mb-6">
           <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
             <Database className="w-3.5 h-3.5" />
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+            <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
               {t('settings.storageCache')}
-            </h3>
+            </h2>
           </div>
 
           <div className="card p-5">
@@ -208,9 +208,9 @@ export default function Settings() {
         <section className="mb-6">
           <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
             <ShieldAlert className="w-3.5 h-3.5" />
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+            <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
               {t('settings.dataManagement')}
-            </h3>
+            </h2>
           </div>
 
           <div className="card overflow-hidden">
@@ -234,9 +234,9 @@ export default function Settings() {
         <section className="mb-6">
           <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
             <HelpCircle className="w-3.5 h-3.5" />
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em]">
+            <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
               {t('settings.supportInfo')}
-            </h3>
+            </h2>
           </div>
 
           <div className="card overflow-hidden divide-y divide-border">

--- a/apps/ratewise/src/routes.tsx
+++ b/apps/ratewise/src/routes.tsx
@@ -26,6 +26,7 @@
 
 import type { RouteRecord } from 'vite-react-ssg';
 import type { ComponentType } from 'react';
+import { Suspense } from 'react';
 import { ClientOnly } from 'vite-react-ssg';
 import CurrencyConverter from './features/ratewise/RateWise';
 import { SEOHelmet } from './components/SEOHelmet';
@@ -36,9 +37,11 @@ import { SkeletonLoader } from './components/SkeletonLoader';
 import { HOMEPAGE_SEO } from './config/seo-metadata';
 import { logger } from './utils/logger';
 import { isChunkLoadError, recoverFromChunkLoadError } from './utils/chunkLoadRecovery';
-import MultiConverter from './pages/MultiConverter';
-import Favorites from './pages/Favorites';
-import Settings from './pages/Settings';
+import { lazyWithRetry } from './utils/lazyWithRetry';
+
+const MultiConverter = lazyWithRetry(() => import('./pages/MultiConverter'));
+const Favorites = lazyWithRetry(() => import('./pages/Favorites'));
+const Settings = lazyWithRetry(() => import('./pages/Settings'));
 
 /** 帶重試機制的動態 import */
 async function importWithRetry<T>(
@@ -132,19 +135,31 @@ export const routes: RouteRecord[] = [
       // 多幣別轉換器
       {
         path: 'multi',
-        element: <MultiConverter />,
+        element: (
+          <Suspense fallback={<SkeletonLoader />}>
+            <MultiConverter />
+          </Suspense>
+        ),
         entry: 'src/pages/MultiConverter.tsx',
       },
       // 收藏與歷史
       {
         path: 'favorites',
-        element: <Favorites />,
+        element: (
+          <Suspense fallback={<SkeletonLoader />}>
+            <Favorites />
+          </Suspense>
+        ),
         entry: 'src/pages/Favorites.tsx',
       },
       // 應用程式設定
       {
         path: 'settings',
-        element: <Settings />,
+        element: (
+          <Suspense fallback={<SkeletonLoader />}>
+            <Settings />
+          </Suspense>
+        ),
         entry: 'src/pages/Settings.tsx',
       },
       // 主題展示頁面


### PR DESCRIPTION
## Summary

- **E-E-A-T signals**: 新增 `buildArticleJsonLd` helper，FAQ / Guide / About 頁加上 Article JSON-LD（`datePublished`、`dateModified`、`author`、`publisher`）
- **標題階層**: Settings 頁 H1 → H3 跳層問題修復，所有 section 標題改為 H2
- **Logo srcset**: AppLayout logo 加入 `srcset` 1x/2x/4x，alt 文字補完品牌全名
- **關鍵字密度**: About 頁正文以「本工具」取代重複品牌名稱，降低 ratewise 密度
- **Code-split**: `MultiConverter`、`Favorites`、`Settings` 改為 `lazyWithRetry` 動態載入，減少初始 app.js 體積（原 255.1 KB > 250 KB 閾值）

## Test plan

- [x] `pnpm --filter @app/ratewise typecheck` 通過
- [x] `pnpm -r test` 通過
- [x] `pnpm build:ratewise` 通過（pre-push build）
- [ ] 驗證 Google Rich Results Test — Article schema 顯示 author/datePublished
- [ ] 驗證 Settings 頁 axe 無 heading-order 警告
- [ ] 驗證 bundle analyzer：`MultiConverter`/`Favorites`/`Settings` 各自獨立 chunk

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)