### PR TITLE
fix(split-meow): 修正歷史摘要人數計算使用行程實際參與者

### DIFF
--- a/apps/split-meow/src/components/HistoryTab.tsx
+++ b/apps/split-meow/src/components/HistoryTab.tsx
@@ -278,23 +278,29 @@ export function HistoryTab() {
           </div>
           <div className="mt-6 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              <div className="flex -space-x-2">
-                {members
-                  .filter((m) => m.isActive)
-                  .slice(0, 3)
-                  .map((m) => (
-                    <MemberAvatar
-                      key={m.id}
-                      seed={m.avatarUrl}
-                      alt={m.name}
-                      size={32}
-                      className="border-2 border-surface-container-lowest"
-                    />
-                  ))}
-              </div>
-              <span className="text-xs text-on-surface-variant">
-                {t('history.members_count', { count: members.filter((m) => m.isActive).length })}
-              </span>
+              {(() => {
+                // 計算行程中實際有參與消費的成員（而非當前活躍成員）
+                const participantIdsSet = new Set(tripExpenses.flatMap((e) => e.participantIds));
+                const tripParticipants = members.filter((m) => participantIdsSet.has(m.id));
+                return (
+                  <>
+                    <div className="flex -space-x-2">
+                      {tripParticipants.slice(0, 3).map((m) => (
+                        <MemberAvatar
+                          key={m.id}
+                          seed={m.avatarUrl}
+                          alt={m.name}
+                          size={32}
+                          className="border-2 border-surface-container-lowest"
+                        />
+                      ))}
+                    </div>
+                    <span className="text-xs text-on-surface-variant">
+                      {t('history.members_count', { count: tripParticipants.length })}
+                    </span>
+                  </>
+                );
+              })()}
             </div>
             {tripExpenses.length > 0 && (
               <button


### PR DESCRIPTION
## Summary

- 修正 `HistoryTab.tsx` 摘要區塊的成員人數計算邏輯
- 改為計算行程中實際有參與消費的成員數，而非使用 `isActive` 屬性
- 確保成員停用後，歷史紀錄仍顯示正確的參與人數

## Problem

原本的程式碼使用 `members.filter((m) => m.isActive).length` 計算成員人數，這會導致：
- 顯示的是「當前活躍成員數」而非「行程實際參與者數」
- 當成員被停用後，歷史紀錄的人數會不正確

## Solution

改為從 `tripExpenses` 中提取所有 `participantIds`，計算實際參與過消費的成員數量：

```typescript
const participantIdsSet = new Set(
  tripExpenses.flatMap((e) => e.participantIds),
);
const tripParticipants = members.filter((m) => participantIdsSet.has(m.id));
```

## Test Plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm test --filter @app/split-meow` 通過 154 項測試
- [ ] CI 全綠

## Related

Closes codex comment on PR #218

Made with [Cursor](https://cursor.com)