### PR TITLE
fix(pwa): 切換 autoUpdate 救援模式，強制更新卡住的舊用戶 SW

### DIFF
--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -81,7 +81,8 @@ async function verifyAndRepairPrecache(): Promise<void> {
 // 清除舊版快取。
 cleanupOutdatedCaches();
 
-// prompt 模式：新 SW 進入 waiting 狀態，由使用者確認後才接管，防止版本撕裂導致 Load failed。
+// autoUpdate 救援模式：立即接管，讓卡住的舊用戶無需手動確認即可拿到修復版。
+void self.skipWaiting();
 clientsClaim();
 
 // 訊息處理：SKIP_WAITING（prompt 更新流程）/ FORCE_HARD_RESET（緊急清除快取）。

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -273,9 +273,9 @@ export default defineConfig(({ mode }) => {
         strategies: 'injectManifest',
         srcDir: 'src',
         filename: 'sw.ts',
-        // prompt：新 SW 等待使用者確認後才接管，避免 skipWaiting 版本撕裂導致 "Load failed"
-        // UpdatePrompt 元件的 needRefresh 回調在此模式下正確觸發
-        registerType: 'prompt',
+        // autoUpdate（救援模式）：強制新 SW 立即 skipWaiting，讓卡住的舊用戶自動拿到修復版。
+        // 待確認舊用戶全數更新後，回復 'prompt' 避免版本撕裂。
+        registerType: 'autoUpdate',
         injectRegister: 'inline',
 
         injectManifest: {


### PR DESCRIPTION
- vite.config: registerType prompt → autoUpdate（救援模式）
- sw.ts: 新增 skipWaiting()，讓新 SW 立即接管，無需用戶確認
- 目的：卡在骨架屏的舊用戶瀏覽器中，waiting SW 因 prompt 模式無法自動啟動
- 本次部署後舊用戶 SW 將自動更新；確認全數更新後回復 prompt 模式

測試：無需額外測試，行為等同 v2.8.3 的 autoUpdate + skipWaiting 組合