### PR TITLE
refactor(security-headers): 精簡 Worker 註解為簡短正式格式

### DIFF
--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -3,28 +3,24 @@
 /**
  * 安全標頭 Worker v4.8
  *
- * 本 Worker 僅處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
- * 固定站點級政策（例如 HSTS）由 Cloudflare Edge 管理；
- * Worker 專注於路由分層 CSP、CSP report、分享圖 CORS 與 ratewise 跨域隔離。
+ * 處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
+ * 固定站點級政策由 Cloudflare Edge 管理，Worker 專注於路由分層 CSP、
+ * CSP report、分享圖 CORS 與 ratewise 跨域隔離。
  *
  * 變更記錄：
- * - v4.8: 新增 AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 鏡像的 AI 爬蟲存取頻率，輸出至 console.log
- * - v4.7: 新增 Server-Timing 診斷標頭（P1-8）：記錄 fetch/rewrite 耗時，供 AI 爬蟲與開發者偵錯
- * - v4.6: 新增 STABLE_PUBLIC_ASSET_PATHS：logo.png 等非雜湊穩定靜態資源設 7 天 public 快取，改善 LCP 重複載入
- * - v4.5: 移除 Rocket Loader 繞過措施（data-cfasync="false"）；已在 Cloudflare Dashboard 關閉 Rocket Loader
- * - v4.4: 修正 Rocket Loader 干擾 vite-react-ssg 骨架屏卡死問題
- *         → InlineScriptNonceInjector 注入 data-cfasync="false"，防止 Rocket Loader 修改 type 屬性
- * - v4.3: 修正上游 .webmanifest 雙重 Content-Type（application/octet-stream, application/manifest+json）
- *         → 強制設為 application/manifest+json，避免 Safari 觸發下載而非解析 PWA manifest
- * - v4.2: 缺檔靜態資產改回 no-store，避免 Cloudflare 邊緣保留 stale 404 造成 SW precache 安裝失敗
- * - v4.1: 統一所有 HTML profile 的 Cache-Control（no-cache, must-revalidate）；
- *         移除上游 Expires 雜訊；OG 圖片 Cache-Control 正規化，消除 Zeabur 上游重複 token
- * - v4.0: app.haotool.org/* 納入統一保護；RateWise 改為 nonce 型 CSP + 串流 HTMLRewriter；
- *         CSP report 端點加入 method/content-type 防護；分享圖白名單改為 SSOT 檔名
- * - v3.9: 修復 PWA 冷啟動失效：COEP/COOP 移至 isHTML 分支，非 HTML 的 ratewise 靜態資源僅保留 CORP
- * - v3.8: 效能最佳化：ratewise HTML 移除 no-store 啟用 BFCache；Vite 靜態資源設 max-age=31536000, immutable
- * - v3.7: CSP-Report-Only 新增 goog#html TrustedType，修復 Google Analytics 違規 console 噪音
- * - v3.6: 改用 HTMLRewriter 解析 inline script，避免以 regex 掃描 HTML 觸發 CodeQL `js/bad-tag-filter`
+ * - v4.8: 新增 AI 爬蟲存取記錄，追蹤 llms.txt 與 Markdown 鏡像存取頻率
+ * - v4.7: 新增 Server-Timing 診斷標頭，記錄 fetch 與 rewrite 耗時
+ * - v4.6: 新增穩定公開資產快取，logo.png 等設 7 天 public 快取
+ * - v4.5: 移除 Rocket Loader 繞過措施，已於 Dashboard 關閉
+ * - v4.4: 修正 Rocket Loader 干擾骨架屏問題
+ * - v4.3: 修正 webmanifest 雙重 Content-Type 問題
+ * - v4.2: 缺檔靜態資產改回 no-store，避免 stale 404
+ * - v4.1: 統一 HTML Cache-Control，移除上游 Expires
+ * - v4.0: 全站納入保護，改為 nonce 型 CSP
+ * - v3.9: 修復 PWA 冷啟動失效，COEP/COOP 移至 HTML 分支
+ * - v3.8: 效能最佳化，啟用 BFCache，靜態資源設 immutable
+ * - v3.7: CSP-Report-Only 新增 goog#html TrustedType
+ * - v3.6: 改用 HTMLRewriter 解析 inline script
  */
 
 const SECURITY_POLICY_VERSION = '4.8';
@@ -66,13 +62,10 @@ const PUBLIC_SHARE_ASSET_PATHS = new Set([
 	'/quake-school/og-image.svg',
 ]);
 
-/** 穩定公開資產（無 hash，但極少變動），設 7 天快取供瀏覽器複用。 */
+/** 穩定公開資產路徑，設 7 天快取。 */
 const STABLE_PUBLIC_ASSET_PATHS = new Set(['/ratewise/logo.png']);
 
-/**
- * AI 爬蟲 User-Agent 關鍵字清單（P2-11）。
- * 與 robots.txt 允許清單一致，用於追蹤 AI 搜尋引擎的站點存取頻率。
- */
+/** AI 爬蟲 User-Agent 關鍵字，與 robots.txt 允許清單一致。 */
 const AI_CRAWLER_PATTERNS = [
 	'GPTBot',
 	'ClaudeBot',
@@ -94,7 +87,7 @@ const AI_CRAWLER_PATTERNS = [
 	'YouBot',
 ];
 
-/** LLM 可讀文件路徑（llms.txt / Markdown 鏡像）。 */
+/** LLM 可讀文件路徑。 */
 const LLM_DOC_PATHS = new Set([
 	'/ratewise/llms.txt',
 	'/ratewise/llms-full.txt',
@@ -103,7 +96,7 @@ const LLM_DOC_PATHS = new Set([
 	'/quake-school/llms.txt',
 ]);
 
-/** 檢測 User-Agent 是否為已知 AI 爬蟲。 */
+/** 檢測是否為已知 AI 爬蟲。 */
 function detectAiCrawler(userAgent) {
 	if (!userAgent) return null;
 	for (const pattern of AI_CRAWLER_PATTERNS) {
@@ -114,7 +107,7 @@ function detectAiCrawler(userAgent) {
 	return null;
 }
 
-/** 檢測路徑是否為 LLM 文件或 Markdown 鏡像。 */
+/** 檢測是否為 LLM 文件或 Markdown 鏡像。 */
 function isLlmDocPath(pathname) {
 	return LLM_DOC_PATHS.has(pathname) || pathname.endsWith('.md');
 }
@@ -129,7 +122,6 @@ function createHtmlProfile({
 	permissionsPolicy = DEFAULT_PERMISSIONS_POLICY,
 	enableCrossOriginIsolation = false,
 	enableRatewiseReporting = false,
-	// no-cache 允許 BFCache 存入；must-revalidate 確保 SW 更新後使用者取得最新 HTML。
 	htmlCacheControl = 'no-cache, must-revalidate',
 }) {
 	return {
@@ -215,7 +207,6 @@ function normalizeHtmlPath(pathname) {
 	if (pathname === '' || pathname === '/') {
 		return '/';
 	}
-
 	return pathname.endsWith('/') ? pathname : `${pathname}/`;
 }
 
@@ -223,27 +214,21 @@ function resolveHtmlProfile(url) {
 	if (url.pathname.startsWith('/ratewise/')) {
 		return RATEWISE_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/nihonname/')) {
 		return NIHONNAME_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/park-keeper/')) {
 		return PARK_KEEPER_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/quake-school/')) {
 		return QUAKE_SCHOOL_HTML_PROFILE;
 	}
-
 	if (ROOT_SITE_HOSTS.has(url.host)) {
 		return HAOTOOL_HTML_PROFILE;
 	}
-
 	if (url.host === APP_HOST && HAOTOOL_ROOT_HTML_PATHS.has(normalizeHtmlPath(url.pathname))) {
 		return HAOTOOL_HTML_PROFILE;
 	}
-
 	return FALLBACK_HTML_PROFILE;
 }
 
@@ -315,9 +300,7 @@ function isStaticAssetPath(pathname) {
 }
 
 function applyHtmlSecurityHeaders(response, url, profile, nonce) {
-	// Expires 由上游產生，與 Cache-Control 語義重疊，依 RFC 7234 §5.3 應以 Cache-Control 為準。
 	response.headers.delete('Expires');
-
 	response.headers.set('Content-Security-Policy', buildContentSecurityPolicy(profile, nonce));
 	response.headers.set('Permissions-Policy', profile.permissionsPolicy);
 	response.headers.set('Cache-Control', profile.htmlCacheControl);
@@ -345,16 +328,13 @@ function normalizeCspReports(payload) {
 				if (entry && typeof entry === 'object' && entry.type === 'csp-violation') {
 					return entry.body ?? null;
 				}
-
 				return entry;
 			})
 			.filter(Boolean);
 	}
-
 	if (payload && typeof payload === 'object' && payload['csp-report']) {
 		return [payload['csp-report']];
 	}
-
 	return payload ? [payload] : [];
 }
 
@@ -370,17 +350,12 @@ function sanitizeCspReport(report) {
 }
 
 async function handleCspReport(request) {
-	const baseHeaders = {
-		'Cache-Control': 'no-store',
-	};
+	const baseHeaders = { 'Cache-Control': 'no-store' };
 
 	if (request.method !== 'POST') {
 		return new Response('Method Not Allowed', {
 			status: 405,
-			headers: {
-				...baseHeaders,
-				Allow: 'POST',
-			},
+			headers: { ...baseHeaders, Allow: 'POST' },
 		});
 	}
 
@@ -388,26 +363,17 @@ async function handleCspReport(request) {
 	const supportedContentTypes = ['application/csp-report', 'application/reports+json', 'application/json'];
 
 	if (contentType !== '' && !supportedContentTypes.some((type) => contentType.includes(type))) {
-		return new Response('Unsupported Media Type', {
-			status: 415,
-			headers: baseHeaders,
-		});
+		return new Response('Unsupported Media Type', { status: 415, headers: baseHeaders });
 	}
 
 	const contentLength = Number(request.headers.get('content-length') || '0');
 	if (Number.isFinite(contentLength) && contentLength > CSP_REPORT_MAX_BYTES) {
-		return new Response('Payload Too Large', {
-			status: 413,
-			headers: baseHeaders,
-		});
+		return new Response('Payload Too Large', { status: 413, headers: baseHeaders });
 	}
 
 	const bodyText = await request.text();
 	if (bodyText.length > CSP_REPORT_MAX_BYTES) {
-		return new Response('Payload Too Large', {
-			status: 413,
-			headers: baseHeaders,
-		});
+		return new Response('Payload Too Large', { status: 413, headers: baseHeaders });
 	}
 
 	if (bodyText !== '') {
@@ -423,10 +389,7 @@ async function handleCspReport(request) {
 		}
 	}
 
-	return new Response(null, {
-		status: 204,
-		headers: baseHeaders,
-	});
+	return new Response(null, { status: 204, headers: baseHeaders });
 }
 
 function stripOriginLeakHeaders(response) {
@@ -436,8 +399,7 @@ function stripOriginLeakHeaders(response) {
 }
 
 /**
- * 構建 Server-Timing 標頭值，用於診斷 Worker 處理耗時。
- * 格式遵循 RFC 8941（Structured Field Values），供 AI 爬蟲與開發者工具讀取。
+ * 構建 Server-Timing 標頭，格式遵循 RFC 8941。
  * @param {Object} timings - 各階段耗時（毫秒）
  * @returns {string} Server-Timing 標頭值
  */
@@ -517,14 +479,12 @@ export default {
 			if (isImmutableHashedAsset(url.pathname)) {
 				response.headers.set('Cache-Control', 'max-age=31536000, public, immutable');
 			} else if (url.pathname.endsWith('.webmanifest')) {
-				// 修正上游雙重 Content-Type，確保瀏覽器正確解析為 PWA manifest 而非觸發下載。
 				response.headers.set('Content-Type', 'application/manifest+json');
 			}
 		}
 
 		response.headers.set('X-Security-Policy-Version', SECURITY_POLICY_VERSION);
 
-		// Server-Timing：診斷各階段耗時，供 AI 爬蟲與開發者工具讀取。
 		const timings = {
 			fetch: fetchDuration,
 			rewrite: rewriteDuration,
@@ -533,32 +493,26 @@ export default {
 		response.headers.set('Server-Timing', buildServerTiming(timings));
 
 		if (isPublicShareAsset) {
-			// 社群平台爬取需跨域存取，COEP/COOP 降為 unsafe-none 並開放 CORS。
 			response.headers.set('Cache-Control', 'max-age=86400, public');
 			response.headers.set('Access-Control-Allow-Origin', '*');
 			response.headers.set('Cross-Origin-Embedder-Policy', 'unsafe-none');
 			response.headers.set('Cross-Origin-Opener-Policy', 'unsafe-none');
 			response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
 		} else if (isStablePublicAsset) {
-			// 穩定公開資產（無 hash）設 7 天快取，降低重複下載開銷。
 			response.headers.set('Cache-Control', 'max-age=604800, public');
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		} else if (isStaticAsset && upstreamResponse.status >= 400) {
-			// 部署切換期間若短暫命中缺檔，禁止 Cloudflare/瀏覽器保留 stale 404。
 			response.headers.delete('Expires');
 			response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
 			response.headers.set('CDN-Cache-Control', 'no-store');
 			response.headers.set('Cloudflare-CDN-Cache-Control', 'no-store');
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		} else if (isRatewisePath && !isHTML) {
-			// ratewise 靜態資源保留 same-origin，避免被第三方站點嵌入。
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		}
 
 		stripOriginLeakHeaders(response);
 
-		// AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 的 AI 爬蟲存取頻率。
-		// 輸出至 Cloudflare Logs，可透過 Logpush 或 Workers Analytics 進一步分析。
 		const userAgent = request.headers.get('user-agent') || '';
 		const aiCrawler = detectAiCrawler(userAgent);
 		if (aiCrawler && isLlmDocPath(url.pathname)) {


### PR DESCRIPTION
## 摘要

精簡 Cloudflare Worker 註解，統一為簡短正式的繁體中文格式。

## 變更內容

- 移除冗餘註解，保留必要技術說明
- 統一變更記錄格式，每行限於一句
- 移除函數內重複註解，僅保留 JSDoc

## 驗證

- Worker 已透過 `wrangler deploy` 部署至 Cloudflare
- 確認 v4.8 正常運作：`curl -sI "https://app.haotool.org/ratewise/__network_probe__" | grep -i "x-security-policy-version"`
- 所有 pre-push 檢查通過（typecheck、test、build:ratewise）

## 影響範圍

- `security-headers/src/worker.js`：-74 行，+28 行（淨減 46 行）

Made with [Cursor](https://cursor.com)