### PR TITLE
feat(ci): 新增排程延遲監測腳本

### DIFF
--- a/.changeset/monitor-schedule-drift.md
+++ b/.changeset/monitor-schedule-drift.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+新增 GitHub Actions 排程延遲監測腳本，可自動比較 cron 理論時間與實際 workflow `createdAt`，統計 drift 與缺漏的 scheduled slots，方便持續追蹤高頻匯率 workflow 的穩定度。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,52 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-03-31T23:47:00+08:00
-> **當前總分**: 1198（初始分: 100）
+> **最後更新**: 2026-04-01T01:07:00+08:00
+> **當前總分**: 1199（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: github-actions-schedule-drift-monitor-001
+date: 2026-04-01
+title: 新增 GitHub Actions 排程延遲監測腳本，量化 cron 理論時間與實際 createdAt 漂移
+score: +1
+type: feat
+content_type: automation
+scope: monorepo
+topics: [github-actions, ci, schedule, observability, tdd]
+keywords: [schedule drift, createdAt, cron, gh run list, missed slots, monitor script]
+aliases: [排程延遲監測, GitHub Actions cron 漂移統計]
+related_entries: [splitmeow-tdd-and-actions-schedule-reliability, rates-workflow-summary-cleanup-001]
+summary: 針對 GitHub Actions `schedule` 只提供 best-effort 觸發、無法保證每 5 分鐘準點的現況，新增 repo 內監測腳本，自動掃描有 `schedule` 的 workflow、比對 cron 理論時間與實際 `createdAt`，並統計 drift 秒數與缺漏的 scheduled slots，讓後續 CI/維運判讀不再只看 YAML。
+root_cause:
+
+- 既有 repo 只有 workflow YAML 與人工 `gh run list` 觀察，無法系統化量化「理論應觸發時間」與「實際 run 建立時間」之間的落差
+- GitHub 官方明示 `schedule` 可能延遲甚至掉單，若沒有自動化統計，維運只能憑零散 log 猜測平台行為
+  impact:
+
+- 無法快速判斷特定 workflow 是 cron 配置錯誤、平台延遲，還是有中間 scheduled slots 被跳過
+- reviewer 與維運人員難以用一致格式比較 latest / moneybox 等高頻 workflow 的穩定度
+  actions:
+
+- 新增 `scripts/monitor-schedule-drift.mjs`，自動掃描 `.github/workflows/*.yml` 中的 scheduled workflows
+- 以 TDD 先新增 `scripts/__tests__/monitor-schedule-drift.test.ts`，鎖定 workflow 探測、理論排程時間對位、missed slots 統計
+- 在 root `package.json` 加入 `monitor:schedule-drift` script，方便本地與 CI 直接執行
+  prevention:
+
+- 未來若調整 cron minute lists 或想把監測接進 CI，只需重用同一支腳本與 `--fail-drift-seconds` / `--fail-missed-slots` 門檻，不應再手動比對 run list
+- 對高頻 GitHub Actions workflow，必須同時觀察 `cron` 與 `createdAt`，不能把 YAML 上的 `*/5` 或 minute list 當成實際 SLA
+  verification:
+
+- `pnpm exec vitest run scripts/__tests__/monitor-schedule-drift.test.ts`
+- `pnpm exec node scripts/monitor-schedule-drift.mjs --workflow "Update Latest Exchange Rates" --workflow "Update MoneyBox Exchange Rates" --limit 12`
+- `pnpm run monitor:schedule-drift -- --workflow "Update Latest Exchange Rates" --workflow "Update MoneyBox Exchange Rates" --limit 12`
+  references:
+
+- scripts/monitor-schedule-drift.mjs
+- scripts/**tests**/monitor-schedule-drift.test.ts
+- package.json
+- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onschedule
+- https://docs.github.com/en/actions/how-tos/troubleshoot-workflows
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:a11y": "pnpm --filter @app/ratewise exec playwright test tests/e2e/accessibility.spec.ts --project=chromium-desktop",
     "seo:test": "pnpm lighthouse && pnpm test:a11y",
     "monitor:history": "node scripts/check-history-manifest.mjs",
+    "monitor:schedule-drift": "node scripts/monitor-schedule-drift.mjs",
     "verify:history": "node scripts/verify-history-data.mjs",
     "verify:precache": "node scripts/verify-precache-assets.mjs",
     "verify:sitemap": "node scripts/verify-sitemap-ssg.mjs",

--- a/scripts/__tests__/monitor-schedule-drift.test.ts
+++ b/scripts/__tests__/monitor-schedule-drift.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeScheduledRuns,
+  discoverScheduledWorkflowsFromSources,
+  findLatestScheduledTime,
+} from '../monitor-schedule-drift.mjs';
+
+describe('monitor-schedule-drift', () => {
+  it('會從 workflow YAML 自動找出有 schedule 的 workflow 與 cron 設定', () => {
+    const workflows = discoverScheduledWorkflowsFromSources([
+      {
+        filePath: '.github/workflows/update-latest-rates.yml',
+        source: `name: Update Latest Exchange Rates\non:\n  schedule:\n    - cron: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *'\n  workflow_dispatch:\n`,
+      },
+      {
+        filePath: '.github/workflows/ci.yml',
+        source: `name: CI\non:\n  push:\n    branches: [main]\n`,
+      },
+    ]);
+
+    expect(workflows).toEqual([
+      {
+        filePath: '.github/workflows/update-latest-rates.yml',
+        name: 'Update Latest Exchange Rates',
+        schedules: ['2,7,12,17,22,27,32,37,42,47,52,57 * * * *'],
+      },
+    ]);
+  });
+
+  it('會把 delayed schedule run 對應回最近一個理論 cron 時間', () => {
+    const expectedAt = findLatestScheduledTime(
+      '4,9,14,19,24,29,34,39,44,49,54,59 * * * *',
+      '2026-03-31T16:42:15Z',
+    );
+
+    expect(expectedAt?.toISOString()).toBe('2026-03-31T16:39:00.000Z');
+  });
+
+  it('會統計 schedule run 的 drift 秒數與中間缺漏的排程次數', () => {
+    const analysis = analyzeScheduledRuns({
+      workflowName: 'Update Latest Exchange Rates',
+      schedules: ['2,7,12,17,22,27,32,37,42,47,52,57 * * * *'],
+      runs: [
+        {
+          databaseId: 23808806333,
+          createdAt: '2026-03-31T16:42:36Z',
+          event: 'schedule',
+          status: 'completed',
+          conclusion: 'success',
+          headBranch: 'main',
+        },
+        {
+          databaseId: 23804882144,
+          createdAt: '2026-03-31T15:14:44Z',
+          event: 'schedule',
+          status: 'completed',
+          conclusion: 'success',
+          headBranch: 'main',
+        },
+      ],
+    });
+
+    expect(analysis.entries).toHaveLength(2);
+    expect(analysis.entries[0]).toMatchObject({
+      expectedAt: '2026-03-31T16:42:00.000Z',
+      driftSeconds: 36,
+      missedSlotsSincePrevious: 17,
+    });
+    expect(analysis.entries[1]).toMatchObject({
+      expectedAt: '2026-03-31T15:12:00.000Z',
+      driftSeconds: 164,
+      missedSlotsSincePrevious: null,
+    });
+    expect(analysis.summary).toMatchObject({
+      sampleCount: 2,
+      maxDriftSeconds: 164,
+      averageDriftSeconds: 100,
+      totalMissedSlots: 17,
+    });
+  });
+});

--- a/scripts/monitor-schedule-drift.mjs
+++ b/scripts/monitor-schedule-drift.mjs
@@ -1,0 +1,462 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* global console, process */
+
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_LOOKBACK_MINUTES = 31 * 24 * 60;
+const DEFAULT_RUN_LIMIT = 20;
+
+const MONTH_NAMES = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+};
+
+const WEEKDAY_NAMES = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function normalizeCronFieldToken(token, names) {
+  const normalized = token.trim().toLowerCase();
+  if (normalized.length === 0) {
+    throw new Error('Cron 欄位包含空白 token');
+  }
+
+  if (!names) {
+    return normalized;
+  }
+
+  return normalized.replace(/[a-z]{3}/g, (match) => {
+    const mapped = names[match];
+    if (mapped == null) {
+      throw new Error(`不支援的 cron 名稱：${match}`);
+    }
+    return String(mapped);
+  });
+}
+
+function expandFieldRange(base, min, max) {
+  if (base === '*') {
+    return { start: min, end: max };
+  }
+
+  if (base.includes('-')) {
+    const [startValue, endValue] = base.split('-').map((value) => Number.parseInt(value, 10));
+    return { start: startValue, end: endValue };
+  }
+
+  const exact = Number.parseInt(base, 10);
+  return { start: exact, end: exact };
+}
+
+function parseCronField(field, min, max, names) {
+  const values = new Set();
+
+  for (const rawToken of field.split(',')) {
+    const token = normalizeCronFieldToken(rawToken, names);
+    const [base, stepValue] = token.split('/');
+    const step = stepValue ? Number.parseInt(stepValue, 10) : 1;
+
+    if (!Number.isFinite(step) || step <= 0) {
+      throw new Error(`無效的 cron step：${token}`);
+    }
+
+    const { start, end } = expandFieldRange(base, min, max);
+    if (
+      !Number.isFinite(start) ||
+      !Number.isFinite(end) ||
+      start < min ||
+      end > max ||
+      start > end
+    ) {
+      throw new Error(`無效的 cron 範圍：${token}`);
+    }
+
+    for (let current = start; current <= end; current += step) {
+      values.add(current);
+    }
+  }
+
+  return values;
+}
+
+function parseCronExpression(cronExpression) {
+  const parts = cronExpression.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error(`只支援 5 欄位 cron：${cronExpression}`);
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+
+  return {
+    minute: parseCronField(minute, 0, 59),
+    hour: parseCronField(hour, 0, 23),
+    dayOfMonth: parseCronField(dayOfMonth, 1, 31),
+    month: parseCronField(month, 1, 12, MONTH_NAMES),
+    dayOfWeek: parseCronField(dayOfWeek, 0, 7, WEEKDAY_NAMES),
+  };
+}
+
+function normalizeDayOfWeek(day) {
+  return day === 7 ? 0 : day;
+}
+
+function matchesParsedCron(date, parsedCron) {
+  const weekday = normalizeDayOfWeek(date.getUTCDay());
+  const allowedWeekdays = new Set(Array.from(parsedCron.dayOfWeek, normalizeDayOfWeek));
+
+  return (
+    parsedCron.minute.has(date.getUTCMinutes()) &&
+    parsedCron.hour.has(date.getUTCHours()) &&
+    parsedCron.dayOfMonth.has(date.getUTCDate()) &&
+    parsedCron.month.has(date.getUTCMonth() + 1) &&
+    allowedWeekdays.has(weekday)
+  );
+}
+
+function floorToMinute(dateLike) {
+  const date = new Date(dateLike);
+  date.setUTCSeconds(0, 0);
+  return date;
+}
+
+function shiftMinutes(date, deltaMinutes) {
+  return new Date(date.getTime() + deltaMinutes * 60_000);
+}
+
+function findLatestScheduledTimeForSchedules(schedules, createdAt, options = {}) {
+  const lookbackMinutes = options.lookbackMinutes ?? DEFAULT_LOOKBACK_MINUTES;
+  const createdDate = new Date(createdAt);
+  const parsedSchedules = schedules.map((cron) => ({ cron, parsed: parseCronExpression(cron) }));
+
+  for (let offset = 0; offset <= lookbackMinutes; offset += 1) {
+    const candidate = shiftMinutes(floorToMinute(createdDate), -offset);
+    const matched = parsedSchedules.find(({ parsed }) => matchesParsedCron(candidate, parsed));
+    if (matched) {
+      return {
+        expectedAt: candidate.toISOString(),
+        matchedSchedule: matched.cron,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function findLatestScheduledTime(cronExpression, createdAt, options = {}) {
+  const scheduled = findLatestScheduledTimeForSchedules([cronExpression], createdAt, options);
+  return scheduled ? new Date(scheduled.expectedAt) : null;
+}
+
+function countMatchedSlotsBetweenSchedules(schedules, startInclusive, endExclusive) {
+  const parsedSchedules = schedules.map((cron) => parseCronExpression(cron));
+  let count = 0;
+  let cursor = shiftMinutes(new Date(startInclusive), 1);
+  const end = new Date(endExclusive);
+
+  while (cursor < end) {
+    if (parsedSchedules.some((parsed) => matchesParsedCron(cursor, parsed))) {
+      count += 1;
+    }
+    cursor = shiftMinutes(cursor, 1);
+  }
+
+  return count;
+}
+
+function computeAverage(values) {
+  if (values.length === 0) return 0;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+export function analyzeScheduledRuns({ workflowName, schedules, runs, defaultBranch = 'main' }) {
+  const scheduleRuns = runs
+    .filter(
+      (run) => run.event === 'schedule' && (!run.headBranch || run.headBranch === defaultBranch),
+    )
+    .sort(
+      (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+    );
+
+  const entries = [];
+  let previousExpectedAt = null;
+
+  for (const run of scheduleRuns) {
+    const scheduled = findLatestScheduledTimeForSchedules(schedules, run.createdAt);
+    if (!scheduled) {
+      continue;
+    }
+
+    const driftSeconds = Math.round(
+      (new Date(run.createdAt).getTime() - new Date(scheduled.expectedAt).getTime()) / 1000,
+    );
+
+    const missedSlotsSincePrevious = previousExpectedAt
+      ? countMatchedSlotsBetweenSchedules(schedules, previousExpectedAt, scheduled.expectedAt)
+      : null;
+
+    entries.push({
+      workflowName,
+      databaseId: run.databaseId,
+      createdAt: run.createdAt,
+      expectedAt: scheduled.expectedAt,
+      matchedSchedule: scheduled.matchedSchedule,
+      driftSeconds,
+      missedSlotsSincePrevious,
+      conclusion: run.conclusion,
+      status: run.status,
+    });
+
+    previousExpectedAt = scheduled.expectedAt;
+  }
+
+  entries.reverse();
+
+  const drifts = entries.map((entry) => entry.driftSeconds);
+  const missedSlots = entries
+    .map((entry) => entry.missedSlotsSincePrevious)
+    .filter((value) => typeof value === 'number');
+
+  return {
+    workflowName,
+    schedules,
+    entries,
+    summary: {
+      sampleCount: entries.length,
+      maxDriftSeconds: drifts.length > 0 ? Math.max(...drifts) : 0,
+      averageDriftSeconds: computeAverage(drifts),
+      totalMissedSlots: missedSlots.reduce((sum, value) => sum + value, 0),
+    },
+  };
+}
+
+export function discoverScheduledWorkflowsFromSources(sources) {
+  return sources
+    .map(({ filePath, source }) => {
+      const nameMatch = source.match(/^name:\s*(.+)$/m);
+      if (!nameMatch || !/^\s*schedule:\s*$/m.test(source)) {
+        return null;
+      }
+
+      const schedules = Array.from(
+        source.matchAll(/^\s*-\s*cron:\s*['"]([^'"]+)['"]\s*$/gm),
+        (match) => match[1],
+      );
+
+      if (schedules.length === 0) {
+        return null;
+      }
+
+      return {
+        filePath,
+        name: nameMatch[1].trim(),
+        schedules,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function discoverScheduledWorkflows(workflowDirectory) {
+  const files = readdirSync(workflowDirectory)
+    .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+    .map((file) => {
+      const filePath = path.join(workflowDirectory, file);
+      return {
+        filePath,
+        source: readFileSync(filePath, 'utf-8'),
+      };
+    });
+
+  return discoverScheduledWorkflowsFromSources(files);
+}
+
+function renderReportLine(workflow) {
+  const latestEntry = workflow.entries[0];
+  const latestDrift = latestEntry ? `${latestEntry.driftSeconds}s` : 'n/a';
+  const totalMissed = workflow.summary.totalMissedSlots;
+  const lastExpected = latestEntry?.expectedAt ?? 'n/a';
+  const lastCreated = latestEntry?.createdAt ?? 'n/a';
+  return [
+    workflow.workflowName.padEnd(34),
+    String(workflow.summary.sampleCount).padStart(3),
+    String(workflow.summary.averageDriftSeconds).padStart(5),
+    String(workflow.summary.maxDriftSeconds).padStart(5),
+    String(totalMissed).padStart(5),
+    latestDrift.padStart(8),
+    lastExpected,
+    lastCreated,
+  ].join('  ');
+}
+
+function printReport(report) {
+  console.log('\n🕒 GitHub Actions 排程延遲監測');
+  console.log('─'.repeat(144));
+  console.log(
+    'Workflow'.padEnd(34) +
+      '  n  avg_s  max_s  miss  latest  expectedAt'.padEnd(42) +
+      '  createdAt',
+  );
+  console.log('─'.repeat(144));
+
+  for (const workflow of report.workflows) {
+    console.log(renderReportLine(workflow));
+  }
+
+  console.log('─'.repeat(144));
+  console.log(
+    `分析 ${report.workflows.length} 個 scheduled workflows，總樣本 ${report.totalSamples} 筆。`,
+  );
+}
+
+function writeStepSummary(report) {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryFile) return;
+
+  const lines = [
+    '## GitHub Actions Schedule Drift Monitor',
+    '',
+    '| Workflow | Samples | Avg Drift (s) | Max Drift (s) | Missed Slots | Latest Drift | Expected At | Created At |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |',
+    ...report.workflows.map((workflow) => {
+      const latestEntry = workflow.entries[0];
+      return `| ${workflow.workflowName} | ${workflow.summary.sampleCount} | ${workflow.summary.averageDriftSeconds} | ${workflow.summary.maxDriftSeconds} | ${workflow.summary.totalMissedSlots} | ${latestEntry?.driftSeconds ?? 'n/a'} | ${latestEntry?.expectedAt ?? 'n/a'} | ${latestEntry?.createdAt ?? 'n/a'} |`;
+    }),
+    '',
+  ];
+
+  appendFileSync(summaryFile, `${lines.join('\n')}\n`);
+}
+
+function parseCliArgs(argv) {
+  const options = {
+    workflowNames: [],
+    limit: DEFAULT_RUN_LIMIT,
+    defaultBranch: 'main',
+    workflowDirectory: path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../.github/workflows',
+    ),
+    failDriftSeconds: null,
+    failMissedSlots: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--workflow') {
+      options.workflowNames.push(argv[index + 1]);
+      index += 1;
+    } else if (arg === '--limit') {
+      options.limit = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+    } else if (arg === '--default-branch') {
+      options.defaultBranch = argv[index + 1];
+      index += 1;
+    } else if (arg === '--fail-drift-seconds') {
+      options.failDriftSeconds = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+    } else if (arg === '--fail-missed-slots') {
+      options.failMissedSlots = Number.parseInt(argv[index + 1], 10);
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function ghRunList(workflowName, limit) {
+  const output = execFileSync(
+    'gh',
+    [
+      'run',
+      'list',
+      '--workflow',
+      workflowName,
+      '--limit',
+      String(limit),
+      '--json',
+      'databaseId,event,status,conclusion,createdAt,displayTitle,headBranch',
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  return JSON.parse(output);
+}
+
+export async function runScheduleDriftMonitor(options = {}) {
+  const workflows = discoverScheduledWorkflows(options.workflowDirectory).filter((workflow) =>
+    options.workflowNames?.length ? options.workflowNames.includes(workflow.name) : true,
+  );
+
+  const analyses = workflows.map((workflow) =>
+    analyzeScheduledRuns({
+      workflowName: workflow.name,
+      schedules: workflow.schedules,
+      runs: ghRunList(workflow.name, options.limit ?? DEFAULT_RUN_LIMIT),
+      defaultBranch: options.defaultBranch ?? 'main',
+    }),
+  );
+
+  return {
+    workflows: analyses,
+    totalSamples: analyses.reduce((sum, workflow) => sum + workflow.summary.sampleCount, 0),
+  };
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const report = await runScheduleDriftMonitor(options);
+  printReport(report);
+  writeStepSummary(report);
+
+  const shouldFail = report.workflows.some((workflow) => {
+    if (
+      Number.isFinite(options.failDriftSeconds) &&
+      workflow.summary.maxDriftSeconds > options.failDriftSeconds
+    ) {
+      return true;
+    }
+
+    if (
+      Number.isFinite(options.failMissedSlots) &&
+      workflow.summary.totalMissedSlots > options.failMissedSlots
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+
+  if (shouldFail) {
+    process.exit(1);
+  }
+}
+
+const isDirectExecution =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error('❌ 排程延遲監測失敗');
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 摘要
- 新增 `scripts/monitor-schedule-drift.mjs`，自動掃描 repo 內 scheduled workflows，統計 cron 理論時間與實際 `createdAt` 漂移
- 補上 TDD 測試與 `pnpm run monitor:schedule-drift` 入口，讓維運與 CI 可以直接重用
- 新增 changeset 與 `docs/dev/002...` 條目，對齊 repo SOP

## 測試
- `pnpm exec vitest run scripts/__tests__/monitor-schedule-drift.test.ts`
- `pnpm run monitor:schedule-drift -- --workflow "Update Latest Exchange Rates" --limit 12`
- `pnpm run monitor:schedule-drift -- --workflow "Update MoneyBox Exchange Rates" --limit 12`
- `git push -u origin feat/schedule-drift-monitor`（含 pre-push：`typecheck` / `test` / `build:ratewise`）
