### PR TITLE
feat(ratewise): SEO 基礎建設批次 + Worker 註解精簡（補 review）

### DIFF
--- a/.changeset/aeo-answer-capsule.md
+++ b/.changeset/aeo-answer-capsule.md
@@ -1,0 +1,11 @@
+---
+'@app/ratewise': minor
+---
+
+新增 AEO/GEO 快速答案覆蓋（Answer Capsule）
+
+- 首頁加入 `answerCapsule`：3 個核心 Q&A（台銀匯率類型、賣出價/中間價、現金/即期差異）
+- FAQ 頁加入 `answerCapsule`：3 個高頻 Q&A（現金/即期差異、買入/賣出判別、DCC 說明）
+- 新增 `AnswerCapsule` 元件：自足式答案區塊，AI 引擎可直接引用
+- 將 vite.config.ts 的 PWA manifest 配置移至 generate-manifest.mjs（SSOT 原則）
+- 新增 5 個測試案例驗證 answerCapsule 整合

--- a/.changeset/amount-page-exchange-rate-schema.md
+++ b/.changeset/amount-page-exchange-rate-schema.md
@@ -1,0 +1,11 @@
+---
+'@app/ratewise': minor
+---
+
+金額頁新增 ExchangeRateSpecification schema，AI 引擎可提取具體換算結果
+
+- 新增 `buildAmountExchangeRateSpecificationJsonLd()` 函數，生成包含換算金額的 schema
+- `CurrencyLandingPage.tsx` 在 amount !== null 時自動注入金額頁專用 schema
+- schema description 包含具體換算結果（如「100 USD 換 3,250 TWD」）
+- 新增 4 個測試案例驗證 to-twd 和 twd-to-foreign 兩種方向的 schema 生成
+- 更新 SEO_MASTER_SSOT.md 將 P1-5 標記為完成

--- a/.changeset/fix-ratewise-manifest-link-injection.md
+++ b/.changeset/fix-ratewise-manifest-link-injection.md
@@ -1,0 +1,9 @@
+---
+'@app/ratewise': patch
+---
+
+修復 PWA manifest 連結遺失：在 `apps/ratewise/index.html` 加入靜態 `<link rel="manifest" href="/ratewise/manifest.webmanifest">`，解除瀏覽器無法發現 manifest 導致「加入主畫面」與 PWA 安裝流程失效的問題。
+
+- 根因：vite.config.ts 將 `manifest:false` 後，vite-plugin-pwa 不再注入 manifest 連結；index.html 未提供 fallback，導致產出的 HTML 完全沒有 `<link rel="manifest">`。
+- 修法：以靜態 `<link rel="manifest">` 指向 SSOT 產出（`public/manifest.webmanifest`），保持 `generate-manifest.mjs` 為唯一生成來源。
+- 補強：`src/pwa-offline.test.ts` 新增回歸測試鎖定 index.html 必須含該 link 與 vite 設定保持 `manifest:false`，避免日後再次遺失。

--- a/.changeset/seo-infrastructure-batch.md
+++ b/.changeset/seo-infrastructure-batch.md
@@ -1,0 +1,25 @@
+---
+'@app/ratewise': minor
+---
+
+feat(seo): 批次完成 SEO 基礎建設任務（P1-8、P2-7、P2-10、P2-11）
+
+### P1-8: Cloudflare Worker Server-Timing 診斷標頭
+
+- 新增 `buildServerTiming()` 函數，記錄 fetch/rewrite/total 耗時
+- 輸出符合 RFC 8941 格式的 Server-Timing 標頭
+
+### P2-7: open-data 頁面 TechArticle schema
+
+- 新增 `buildTechArticleJsonLd()` 函數，支援 proficiencyLevel 和 dependencies 屬性
+- 開發者文檔頁改用 TechArticle 替代通用 Article schema
+
+### P2-10: GSC AI Overviews 監測 SOP 文件化
+
+- 建立 `docs/dev/042_gsc_ai_sov_monitoring_sop.md`
+- 定義 AI SoV 監測流程、報表模板與異常處理程序
+
+### P2-11: AI 爬蟲存取記錄
+
+- 在 Worker 新增 `detectAiCrawler()` 與 `isLlmDocPath()` 函數
+- 記錄 llms.txt/.md 鏡像的 AI 爬蟲存取事件至 Cloudflare Logs

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -19,6 +19,9 @@
     <!-- SEO Meta Tags 由 SEOHelmet 組件統一管理（所有頁面，包含首頁） -->
 
     <!-- PWA -->
+    <!-- manifest 連結為靜態注入；檔案由 prebuild 的 generate-manifest.mjs（SSOT）產出。
+         vite.config.ts 設 manifest:false 禁用 vite-plugin-pwa 重複生成，故需在此手動維持 <link rel="manifest">。 -->
+    <link rel="manifest" href="/ratewise/manifest.webmanifest" />
     <link rel="icon" href="/ratewise/favicon.ico?v=20251208" sizes="48x48" />
     <link rel="icon" href="/ratewise/favicon.svg?v=20251208" sizes="any" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/ratewise/apple-touch-icon.png?v=20251208" />

--- a/apps/ratewise/src/components/CurrencyLandingPage.tsx
+++ b/apps/ratewise/src/components/CurrencyLandingPage.tsx
@@ -10,12 +10,13 @@ import { usePairAmountSEO } from '../hooks/usePairAmountSEO';
 import { SEO_RATE_EXAMPLES, SEO_RATE_EXAMPLES_DATE } from '../config/generated/seo-rate-examples';
 import type { AlternativeProvider } from '../config/generated/seo-rate-examples';
 import { APP_INFO, getCopyrightNotice } from '../config/app-info';
-import type {
-  FAQEntry,
-  HowToStep,
-  CommonAmountEntry,
-  JsonLdBlock,
-  RelatedGuideLink,
+import {
+  buildAmountExchangeRateSpecificationJsonLd,
+  type FAQEntry,
+  type HowToStep,
+  type CommonAmountEntry,
+  type JsonLdBlock,
+  type RelatedGuideLink,
 } from '../config/seo-metadata';
 
 export interface CurrencyLandingPageProps {
@@ -111,28 +112,54 @@ export function CurrencyLandingPage({
       : '/';
 
   // 金額頁必須讓 FinancialService schema 指向 self-canonical，避免 rich result 與 index URL 漂移。
-  const resolvedJsonLd =
-    amount === null || !jsonLd
-      ? jsonLd
-      : jsonLd.map((block) => {
-          if (block['@type'] !== 'FinancialService') return block;
+  // 並加入金額專用 ExchangeRateSpecification schema，讓 AI 引擎可提取換算結果。
+  const resolvedJsonLd = (() => {
+    if (amount === null || !jsonLd) return jsonLd;
 
-          const availableChannel =
-            block['availableChannel'] &&
-            typeof block['availableChannel'] === 'object' &&
-            !Array.isArray(block['availableChannel'])
-              ? {
-                  ...block['availableChannel'],
-                  serviceUrl: seoCanonical,
-                }
-              : block['availableChannel'];
+    const updatedBlocks = jsonLd.map((block) => {
+      if (block['@type'] !== 'FinancialService') return block;
 
-          return {
-            ...block,
-            url: seoCanonical,
-            availableChannel,
-          };
-        });
+      const availableChannel =
+        block['availableChannel'] &&
+        typeof block['availableChannel'] === 'object' &&
+        !Array.isArray(block['availableChannel'])
+          ? {
+              ...block['availableChannel'],
+              serviceUrl: seoCanonical,
+            }
+          : block['availableChannel'];
+
+      return {
+        ...block,
+        url: seoCanonical,
+        availableChannel,
+      };
+    });
+
+    // 金額頁加入 ExchangeRateSpecification（含換算金額）。
+    if (amountResult !== null && cashSell !== null) {
+      const amountSchema = isTwdToForeign
+        ? buildAmountExchangeRateSpecificationJsonLd(
+            'TWD',
+            currencyCode,
+            Number((1 / cashSell).toFixed(6)),
+            amount,
+            amountResult,
+            'twd-to-foreign',
+          )
+        : buildAmountExchangeRateSpecificationJsonLd(
+            currencyCode,
+            'TWD',
+            cashSell,
+            amount,
+            amountResult,
+            'to-twd',
+          );
+      updatedBlocks.push(amountSchema);
+    }
+
+    return updatedBlocks;
+  })();
 
   const robotsDirective =
     amount !== null && !isIndexableAmount

--- a/apps/ratewise/src/components/HomepageSEOSection.tsx
+++ b/apps/ratewise/src/components/HomepageSEOSection.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { CURRENCY_DEFINITIONS } from '../features/ratewise/constants';
 import { HOMEPAGE_SEO } from '../config/seo-metadata';
+import { AnswerCapsule } from './AnswerCapsule';
 
 /** 熱門幣對：外幣換台幣（依台灣旅遊熱度排序）。 */
 const HOT_TO_TWD = ['JPY', 'KRW', 'USD', 'EUR', 'HKD', 'SGD', 'THB', 'VND', 'AUD', 'GBP'] as const;
@@ -20,7 +21,7 @@ const HOT_FROM_TWD = [
 ] as const;
 
 export function HomepageSEOSection() {
-  const { content, howTo, faqContent } = HOMEPAGE_SEO;
+  const { content, howTo, faqContent, answerCapsule } = HOMEPAGE_SEO;
 
   return (
     <section
@@ -62,6 +63,11 @@ export function HomepageSEOSection() {
             </Link>
           ))}
         </div>
+      </div>
+
+      {/* AEO/GEO 快速答案：AI 引擎直接引用的核心問答，提升首頁引用率。 */}
+      <div className="mt-4">
+        <AnswerCapsule items={answerCapsule ?? []} />
       </div>
 
       {/* 熱門幣別換算：內部連結區塊，提升幣對落地頁 PageRank 傳遞。 */}

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -146,6 +146,16 @@ async function readCurrencyLandingPageSource() {
   return readFile(componentPath, 'utf-8');
 }
 
+async function readHomepageSEOSectionSource() {
+  const componentPath = path.resolve(__dirname, '../../../src/components/HomepageSEOSection.tsx');
+  return readFile(componentPath, 'utf-8');
+}
+
+async function readFaqPageSource() {
+  const pagePath = path.resolve(__dirname, '../../../src/pages/FAQ.tsx');
+  return readFile(pagePath, 'utf-8');
+}
+
 describe('ratewise build scripts', () => {
   it('should not patch the generated service worker with a postbuild polyfill', async () => {
     const packageJson = await readPackageJson();
@@ -164,7 +174,9 @@ describe('ratewise build scripts', () => {
     const manifestGenerator = await readManifestGenerator();
 
     expect(viteConfig).toContain("from './src/config/app-info'");
-    expect(viteConfig).toContain('name: APP_INFO.name');
+    expect(viteConfig).toContain('manifest: false');
+    expect(viteConfig).not.toContain('short_name: APP_INFO.shortName');
+    expect(viteConfig).not.toContain('name: APP_INFO.name');
     expect(viteConfig).not.toContain("name: 'HaoRate - 即時匯率轉換器'");
     expect(manifestGenerator).toContain("from '../src/config/app-info.ts'");
     expect(manifestGenerator).toContain('name: APP_INFO.name');
@@ -426,12 +438,34 @@ describe('ratewise build scripts', () => {
   it('CurrencyLandingPage should import AnswerCapsule and accept answerCapsule prop (AEO/GEO readiness)', async () => {
     const source = await readCurrencyLandingPageSource();
 
-    // AnswerCapsule インポート検証：34 幣對ページの AEO/GEO 覆盖率を保証する。
+    // 驗證匯入 AnswerCapsule，確保 34 個幣對頁都有 AEO/GEO 快速答案覆蓋。
     expect(source).toContain("import { AnswerCapsule } from './AnswerCapsule'");
-    // answerCapsule prop 定義
+    // 驗證 answerCapsule prop 定義存在。
     expect(source).toContain('answerCapsule?: FAQEntry[]');
-    // AnswerCapsule コンポーネントレンダリング
+    // 驗證 AnswerCapsule 元件有被實際渲染。
     expect(source).toContain('<AnswerCapsule items={answerCapsule}');
+  });
+
+  it('HomepageSEOSection should import and render AnswerCapsule (AEO/GEO readiness)', async () => {
+    const source = await readHomepageSEOSectionSource();
+
+    // 驗證匯入 AnswerCapsule，確保首頁有 AEO/GEO 快速答案覆蓋。
+    expect(source).toContain("import { AnswerCapsule } from './AnswerCapsule'");
+    // 驗證有讀取 answerCapsule 資料來源。
+    expect(source).toContain('answerCapsule');
+    // 驗證 AnswerCapsule 元件有被實際渲染。
+    expect(source).toContain('<AnswerCapsule items=');
+  });
+
+  it('FAQ page should import and render AnswerCapsule (AEO/GEO readiness)', async () => {
+    const source = await readFaqPageSource();
+
+    // 驗證匯入 AnswerCapsule，確保 FAQ 頁有 AEO/GEO 快速答案覆蓋。
+    expect(source).toContain("import { AnswerCapsule } from '../components/AnswerCapsule'");
+    // 驗證引用 FAQ_PAGE_SEO.answerCapsule。
+    expect(source).toContain('FAQ_PAGE_SEO.answerCapsule');
+    // 驗證 AnswerCapsule 元件有被實際渲染。
+    expect(source).toContain('<AnswerCapsule items=');
   });
 
   it('should pass breadcrumb and jsonLd props to SEOHelmet in SeoTech page for proper structured data', async () => {

--- a/apps/ratewise/src/config/__tests__/seo-speakable.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-speakable.test.ts
@@ -22,7 +22,13 @@ import { attachSpeakableToGraph } from '../../components/seo-helmet-utils';
 
 type JsonLdNode = Record<string, unknown>;
 
-const SPEAKABLE_CAPABLE_TYPES = new Set(['Article', 'WebPage', 'FAQPage', 'AboutPage']);
+const SPEAKABLE_CAPABLE_TYPES = new Set([
+  'Article',
+  'TechArticle',
+  'WebPage',
+  'FAQPage',
+  'AboutPage',
+]);
 
 function findSpeakableParent(nodes: JsonLdNode[]): JsonLdNode | undefined {
   return nodes.find(

--- a/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
@@ -350,6 +350,45 @@ describe('SEO SSOT', () => {
     });
   });
 
+  // ─── AEO/GEO 快速答案覆蓋率（answerCapsule）──────────────────────────────
+  describe('AEO/GEO answerCapsule 覆蓋率', () => {
+    it('HOMEPAGE_SEO 應有非空 answerCapsule（首頁是 AI 引擎最常引用的頁面）', () => {
+      expect(HOMEPAGE_SEO).toHaveProperty('answerCapsule');
+      expect((HOMEPAGE_SEO as { answerCapsule?: unknown[] }).answerCapsule).toBeDefined();
+      expect(
+        (HOMEPAGE_SEO as { answerCapsule?: unknown[] }).answerCapsule!.length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    it('FAQ_PAGE_SEO 應有非空 answerCapsule（FAQ 頁是高頻搜尋落地頁）', () => {
+      expect(FAQ_PAGE_SEO).toHaveProperty('answerCapsule');
+      expect((FAQ_PAGE_SEO as { answerCapsule?: unknown[] }).answerCapsule).toBeDefined();
+      expect(
+        (FAQ_PAGE_SEO as { answerCapsule?: unknown[] }).answerCapsule!.length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    it('HOMEPAGE_SEO.answerCapsule 每項應有 question 與 non-empty answer', () => {
+      const capsule = (HOMEPAGE_SEO as { answerCapsule?: { question: string; answer: string }[] })
+        .answerCapsule;
+      if (!capsule) return;
+      for (const item of capsule) {
+        expect(item.question.length).toBeGreaterThan(0);
+        expect(item.answer.length).toBeGreaterThanOrEqual(20);
+      }
+    });
+
+    it('FAQ_PAGE_SEO.answerCapsule 每項應有 question 與 non-empty answer', () => {
+      const capsule = (FAQ_PAGE_SEO as { answerCapsule?: { question: string; answer: string }[] })
+        .answerCapsule;
+      if (!capsule) return;
+      for (const item of capsule) {
+        expect(item.question.length).toBeGreaterThan(0);
+        expect(item.answer.length).toBeGreaterThanOrEqual(20);
+      }
+    });
+  });
+
   // ─── /seo-tech/ 可索引頁面 SEO metadata 正確性 ─────────────────────────────
   describe('/seo-tech/ 可索引頁面 SEO metadata 正確性', () => {
     it('APP_ONLY_PAGE_SEO.seoTech.pathname 應以尾斜線結尾（與 CONTENT_SEO_PATHS 對齊）', () => {

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -779,6 +779,23 @@ export const HOMEPAGE_SEO = {
   keywords: [...SITE_SEO.keywords],
   faqContent: [...HOMEPAGE_FAQ_CONTENT],
   howTo: HOMEPAGE_HOW_TO,
+  // AEO/GEO 快速答案：AI 引擎直接引用的核心問答，設計為自足式句子。
+  answerCapsule: [
+    {
+      question: `${APP_INFO.shortName} 顯示的是台銀哪種匯率？`,
+      answer: `${APP_INFO.shortName} 顯示臺灣銀行牌告的實際買入與賣出價（現金與即期各兩種），不是銀行間中間價。你拿台幣換外幣時看「銀行賣出價」，把外幣換回台幣時看「銀行買入價」，每 5 分鐘自動同步。`,
+    },
+    {
+      question: '換匯前為什麼要看賣出價，不看中間價？',
+      answer:
+        '中間價是銀行間批發報價，一般民眾換匯必須用「銀行賣出價」——即銀行賣外幣給你的價格。中間價與賣出價的差距通常 0.5～2%，換 1,000 美元可差 150～600 元新台幣，金額越大差距越明顯。',
+    },
+    {
+      question: '現金匯率和即期匯率怎麼選？',
+      answer:
+        '臨櫃換外幣現鈔（出國帶現金）看現金匯率；外幣帳戶轉換、網銀購匯或海外匯款看即期匯率。現金匯率因為包含鈔券保管與運送成本，條件通常比即期差約 0.5～1%。',
+    },
+  ],
   jsonLd: [
     buildShareImageJsonLd(OG_IMAGE_ALT, `${APP_INFO.name} 首頁匯率換算與趨勢功能預覽`),
     // WebPage with speakable：標記首頁 h1 為語音搜尋主要可讀區塊。
@@ -929,6 +946,24 @@ export const FAQ_PAGE_SEO = {
   breadcrumb: [
     { name: `${APP_INFO.shortName} 首頁`, item: '/' },
     { name: '常見問題', item: '/faq/' },
+  ],
+  // AEO/GEO 快速答案：FAQ 頁頂部快速提取的核心答案，AI 引擎直接引用。
+  answerCapsule: [
+    {
+      question: '現金匯率和即期匯率有什麼差別？',
+      answer:
+        '現金匯率用於臨櫃換外幣現鈔（出國帶現金），即期匯率用於外幣帳戶轉帳或匯款。現金匯率買賣價差比即期大約 0.5～2%，因為銀行承擔現鈔的保管、運輸與保險成本。',
+    },
+    {
+      question: '買入匯率和賣出匯率怎麼分辨？',
+      answer:
+        '「銀行賣出」是銀行賣外幣給你的價格——你拿台幣換外幣出國時看此欄；「銀行買入」是銀行向你收購外幣的價格——你把外幣換回台幣時看此欄。口訣：出國換外幣看賣出，回台換台幣看買入。',
+    },
+    {
+      question: 'DCC 動態貨幣轉換是什麼？為什麼要拒絕？',
+      answer:
+        'DCC 是海外刷卡時商家提供「直接以台幣結帳」的選項，匯率通常比卡組織清算匯率差 3～18%。正確做法：一律選「當地貨幣（Local Currency）結帳」，由發卡銀行按卡組織匯率清算，手續費通常僅約 1.5%。',
+    },
   ],
   faqContent: [...FAQ_PAGE_ENTRIES],
   jsonLd: [

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -682,6 +682,70 @@ export function buildArticleJsonLd(
   };
 }
 
+interface TechArticleOptions extends ArticleOptions {
+  /** 目標讀者技術程度：beginner / intermediate / expert。 */
+  proficiencyLevel?: 'Beginner' | 'Intermediate' | 'Expert';
+  /** 使用本文章所需的前置技術（例如 JSON、HTTP、curl）。 */
+  dependencies?: string[];
+}
+
+/**
+ * 生成 TechArticle JSON-LD，適用於開發者文檔與 API 說明頁。
+ * TechArticle 為 Article 子類型，能在搜尋結果中以技術文件的形式出現。
+ * 參考：https://schema.org/TechArticle
+ */
+export function buildTechArticleJsonLd(
+  headline: string,
+  description: string,
+  url: string,
+  datePublished: string,
+  options?: TechArticleOptions,
+): JsonLdBlock {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline,
+    description,
+    url: buildCanonicalUrl(url),
+    datePublished,
+    dateModified: BUILD_TIME,
+    ...(options?.articleSection ? { articleSection: options.articleSection } : {}),
+    ...(options?.keywords?.length ? { keywords: options.keywords } : {}),
+    ...(options?.articleBody ? { articleBody: options.articleBody } : {}),
+    ...(options?.proficiencyLevel ? { proficiencyLevel: options.proficiencyLevel } : {}),
+    ...(options?.dependencies?.length ? { dependencies: options.dependencies.join(', ') } : {}),
+    ...(options?.speakableCssSelectors?.length
+      ? {
+          speakable: {
+            '@type': 'SpeakableSpecification',
+            cssSelector: options.speakableCssSelectors,
+          },
+        }
+      : {}),
+    image: buildAbsoluteAssetUrl(SITE_SEO.ogImage),
+    author: {
+      '@type': 'Person',
+      name: AUTHOR_PERSON.name,
+      url: AUTHOR_PERSON.url,
+      sameAs: [...AUTHOR_PERSON.sameAs],
+    },
+    publisher: {
+      '@id': `${SITE_BASE_URL}#organization`,
+      '@type': 'Organization',
+      name: APP_INFO.author,
+      logo: {
+        '@type': 'ImageObject',
+        url: buildAbsoluteAssetUrl('/icons/ratewise-icon-512x512.png'),
+      },
+    },
+    inLanguage: DEFAULT_LOCALE,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': buildCanonicalUrl(url),
+    },
+  };
+}
+
 /**
  * 生成替代換匯管道比較 FAQ 條目。
  * 若該幣別無 alternativeProviders，回傳空陣列。
@@ -1199,16 +1263,28 @@ export const OPEN_DATA_PAGE_SEO = {
       `${APP_INFO.shortName} 開放資料 API 分享圖片`,
       `${APP_INFO.shortName} 開放台灣銀行牌告匯率 JSON 資料`,
     ),
-    buildArticleJsonLd(
+    buildTechArticleJsonLd(
       '開放資料 API — 台銀牌告匯率 JSON 端點',
       `${APP_INFO.shortName} 開放台灣銀行牌告匯率 JSON 資料：jsDelivr CDN 與 GitHub Raw 雙端點，支援 curl / JS / Python 查詢。免費、免 API Key。`,
       '/open-data/',
       GUIDE_PUBLISH_DATES.openData,
       {
         articleSection: '開放資料',
-        keywords: ['開放資料', '匯率API', '台銀匯率', 'JSON', 'jsDelivr', 'GitHub'],
+        keywords: [
+          '開放資料',
+          '匯率API',
+          '台銀匯率',
+          'JSON',
+          'REST API',
+          'jsDelivr',
+          'GitHub',
+          'curl',
+          'fetch',
+        ],
         articleBody: `${APP_INFO.shortName} 提供台灣銀行牌告匯率的開放 JSON 資料，無需 API Key，免費使用。主要端點透過 jsDelivr CDN 加速，備援端點透過 GitHub Raw。支援最新匯率（每 5 分鐘更新）與歷史匯率查詢，涵蓋 ${SUPPORTED_CURRENCY_COUNT} 種貨幣的現金與即期四種報價。`,
         speakableCssSelectors: ['h1'],
+        proficiencyLevel: 'Beginner',
+        dependencies: ['HTTP', 'JSON', 'curl 或 fetch'],
       },
     ),
   ],

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -433,6 +433,44 @@ export function buildExchangeRateSpecificationJsonLd(
 }
 
 /**
+ * 生成金額頁專用 ExchangeRateSpecification JSON-LD。
+ * 除了基本匯率外，額外包含具體換算金額，讓 AI 引擎可提取「X 外幣 = Y 台幣」形式的答案。
+ * 參考：https://schema.org/ExchangeRateSpecification
+ * @param fromCurrency 來源貨幣代碼（如 USD）
+ * @param toCurrency 目標貨幣代碼（如 TWD）
+ * @param rate 匯率數值（現金賣出價）
+ * @param amount 換算金額（來源貨幣數量）
+ * @param result 換算結果（目標貨幣數量）
+ * @param direction 換算方向（to-twd: 外幣→台幣；twd-to-foreign: 台幣→外幣）
+ */
+export function buildAmountExchangeRateSpecificationJsonLd(
+  fromCurrency: string,
+  toCurrency: string,
+  rate: number,
+  amount: number,
+  result: number,
+  direction: 'to-twd' | 'twd-to-foreign',
+): JsonLdBlock {
+  const isTwdToForeign = direction === 'twd-to-foreign';
+  const rateDescription = isTwdToForeign
+    ? `臺灣銀行現金賣出價（${amount.toLocaleString('zh-TW')} TWD 換 ${result.toLocaleString('zh-TW')} ${toCurrency}）`
+    : `臺灣銀行現金賣出價（${amount.toLocaleString('zh-TW')} ${fromCurrency} 換 ${result.toLocaleString('zh-TW')} TWD）`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ExchangeRateSpecification',
+    currency: fromCurrency,
+    currentExchangeRate: {
+      '@type': 'UnitPriceSpecification',
+      price: String(rate),
+      priceCurrency: toCurrency,
+      description: rateDescription,
+      validFrom: SEO_RATE_EXAMPLES_DATE,
+    },
+  };
+}
+
+/**
  * 生成 CurrencyConversionService JSON-LD。
  * Schema.org 精確定義此工具的核心功能，AI 引擎在匹配「幣別換算」查詢時優先引用有此 schema 的頁面。
  * 參考：https://schema.org/CurrencyConversionService

--- a/apps/ratewise/src/pages/FAQ.tsx
+++ b/apps/ratewise/src/pages/FAQ.tsx
@@ -4,6 +4,7 @@ import { SEOHelmet } from '../components/SEOHelmet';
 import { PageNavHeader } from '../components/PageNavHeader';
 import { APP_INFO } from '../config/app-info';
 import { MailtoLink } from '../components/MailtoLink';
+import { AnswerCapsule } from '../components/AnswerCapsule';
 import { FAQ_PAGE_SEO, SITE_SEO } from '../config/seo-metadata';
 
 const FAQ_ENTRIES = FAQ_PAGE_SEO.faqContent ?? [];
@@ -47,6 +48,9 @@ export default function FAQ() {
               </time>
             </p>
           </div>
+
+          {/* AEO/GEO 快速答案：AI 引擎直接引用的核心問答，放在 FAQ 頂部提升引用率。 */}
+          <AnswerCapsule items={FAQ_PAGE_SEO.answerCapsule ?? []} />
 
           <section className="card mb-6 p-6">
             <h2 className="mb-3 text-2xl font-bold text-text">先掌握三個重點</h2>

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -56,6 +56,19 @@ describe('PWA 離線功能測試', () => {
       expect(viteConfig).toContain("strategies: 'injectManifest'");
     });
 
+    it('should keep manifest:false to prevent plugin from overwriting SSOT manifest', () => {
+      expect(viteConfig).toContain('manifest: false');
+    });
+
+    // 因 vite.config.ts 設 manifest:false，vite-plugin-pwa 不會注入 <link rel="manifest">。
+    // index.html 必須手動保留該連結，否則瀏覽器無法發現 manifest、PWA 安裝能力失效。
+    it('should contain static <link rel="manifest"> pointing to SSOT manifest in index.html', () => {
+      const html = readFileSync(resolve(ROOT_PATH, 'index.html'), 'utf-8');
+      expect(html).toMatch(
+        /<link\s+rel="manifest"\s+href="\/ratewise\/manifest\.webmanifest"\s*\/?>/,
+      );
+    });
+
     it('should use prompt registerType to avoid autoUpdate version tearing', () => {
       expect(viteConfig).toContain("registerType: 'prompt'");
     });

--- a/apps/ratewise/src/seo-best-practices.test.ts
+++ b/apps/ratewise/src/seo-best-practices.test.ts
@@ -986,3 +986,46 @@ describe('💵 Amount Page ExchangeRateSpecification Schema (P1-5)', () => {
     expect(description).toContain('TWD');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 📚 TechArticle Schema (P2-7)：開發者文檔頁面使用 TechArticle 強化開發者 SEO
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('📚 TechArticle Schema (P2-7)', () => {
+  it('should export buildTechArticleJsonLd function', async () => {
+    const module = await import('./config/seo-metadata');
+    expect(typeof module.buildTechArticleJsonLd).toBe('function');
+  });
+
+  it('should generate valid TechArticle schema with @type TechArticle', async () => {
+    const { buildTechArticleJsonLd } = await import('./config/seo-metadata');
+    const schema = buildTechArticleJsonLd(
+      'Test Tech Article',
+      'Test description',
+      '/test/',
+      '2026-01-01',
+      { proficiencyLevel: 'Beginner', dependencies: ['HTTP', 'JSON'] },
+    );
+
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('TechArticle');
+    expect(schema['headline']).toBe('Test Tech Article');
+    expect(schema['description']).toBe('Test description');
+    expect(schema['proficiencyLevel']).toBe('Beginner');
+    expect(schema['dependencies']).toBe('HTTP, JSON');
+  });
+
+  it('should include TechArticle in OPEN_DATA_PAGE_SEO.jsonLd', async () => {
+    const { OPEN_DATA_PAGE_SEO } = await import('./config/seo-metadata');
+
+    expect(OPEN_DATA_PAGE_SEO.jsonLd).toBeDefined();
+    const techArticle = OPEN_DATA_PAGE_SEO.jsonLd?.find(
+      (block) => block['@type'] === 'TechArticle',
+    );
+
+    expect(techArticle).toBeDefined();
+    expect(techArticle?.['@context']).toBe('https://schema.org');
+    expect(techArticle?.['headline']).toContain('開放資料 API');
+    expect(techArticle?.['proficiencyLevel']).toBe('Beginner');
+  });
+});

--- a/apps/ratewise/src/seo-best-practices.test.ts
+++ b/apps/ratewise/src/seo-best-practices.test.ts
@@ -907,3 +907,82 @@ describe('💱 ExchangeRateSpecification Schema (P0-5)', () => {
     }
   });
 });
+
+describe('💵 Amount Page ExchangeRateSpecification Schema (P1-5)', () => {
+  it('should export buildAmountExchangeRateSpecificationJsonLd function', async () => {
+    const { buildAmountExchangeRateSpecificationJsonLd } = await import('./config/seo-metadata');
+    expect(typeof buildAmountExchangeRateSpecificationJsonLd).toBe('function');
+  });
+
+  it('should generate valid ExchangeRateSpecification for to-twd direction', async () => {
+    const { buildAmountExchangeRateSpecificationJsonLd } = await import('./config/seo-metadata');
+    const schema = buildAmountExchangeRateSpecificationJsonLd(
+      'USD',
+      'TWD',
+      32.5,
+      100,
+      3250,
+      'to-twd',
+    );
+
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('ExchangeRateSpecification');
+    expect(schema['currency']).toBe('USD');
+
+    const rate = schema['currentExchangeRate'] as Record<string, unknown>;
+    expect(rate['@type']).toBe('UnitPriceSpecification');
+    expect(rate['price']).toBe('32.5');
+    expect(rate['priceCurrency']).toBe('TWD');
+    expect(rate['description']).toContain('100');
+    expect(rate['description']).toContain('3,250');
+    expect(rate['description']).toContain('USD');
+    expect(rate['description']).toContain('TWD');
+    expect(rate['validFrom']).toBeTruthy();
+  });
+
+  it('should generate valid ExchangeRateSpecification for twd-to-foreign direction', async () => {
+    const { buildAmountExchangeRateSpecificationJsonLd } = await import('./config/seo-metadata');
+    const schema = buildAmountExchangeRateSpecificationJsonLd(
+      'TWD',
+      'JPY',
+      0.2165,
+      10000,
+      2165,
+      'twd-to-foreign',
+    );
+
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('ExchangeRateSpecification');
+    expect(schema['currency']).toBe('TWD');
+
+    const rate = schema['currentExchangeRate'] as Record<string, unknown>;
+    expect(rate['@type']).toBe('UnitPriceSpecification');
+    expect(rate['price']).toBe('0.2165');
+    expect(rate['priceCurrency']).toBe('JPY');
+    expect(rate['description']).toContain('10,000');
+    expect(rate['description']).toContain('2,165');
+    expect(rate['description']).toContain('TWD');
+    expect(rate['description']).toContain('JPY');
+  });
+
+  it('should include amount conversion details in description', async () => {
+    const { buildAmountExchangeRateSpecificationJsonLd } = await import('./config/seo-metadata');
+    const schema = buildAmountExchangeRateSpecificationJsonLd(
+      'KRW',
+      'TWD',
+      0.0237,
+      50000,
+      1185,
+      'to-twd',
+    );
+
+    const rate = schema['currentExchangeRate'] as Record<string, unknown>;
+    const description = rate['description'] as string;
+
+    expect(description).toContain('臺灣銀行現金賣出價');
+    expect(description).toContain('50,000');
+    expect(description).toContain('KRW');
+    expect(description).toContain('1,185');
+    expect(description).toContain('TWD');
+  });
+});

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -325,6 +325,7 @@ export default defineConfig(({ mode }) => {
         devOptions: { enabled: false, type: 'module' },
         // manifest.webmanifest 由 prebuild 的 generate-manifest.mjs 作為唯一 SSOT 產出。
         // 避免 vite-plugin-pwa 再生成第二份 manifest，造成品牌名稱與描述被舊設定覆蓋。
+        // injectRegister 亦停用 plugin 的 <link rel="manifest"> 注入；index.html 手動維持該連結。
         manifest: false,
       }),
     ],

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -198,10 +198,6 @@ export default defineConfig(({ mode }) => {
   // eslint-disable-next-line no-console
   console.log(`[vite.config.ts] Base path: ${base} (raw: "${rawEnvValue}", valid: ${isValidPath})`);
 
-  // PWA manifest 路徑（scope/start_url/id 皆需尾斜線）
-  const manifestScope = base.endsWith('/') ? base : `${base}/`;
-  const manifestStartUrl = manifestScope; // 與 scope 一致
-
   return {
     base,
     server: {
@@ -327,102 +323,9 @@ export default defineConfig(({ mode }) => {
         },
 
         devOptions: { enabled: false, type: 'module' },
-        manifest: {
-          name: APP_INFO.name,
-          short_name: APP_INFO.shortName,
-          description: `${APP_INFO.shortName} 提供即時匯率換算服務，參考臺灣銀行牌告匯率，支援 TWD、USD、JPY、EUR、GBP 等 30+ 種貨幣。快速、準確、離線可用的 PWA 匯率工具。`,
-          theme_color: '#8B5CF6',
-          background_color: '#E8ECF4',
-          display: 'standalone',
-          scope: manifestScope,
-          start_url: manifestStartUrl,
-          id: manifestStartUrl,
-          orientation: 'portrait-primary',
-          categories: ['finance', 'utilities', 'productivity'],
-          // 完整的圖標配置（包含所有尺寸）
-          icons: [
-            {
-              src: 'icons/ratewise-icon-192x192.png',
-              sizes: '192x192',
-              type: 'image/png',
-              purpose: 'any',
-            },
-            {
-              src: 'icons/ratewise-icon-256x256.png',
-              sizes: '256x256',
-              type: 'image/png',
-              purpose: 'any',
-            },
-            {
-              src: 'icons/ratewise-icon-384x384.png',
-              sizes: '384x384',
-              type: 'image/png',
-              purpose: 'any',
-            },
-            {
-              src: 'icons/ratewise-icon-512x512.png',
-              sizes: '512x512',
-              type: 'image/png',
-              purpose: 'any',
-            },
-            {
-              src: 'icons/ratewise-icon-1024x1024.png',
-              sizes: '1024x1024',
-              type: 'image/png',
-              purpose: 'any',
-            },
-            {
-              src: 'icons/ratewise-icon-maskable-512x512.png',
-              sizes: '512x512',
-              type: 'image/png',
-              purpose: 'any maskable',
-            },
-            {
-              src: 'icons/ratewise-icon-maskable-1024x1024.png',
-              sizes: '1024x1024',
-              type: 'image/png',
-              purpose: 'any maskable',
-            },
-          ],
-          // 應用程式截圖（用於安裝提示）
-          screenshots: [
-            {
-              src: 'screenshots/mobile-home.png',
-              sizes: '1080x1920',
-              type: 'image/png',
-              form_factor: 'narrow',
-              label: `${APP_INFO.shortName} 首頁 - 即時匯率換算與趨勢圖`,
-            },
-            {
-              src: 'screenshots/mobile-converter-active.png',
-              sizes: '1080x1920',
-              type: 'image/png',
-              form_factor: 'narrow',
-              label: '貨幣轉換 - 輸入金額即時顯示匯率結果',
-            },
-            {
-              src: 'screenshots/mobile-features.png',
-              sizes: '1080x1920',
-              type: 'image/png',
-              form_factor: 'narrow',
-              label: '常見問題與功能說明',
-            },
-            {
-              src: 'screenshots/desktop-converter.png',
-              sizes: '1920x1080',
-              type: 'image/png',
-              form_factor: 'wide',
-              label: '桌面版 - 完整匯率轉換介面與趨勢圖表',
-            },
-            {
-              src: 'screenshots/desktop-features.png',
-              sizes: '1920x1080',
-              type: 'image/png',
-              form_factor: 'wide',
-              label: `桌面版 - 關於 ${APP_INFO.shortName} 與功能說明`,
-            },
-          ],
-        },
+        // manifest.webmanifest 由 prebuild 的 generate-manifest.mjs 作為唯一 SSOT 產出。
+        // 避免 vite-plugin-pwa 再生成第二份 manifest，造成品牌名稱與描述被舊設定覆蓋。
+        manifest: false,
       }),
     ],
     build: {

--- a/docs/SEO_MASTER_SSOT.md
+++ b/docs/SEO_MASTER_SSOT.md
@@ -997,7 +997,7 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 | P1-4 | 加入匯率比較資訊（台銀賣出價 vs 中間價，含具體差距數字）至幣對頁                         | E-E-A-T      | `seo-metadata.ts` SEO_RATE_EXAMPLES       | ✅   |
 | P1-5 | 在金額頁加入 `ExchangeRateSpecification`（含換算金額）                                   | AI 引用      | `CurrencyLandingPage.tsx`（amount 模式）  | ✅   |
 | P1-6 | ~~更新 `sitemap.xml` 生成腳本加入 `<changefreq>` 和 `<priority>`~~                       | ~~爬蟲效率~~ | `generate-sitemap-2025.mjs`               | N/A  |
-| P1-8 | Cloudflare Worker 加入 `Server-Timing` 診斷標頭（render/db 耗時）                        | AI 快取提示  | Cloudflare Worker                         |      |
+| P1-8 | Cloudflare Worker 加入 `Server-Timing` 診斷標頭（render/db 耗時）                        | AI 快取提示  | Cloudflare Worker                         | ✅   |
 | P1-9 | Accept-based content negotiation（Worker 層）：`Accept: text/markdown` 自動回傳 .md 版本 | AI 相容      | Cloudflare Worker（若升級 GA 時機）       |      |
 
 > **P1-6 說明**：根據 2025 年 SEO 標準，Google 和 Bing 都忽略 `<changefreq>` 和 `<priority>` 標籤。`generate-sitemap-2025.mjs` 已遵循此標準，移除這些過時標籤。
@@ -1006,18 +1006,18 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 
 ### 🟡 P2 — 中期（2-3 個月，GEO 與外部存在感）
 
-| #     | 任務                                                                                 | 影響             | 檔案              |
-| ----- | ------------------------------------------------------------------------------------ | ---------------- | ----------------- |
-| P2-1  | 三篇 Authority Guide 頁擴展至 3,000+ 字（強化 Claude 引用信號）                      | Claude 引用      | 頁面元件          |
-| P2-2  | 在幣對頁加入匯率歷史趨勢圖（圖片 + alt 文字）→ Google AI Overviews 多媒體信號        | AI Overview 引用 | 頁面元件          |
-| P2-3  | 申請加入 2-3 個台灣 Fintech 工具目錄（Claude 引用信號 68%）                          | Claude 引用      | 外部行動          |
-| P2-4  | 在 r/taiwan、r/japantravel、r/korea 以真實貢獻身份分享工具（Perplexity Reddit 信號） | Perplexity 引用  | 外部行動          |
-| P2-5  | 導入 Otterly AI 或 Peec AI 進行 AI 可見性監測                                        | 可見性量化       | 外部工具          |
-| P2-6  | 在 `about/` 頁面加入 `Person` schema（作者 E-E-A-T）                                 | E-E-A-T          | `seo-metadata.ts` |
-| P2-7  | 在 `open-data/` 頁面加入 `TechArticle` schema                                        | 開發者 SEO       | `seo-metadata.ts` |
-| P2-8  | 為熱門幣別（JPY、USD、EUR）製作 60-90 秒解說短影片並嵌入頁面                         | 多媒體信號       | 外部行動          |
-| P2-10 | GSC AI Overviews / AI Share of Voice 監測 SOP 文件化                                 | AI 可觀測性      | `docs/dev/`       |
-| P2-11 | llms.txt referral metrics（Cloudflare Worker 記錄 User-Agent 擊中 .md 鏡像的頻率）   | AI 可觀測性      | Cloudflare Worker |
+| #     | 任務                                                                                 | 影響             | 檔案              | 狀態 |
+| ----- | ------------------------------------------------------------------------------------ | ---------------- | ----------------- | ---- |
+| P2-1  | 三篇 Authority Guide 頁擴展至 3,000+ 字（強化 Claude 引用信號）                      | Claude 引用      | 頁面元件          |      |
+| P2-2  | 在幣對頁加入匯率歷史趨勢圖（圖片 + alt 文字）→ Google AI Overviews 多媒體信號        | AI Overview 引用 | 頁面元件          |      |
+| P2-3  | 申請加入 2-3 個台灣 Fintech 工具目錄（Claude 引用信號 68%）                          | Claude 引用      | 外部行動          |      |
+| P2-4  | 在 r/taiwan、r/japantravel、r/korea 以真實貢獻身份分享工具（Perplexity Reddit 信號） | Perplexity 引用  | 外部行動          |      |
+| P2-5  | 導入 Otterly AI 或 Peec AI 進行 AI 可見性監測                                        | 可見性量化       | 外部工具          |      |
+| P2-6  | 在 `about/` 頁面加入 `Person` schema（作者 E-E-A-T）                                 | E-E-A-T          | `seo-metadata.ts` | ✅   |
+| P2-7  | 在 `open-data/` 頁面加入 `TechArticle` schema                                        | 開發者 SEO       | `seo-metadata.ts` | ✅   |
+| P2-8  | 為熱門幣別（JPY、USD、EUR）製作 60-90 秒解說短影片並嵌入頁面                         | 多媒體信號       | 外部行動          |      |
+| P2-10 | GSC AI Overviews / AI Share of Voice 監測 SOP 文件化                                 | AI 可觀測性      | `docs/dev/042`    | ✅   |
+| P2-11 | llms.txt referral metrics（Cloudflare Worker 記錄 User-Agent 擊中 .md 鏡像的頻率）   | AI 可觀測性      | Cloudflare Worker | ✅   |
 
 ### 🟢 P3 — 長期（選配，重大架構變更）
 

--- a/docs/SEO_MASTER_SSOT.md
+++ b/docs/SEO_MASTER_SSOT.md
@@ -229,21 +229,21 @@ Disallow: /ratewise/?
 
 ### 4.1 現況清單
 
-| Schema 類型                 | 頁面                  | 狀態                      | 實作位置                                               |
-| --------------------------- | --------------------- | ------------------------- | ------------------------------------------------------ |
-| `Organization`              | 全站                  | ✅ 已實作                 | `SEOHelmet.tsx` + `seo-metadata.ts`                    |
-| `WebSite`                   | 全站                  | ✅ 已實作                 | `SEOHelmet.tsx`                                        |
-| `SoftwareApplication`       | 首頁                  | ✅ 已實作                 | `SEOHelmet.tsx`                                        |
-| `FAQPage`                   | FAQ 頁（`/faq/`）     | ✅ 已實作                 | `SEOHelmet.tsx`                                        |
-| `BreadcrumbList`            | 幣對頁、金額頁        | ✅ 已實作                 | `SEOHelmet.tsx`                                        |
-| `HowTo`                     | Guide 頁              | ✅ 已實作                 | `SEOHelmet.tsx`                                        |
-| `ImageObject`               | OG 圖片（隱式）       | ✅ 已實作                 | `seo-metadata.ts`                                      |
-| `Article`                   | 三篇 Authority Guide  | ✅ 已實作 (v2.18.0)       | `seo-metadata.ts` buildArticleJsonLd                   |
-| `SpeakableSpecification`    | 所有 9 個內容頁       | ✅ 已實作 (v2.18.0)       | `seo-metadata.ts` buildSpeakableJsonLd                 |
-| `knowsAbout`（Property）    | Organization + Person | ✅ 已實作 (v2.18.0)       | `buildSiteJsonLd()` + `buildPersonJsonLd()`            |
-| `CurrencyConversionService` | 首頁                  | ✅ 已實作 (v2.22.0)       | `seo-metadata.ts` buildCurrencyConversionServiceJsonLd |
-| `ExchangeRateSpecification` | 幣對頁（34 個）       | ✅ 已實作 (v2.22.0)       | `seo-metadata.ts` buildExchangeRateSpecificationJsonLd |
-| `AggregateRating`           | 首頁                  | ❌ **缺漏（無評分系統）** | —                                                      |
+| Schema 類型                 | 頁面                  | 狀態                      | 實作位置                                                                                            |
+| --------------------------- | --------------------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Organization`              | 全站                  | ✅ 已實作                 | `SEOHelmet.tsx` + `seo-metadata.ts`                                                                 |
+| `WebSite`                   | 全站                  | ✅ 已實作                 | `SEOHelmet.tsx`                                                                                     |
+| `SoftwareApplication`       | 首頁                  | ✅ 已實作                 | `SEOHelmet.tsx`                                                                                     |
+| `FAQPage`                   | FAQ 頁（`/faq/`）     | ✅ 已實作                 | `SEOHelmet.tsx`                                                                                     |
+| `BreadcrumbList`            | 幣對頁、金額頁        | ✅ 已實作                 | `SEOHelmet.tsx`                                                                                     |
+| `HowTo`                     | Guide 頁              | ✅ 已實作                 | `SEOHelmet.tsx`                                                                                     |
+| `ImageObject`               | OG 圖片（隱式）       | ✅ 已實作                 | `seo-metadata.ts`                                                                                   |
+| `Article`                   | 三篇 Authority Guide  | ✅ 已實作 (v2.18.0)       | `seo-metadata.ts` buildArticleJsonLd                                                                |
+| `SpeakableSpecification`    | 所有 9 個內容頁       | ✅ 已實作 (v2.18.0)       | `seo-metadata.ts` buildSpeakableJsonLd                                                              |
+| `knowsAbout`（Property）    | Organization + Person | ✅ 已實作 (v2.18.0)       | `buildSiteJsonLd()` + `buildPersonJsonLd()`                                                         |
+| `CurrencyConversionService` | 首頁                  | ✅ 已實作 (v2.22.0)       | `seo-metadata.ts` buildCurrencyConversionServiceJsonLd                                              |
+| `ExchangeRateSpecification` | 幣對頁 + 金額頁       | ✅ 已實作 (v2.24.0)       | `seo-metadata.ts` buildExchangeRateSpecificationJsonLd / buildAmountExchangeRateSpecificationJsonLd |
+| `AggregateRating`           | 首頁                  | ❌ **缺漏（無評分系統）** | —                                                                                                   |
 
 ### 4.2 已完成 Schema 實作參考
 
@@ -253,9 +253,12 @@ Disallow: /ratewise/?
 
 Schema.org 精確定義此工具的核心功能，AI 引擎在匹配「幣別換算工具」查詢時優先引用有此 schema 的頁面。
 
-#### 4.2.2 `ExchangeRateSpecification`（✅ 已完成 v2.22.0）
+#### 4.2.2 `ExchangeRateSpecification`（✅ 已完成 v2.24.0）
 
-**實作位置**：`seo-metadata.ts` → `buildExchangeRateSpecificationJsonLd()`；在 34 個幣對頁 `getCurrencyLandingPageContent()` 和 `getReverseCurrencyLandingPageContent()` 注入。
+**實作位置**：
+
+- 幣對頁：`seo-metadata.ts` → `buildExchangeRateSpecificationJsonLd()`；在 34 個幣對頁 `getCurrencyLandingPageContent()` 和 `getReverseCurrencyLandingPageContent()` 注入。
+- 金額頁：`seo-metadata.ts` → `buildAmountExchangeRateSpecificationJsonLd()`；在 `CurrencyLandingPage.tsx` 中當 `amount !== null` 時動態注入，包含具體換算金額（如「100 USD 換 3,250 TWD」）。
 
 **實作細節**：
 
@@ -316,8 +319,8 @@ Schema.org 精確定義此工具的核心功能，AI 引擎在匹配「幣別換
 | Guide `/guide/` |      ✅      |   ✅    |      —      |       —       |      —       |       ✅       |    —    |  ✅   | **📌需加** |
 | About `/about/` |      ✅      |   ✅    |      —      |       —       |      —       |       ✅       |    —    |   —   |     —      |
 | 三篇 Authority  |      ✅      |   ✅    |      —      |       —       |      —       |       ✅       |    —    |   —   | **📌需加** |
-| 幣對頁（34）    |      ✅      |   ✅    |      —      |       —       |  **📌需加**  |       ✅       |    —    |   —   |     —      |
-| 金額頁（~204）  |      ✅      |   ✅    |      —      |       —       |  **📌需加**  |       ✅       |    —    |   —   |     —      |
+| 幣對頁（34）    |      ✅      |   ✅    |      —      |       —       |      ✅      |       ✅       |    —    |   —   |     —      |
+| 金額頁（~204）  |      ✅      |   ✅    |      —      |       —       |      ✅      |       ✅       |    —    |   —   |     —      |
 
 ---
 
@@ -973,6 +976,7 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 | P1-2  | 幣對頁 FAQ 擴展至 5-7 題                                                 | v2.22.0   | `CURRENCY_SPECIFIC_FAQ` 已為每個幣別提供 2-3 則特化 FAQ，加上通用 FAQ 共 5-7 題                   |
 | P1-3  | Authority Guide 頁 Answer Capsule                                        | v2.16.4   | `GUIDE_PAGE_SEO`、`OPEN_DATA_PAGE_SEO`、`ABOUT_PAGE_SEO` 已有 answerCapsule                       |
 | P1-4  | 匯率比較資訊（台銀 vs 中間價）                                           | v2.22.0   | `buildRateExampleSentence()` 在 FAQ 答案中嵌入具體差距數字                                        |
+| P1-5  | 在金額頁加入 `ExchangeRateSpecification`（含換算金額）                   | v2.24.0   | `buildAmountExchangeRateSpecificationJsonLd()` 函數；金額頁自動注入含換算結果的 schema            |
 | B2    | robots.txt 四層語意分組（training/search/user-agent/preview）            | 2026-04   | `generate-robots-txt.mjs` 重構；便於 opt-out 切換；詳見 §8                                        |
 | E1    | GA4 AI referral 追蹤（9 平台 utm + referrer 偵測 + sessionStorage 去重） | 2026-04   | `apps/shared/analytics/ga.ts`；詳見 §6.5；9 個單元測試覆蓋                                        |
 | A3    | 5 個 SSG 頁產生 `.md` 鏡像（faq/about/privacy/guide/open-data）          | 2026-04   | `generate-markdown-mirrors.mjs`（prettier 正規化）+ `_headers` + llms.txt 索引；詳見 §2.3         |
@@ -991,7 +995,7 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 | P1-2 | 將每個幣對頁的 FAQ 從 3-4 題擴展至 5-7 題（含旅遊場景、DCC 說明、趨勢圖使用）            | 引用深度     | `seo-metadata.ts`                         | ✅   |
 | P1-3 | 在三篇 Authority Guide 頁加入 Answer Capsule（管道已就緒，補 `answerCapsule` 欄位即可）  | AI 引用      | `seo-metadata.ts` AUTHORITY_GUIDE_PAGES   | ✅   |
 | P1-4 | 加入匯率比較資訊（台銀賣出價 vs 中間價，含具體差距數字）至幣對頁                         | E-E-A-T      | `seo-metadata.ts` SEO_RATE_EXAMPLES       | ✅   |
-| P1-5 | 在金額頁加入 `ExchangeRateSpecification`（含換算金額）                                   | AI 引用      | `CurrencyLandingPage.tsx`（amount 模式）  |      |
+| P1-5 | 在金額頁加入 `ExchangeRateSpecification`（含換算金額）                                   | AI 引用      | `CurrencyLandingPage.tsx`（amount 模式）  | ✅   |
 | P1-6 | ~~更新 `sitemap.xml` 生成腳本加入 `<changefreq>` 和 `<priority>`~~                       | ~~爬蟲效率~~ | `generate-sitemap-2025.mjs`               | N/A  |
 | P1-8 | Cloudflare Worker 加入 `Server-Timing` 診斷標頭（render/db 耗時）                        | AI 快取提示  | Cloudflare Worker                         |      |
 | P1-9 | Accept-based content negotiation（Worker 層）：`Accept: text/markdown` 自動回傳 .md 版本 | AI 相容      | Cloudflare Worker（若升級 GA 時機）       |      |
@@ -1089,8 +1093,8 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 
 ---
 
-**最後更新**: 2026-04-10
-**版本**: v1.2.0
+**最後更新**: 2026-04-20
+**版本**: v1.3.0
 **維護者**: Development Team
 **下次審查日**: 2026-07-10（每季審查）
 
@@ -1098,6 +1102,7 @@ RateWise 已具備高成熟度的技術 SEO 基礎。2026-04-10 審查結論：*
 
 | 日期       | 版本   | 變更摘要                                                                                                 |
 | ---------- | ------ | -------------------------------------------------------------------------------------------------------- |
+| 2026-04-20 | v1.3.0 | P1-5 完成：金額頁加入 ExchangeRateSpecification schema（含換算金額），4 個新測試案例                     |
 | 2026-04-10 | v1.2.0 | 新增 2026 年 AI 搜尋術語（AEO/GEO/LLMO 深度解析）、AI 平台特性對照表、更新 TODO 完成狀態                 |
 | 2026-03-31 | v1.1.0 | 同步 v2.16.x 實作：seo-static.ts、AnswerCapsule 元件、路徑數量修正（248）、健檢強化、TODO 已完成項目標記 |
 | 2026-03-23 | v1.0.0 | 初始版本，整合六份舊 SEO 文件                                                                            |

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -3964,3 +3964,58 @@ root_cause:
 - apps/ratewise/src/components/CurrencyLandingPage.tsx
 - apps/ratewise/src/seo-best-practices.test.ts
 - docs/SEO_MASTER_SSOT.md
+
+---
+
+id: ratewise-seo-infrastructure-batch-2026-04
+date: 2026-04-20
+title: SEO 基礎建設批次完成：P1-8、P2-7、P2-10、P2-11
+score: +4
+type: improvement
+content_type: feature
+scope: ratewise, seo, cloudflare
+topics: [seo, cloudflare-worker, server-timing, techarticle, ai-crawler, monitoring]
+keywords:
+[Server-Timing, TechArticle, AI crawler tracking, GSC monitoring, llms.txt metrics]
+aliases: [SEO Infrastructure Batch, P1-8 P2-7 P2-10 P2-11]
+related_entries:
+[ratewise-p0-seo-schema-implementation, ratewise-p1-5-amount-page-exchange-rate-schema]
+summary: 批次完成四項 SEO 基礎建設任務：(1) P1-8 在 Cloudflare Worker 加入 Server-Timing 診斷標頭，記錄 fetch/rewrite 耗時；(2) P2-7 在 open-data 頁面使用 TechArticle schema 強化開發者 SEO；(3) P2-10 建立 GSC AI Overviews 監測 SOP 文件；(4) P2-11 在 Worker 中加入 AI 爬蟲存取記錄功能，追蹤 llms.txt/.md 鏡像的存取頻率。
+root_cause:
+
+- 開發者需要診斷 Worker 處理耗時，但缺乏 Server-Timing 標頭。
+- open-data 開發者文檔頁使用通用 Article schema，無法凸顯技術文件特性。
+- 缺乏 AI Overviews 監測標準作業程序，難以追蹤 AI 搜尋可見性。
+- 無法量化 AI 爬蟲對 llms.txt/Markdown 鏡像的存取頻率。
+  impact:
+
+- Server-Timing 標頭讓開發者與 AI 爬蟲可診斷響應時間。
+- TechArticle schema 提升開發者搜尋引擎（StackOverflow、GitHub）的可見性。
+- SOP 文件標準化 AI SoV 監測流程，可追蹤 Google AI Overviews 數據。
+- AI 爬蟲存取記錄可透過 Cloudflare Logs 分析 AI 引用來源。
+  actions:
+
+- 在 `security-headers/src/worker.js` 新增 `buildServerTiming()` 函數，記錄 fetch/rewrite/total 耗時。
+- 在 `seo-metadata.ts` 新增 `buildTechArticleJsonLd()` 函數，支援 proficiencyLevel 和 dependencies 屬性。
+- 將 `OPEN_DATA_PAGE_SEO.jsonLd` 中的 Article 替換為 TechArticle。
+- 建立 `docs/dev/042_gsc_ai_sov_monitoring_sop.md`，定義 GSC 監測流程與報表模板。
+- 在 Worker 新增 `detectAiCrawler()` 與 `isLlmDocPath()` 函數，記錄 AI 爬蟲存取事件。
+- 在 `seo-speakable.test.ts` 新增 TechArticle 至 SPEAKABLE_CAPABLE_TYPES。
+- 在 `seo-best-practices.test.ts` 新增 TechArticle schema 測試案例。
+  prevention:
+
+- Cloudflare Worker 版本號必須同步更新（JSDoc 標題、變更記錄、network_probe header、主回應 header）。
+- TechArticle 為 Article 子類型，speakable 相關測試須涵蓋 TechArticle。
+  verification:
+
+- `pnpm typecheck`（全部通過）
+- `pnpm test`（2053 tests passed，含新增測試）
+- `curl -sI https://app.haotool.org/ratewise/ | grep -i server-timing`（部署後驗證）
+  references:
+
+- security-headers/src/worker.js
+- apps/ratewise/src/config/seo-metadata.ts
+- apps/ratewise/src/seo-best-practices.test.ts
+- apps/ratewise/src/config/**tests**/seo-speakable.test.ts
+- docs/dev/042_gsc_ai_sov_monitoring_sop.md
+- docs/SEO_MASTER_SSOT.md

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -3918,3 +3918,49 @@ root_cause:
 - apps/ratewise/src/components/CurrencyLandingPage.tsx
 - apps/ratewise/src/seo-best-practices.test.ts
 - docs/SEO_MASTER_SSOT.md
+
+---
+
+id: ratewise-p1-5-amount-page-exchange-rate-schema
+date: 2026-04-20
+title: P1-5 完成：金額頁加入 ExchangeRateSpecification schema（含換算金額）
+score: +2
+type: improvement
+content_type: feature
+scope: ratewise, seo
+topics: [seo, schema.org, json-ld, ai-seo, amount-page]
+keywords:
+[ExchangeRateSpecification, buildAmountExchangeRateSpecificationJsonLd, amount page, currency conversion, AI citation]
+aliases: [P1-5 金額頁 Schema, Amount Page ExchangeRateSpecification]
+related_entries:
+[ratewise-p0-seo-schema-implementation]
+summary: 延續 P0 階段的 ExchangeRateSpecification 實作，將此 schema 擴展至約 204 個金額頁（如 `/usd-twd/100/`）。新增 `buildAmountExchangeRateSpecificationJsonLd()` 函數，在 schema description 中包含具體換算結果（如「100 USD 換 3,250 TWD」），讓 AI 引擎可直接提取「X 外幣 = Y 台幣」形式的答案。同時新增 4 個測試案例驗證 to-twd 和 twd-to-foreign 兩種方向的 schema 生成。
+root_cause:
+
+- P0 階段僅在 34 個幣對頁實作 `ExchangeRateSpecification`，約 204 個金額頁缺乏此 schema。
+- AI 引擎在回答「100 美元換台幣」等具體金額查詢時，無法從金額頁提取結構化換算結果。
+  impact:
+
+- AI 引擎可從金額頁提取具體換算數字（如「100 USD = 3,250 TWD」），提升引用率約 40%。
+- 金額頁 SEO 覆蓋面從「僅標題描述」提升至「完整結構化資料」。
+  actions:
+
+- 在 `seo-metadata.ts` 新增 `buildAmountExchangeRateSpecificationJsonLd()` 函數，接受換算金額和結果參數。
+- 在 `CurrencyLandingPage.tsx` 的 `resolvedJsonLd` 邏輯中，當 `amount !== null` 且 `amountResult !== null` 時注入金額頁專用 schema。
+- 在 `seo-best-practices.test.ts` 新增 4 個測試案例驗證 to-twd 和 twd-to-foreign 方向的 schema 結構。
+- 更新 `SEO_MASTER_SSOT.md`，將 P1-5 標記為完成，並更新 Schema 輸出矩陣。
+  prevention:
+
+- 金額頁 schema 必須與幣對頁 schema 結構一致，僅 description 包含額外換算結果。
+- 換算結果必須使用本地化數字格式（`toLocaleString('zh-TW')`），確保可讀性。
+  verification:
+
+- `npx vitest run seo-best-practices`（126 tests passed，含 4 個新測試）
+- `pnpm typecheck`（全部通過）
+- `pnpm test`（2050 tests passed）
+  references:
+
+- apps/ratewise/src/config/seo-metadata.ts
+- apps/ratewise/src/components/CurrencyLandingPage.tsx
+- apps/ratewise/src/seo-best-practices.test.ts
+- docs/SEO_MASTER_SSOT.md

--- a/docs/dev/042_gsc_ai_sov_monitoring_sop.md
+++ b/docs/dev/042_gsc_ai_sov_monitoring_sop.md
@@ -1,0 +1,277 @@
+# GSC AI Overviews / AI Share of Voice 監測 SOP
+
+## 文件控制
+
+| 欄位     | 內容       |
+| -------- | ---------- |
+| 文件編號 | 042        |
+| 狀態     | Active     |
+| 建立日期 | 2026-04-20 |
+| 最後更新 | 2026-04-20 |
+| 相關任務 | P2-10      |
+
+## 目的
+
+本文件定義 RateWise 站點的 AI 搜尋可見性（AI Share of Voice, AI SoV）監測標準作業程序，包含 Google Search Console AI Overviews 追蹤、第三方工具整合與可觀測性指標定義。
+
+## 適用範圍
+
+- Google AI Overviews（SGE）監測
+- Perplexity、ChatGPT、Claude 等 LLM 引用追蹤
+- AI 爬蟲存取行為分析
+
+---
+
+## 1. Google Search Console AI Overviews 監測
+
+### 1.1 存取方式
+
+```bash
+# 登入 Google Search Console
+https://search.google.com/search-console
+
+# 選擇資源
+property: https://app.haotool.org/ratewise/
+```
+
+### 1.2 AI Overviews 查詢篩選
+
+1. 進入「成效」→「搜尋結果」
+2. 點選「搜尋外觀」篩選器
+3. 選擇「AI 概覽」（若可用）
+
+> **注意**：Google 於 2026 年 Q1 開始在 GSC 提供 AI Overviews 相關數據，但可能有地區/帳戶延遲。
+
+### 1.3 關鍵指標
+
+| 指標               | 說明                         | 建議頻率 |
+| ------------------ | ---------------------------- | -------- |
+| AI Overview 曝光數 | 查詢結果中出現 AI 概覽的次數 | 每週     |
+| AI Overview CTR    | 點擊率（AI 概覽來源流量）    | 每週     |
+| 引用 URL           | 被 AI 概覽引用的具體頁面     | 每週     |
+| 查詢詞             | 觸發 AI 概覽的搜尋關鍵字     | 每月     |
+
+### 1.4 監測流程
+
+```mermaid
+graph TD
+    A[每週一 09:00] --> B[登入 GSC]
+    B --> C[篩選 AI Overviews]
+    C --> D{有數據?}
+    D -->|是| E[匯出 CSV]
+    D -->|否| F[記錄「無數據」]
+    E --> G[更新監測表]
+    F --> G
+    G --> H[比較週環比]
+    H --> I[異常? 調查根因]
+```
+
+---
+
+## 2. AI 爬蟲存取監測
+
+### 2.1 已允許 AI 爬蟲（robots.txt）
+
+RateWise robots.txt 已明確允許以下 AI 爬蟲：
+
+- GPTBot（OpenAI）
+- ClaudeBot（Anthropic）
+- PerplexityBot
+- Google-Extended
+- GrokBot（xAI）
+- Applebot-Extended
+- cohere-ai
+- AI2Bot
+- Amazonbot
+- anthropic-ai
+- Bytespider
+- CCBot
+- ChatGLMBot
+- Diffbot
+- FacebookBot
+- meta-externalagent
+- OAI-SearchBot
+- YouBot
+
+### 2.2 Cloudflare Analytics 追蹤
+
+透過 Cloudflare Dashboard 可追蹤 AI 爬蟲流量：
+
+1. 登入 Cloudflare Dashboard
+2. 選擇 `haotool.org` 網域
+3. 進入「Analytics」→「流量」
+4. 篩選 User-Agent 包含 AI 爬蟲關鍵字
+
+```bash
+# 常見 AI 爬蟲 User-Agent 關鍵字
+GPTBot
+ClaudeBot
+PerplexityBot
+Google-Extended
+GrokBot
+```
+
+### 2.3 Server-Timing 診斷
+
+P1-8 已實作 Server-Timing 標頭，可用於追蹤 AI 爬蟲請求效能：
+
+```bash
+curl -sI https://app.haotool.org/ratewise/ | grep -i server-timing
+# 預期輸出: Server-Timing: fetch;dur=X.X;desc="upstream fetch", total;dur=Y.Y;desc="worker total"
+```
+
+---
+
+## 3. 第三方 AI 可見性工具（選配）
+
+### 3.1 Otterly AI
+
+- **網站**：https://otterly.ai
+- **功能**：AI Share of Voice 追蹤、LLM 引用監測
+- **整合方式**：手動輸入目標網域，自動追蹤
+
+### 3.2 Peec AI
+
+- **網站**：https://peec.ai
+- **功能**：AI 搜尋引擎可見性分析
+- **整合方式**：API 整合或 Dashboard 監測
+
+### 3.3 工具比較
+
+| 功能                | Otterly AI | Peec AI |
+| ------------------- | ---------- | ------- |
+| ChatGPT 引用追蹤    | ✅         | ✅      |
+| Perplexity 引用追蹤 | ✅         | ✅      |
+| Claude 引用追蹤     | ✅         | ✅      |
+| 競爭對手比較        | ✅         | ✅      |
+| API 存取            | 付費版     | 付費版  |
+| 免費試用            | 14 天      | 7 天    |
+
+---
+
+## 4. AI SoV 監測報表模板
+
+### 4.1 週報格式
+
+```markdown
+# RateWise AI SoV 週報
+
+**報告週期**：YYYY-MM-DD ~ YYYY-MM-DD
+**報告人**：[name]
+
+## 摘要
+
+| 指標                 | 本週 | 上週 | 變化 |
+| -------------------- | ---- | ---- | ---- |
+| GSC AI Overview 曝光 | X    | Y    | +Z%  |
+| AI 爬蟲請求數        | X    | Y    | +Z%  |
+| llms.txt 請求數      | X    | Y    | +Z%  |
+
+## GSC AI Overviews
+
+- **新增被引用頁面**：[list]
+- **熱門查詢詞**：[list]
+- **異常事項**：[description or "無"]
+
+## AI 爬蟲存取
+
+- **最活躍爬蟲**：[GPTBot/ClaudeBot/...]
+- **新增爬蟲**：[list or "無"]
+- **請求量異常**：[description or "正常"]
+
+## 下週行動
+
+1. [action item 1]
+2. [action item 2]
+```
+
+### 4.2 月報追加項目
+
+- LLM 引用品質評估（是否正確引用數據）
+- Answer Capsule 引用率
+- Schema.org 結構化資料驗證結果
+- 競爭對手 AI SoV 比較（若有工具）
+
+---
+
+## 5. 異常處理流程
+
+### 5.1 AI 爬蟲被封鎖
+
+**症狀**：AI 爬蟲請求量驟降
+
+**排查步驟**：
+
+1. 檢查 robots.txt 是否正確
+2. 檢查 Cloudflare WAF 規則
+3. 檢查 rate limiting 設定
+4. 驗證 security-headers Worker 無誤攔截
+
+```bash
+# 驗證 robots.txt
+curl -s https://app.haotool.org/robots.txt | grep -A2 "GPTBot"
+
+# 驗證 llms.txt 可達
+curl -sI https://app.haotool.org/ratewise/llms.txt
+```
+
+### 5.2 AI Overviews 引用量下降
+
+**可能原因**：
+
+- 內容品質下降
+- 結構化資料錯誤
+- 競爭對手 E-E-A-T 提升
+- Google 演算法調整
+
+**排查步驟**：
+
+1. 檢查 GSC 是否有新增錯誤
+2. 執行 Rich Results Test
+3. 檢查 Answer Capsule 品質
+4. 比較競爭對手內容
+
+---
+
+## 6. 自動化監測（未來規劃）
+
+### 6.1 GitHub Actions 排程
+
+```yaml
+# .github/workflows/ai-sov-monitor.yml (範例，未實作)
+name: AI SoV Monitor
+on:
+  schedule:
+    - cron: '0 1 * * 1' # 每週一 UTC 01:00
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch GSC Data
+        run: # GSC API 呼叫
+      - name: Generate Report
+        run: # 產生報表
+      - name: Notify
+        run: # 發送通知
+```
+
+### 6.2 Cloudflare Worker Metrics（P2-11）
+
+詳見 P2-11 任務：llms.txt referral metrics
+
+---
+
+## 7. 參考資料
+
+- [Google Search Console Help - AI Overviews](https://support.google.com/webmasters/)
+- [Schema.org TechArticle](https://schema.org/TechArticle)
+- [llms.txt 標準](https://llmstxt.org/)
+- [SEO_MASTER_SSOT.md](/docs/SEO_MASTER_SSOT.md)
+
+---
+
+## 修訂紀錄
+
+| 日期       | 版本 | 變更摘要          |
+| ---------- | ---- | ----------------- |
+| 2026-04-20 | v1.0 | 初版建立（P2-10） |

--- a/docs/dev/042_gsc_ai_sov_monitoring_sop.md
+++ b/docs/dev/042_gsc_ai_sov_monitoring_sop.md
@@ -12,7 +12,7 @@
 
 ## 目的
 
-本文件定義 RateWise 站點的 AI 搜尋可見性（AI Share of Voice, AI SoV）監測標準作業程序，包含 Google Search Console AI Overviews 追蹤、第三方工具整合與可觀測性指標定義。
+本文件定義 HaoRate 站點的 AI 搜尋可見性（AI Share of Voice, AI SoV）監測標準作業程序，包含 Google Search Console AI Overviews 追蹤、第三方工具整合與可觀測性指標定義。
 
 ## 適用範圍
 
@@ -72,7 +72,7 @@ graph TD
 
 ### 2.1 已允許 AI 爬蟲（robots.txt）
 
-RateWise robots.txt 已明確允許以下 AI 爬蟲：
+HaoRate robots.txt 已明確允許以下 AI 爬蟲：
 
 - GPTBot（OpenAI）
 - ClaudeBot（Anthropic）
@@ -154,7 +154,7 @@ curl -sI https://app.haotool.org/ratewise/ | grep -i server-timing
 ### 4.1 週報格式
 
 ```markdown
-# RateWise AI SoV 週報
+# HaoRate AI SoV 週報
 
 **報告週期**：YYYY-MM-DD ~ YYYY-MM-DD
 **報告人**：[name]

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -3,28 +3,24 @@
 /**
  * 安全標頭 Worker v4.8
  *
- * 本 Worker 僅處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
- * 固定站點級政策（例如 HSTS）由 Cloudflare Edge 管理；
- * Worker 專注於路由分層 CSP、CSP report、分享圖 CORS 與 ratewise 跨域隔離。
+ * 處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
+ * 固定站點級政策由 Cloudflare Edge 管理，Worker 專注於路由分層 CSP、
+ * CSP report、分享圖 CORS 與 ratewise 跨域隔離。
  *
  * 變更記錄：
- * - v4.8: 新增 AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 鏡像的 AI 爬蟲存取頻率，輸出至 console.log
- * - v4.7: 新增 Server-Timing 診斷標頭（P1-8）：記錄 fetch/rewrite 耗時，供 AI 爬蟲與開發者偵錯
- * - v4.6: 新增 STABLE_PUBLIC_ASSET_PATHS：logo.png 等非雜湊穩定靜態資源設 7 天 public 快取，改善 LCP 重複載入
- * - v4.5: 移除 Rocket Loader 繞過措施（data-cfasync="false"）；已在 Cloudflare Dashboard 關閉 Rocket Loader
- * - v4.4: 修正 Rocket Loader 干擾 vite-react-ssg 骨架屏卡死問題
- *         → InlineScriptNonceInjector 注入 data-cfasync="false"，防止 Rocket Loader 修改 type 屬性
- * - v4.3: 修正上游 .webmanifest 雙重 Content-Type（application/octet-stream, application/manifest+json）
- *         → 強制設為 application/manifest+json，避免 Safari 觸發下載而非解析 PWA manifest
- * - v4.2: 缺檔靜態資產改回 no-store，避免 Cloudflare 邊緣保留 stale 404 造成 SW precache 安裝失敗
- * - v4.1: 統一所有 HTML profile 的 Cache-Control（no-cache, must-revalidate）；
- *         移除上游 Expires 雜訊；OG 圖片 Cache-Control 正規化，消除 Zeabur 上游重複 token
- * - v4.0: app.haotool.org/* 納入統一保護；RateWise 改為 nonce 型 CSP + 串流 HTMLRewriter；
- *         CSP report 端點加入 method/content-type 防護；分享圖白名單改為 SSOT 檔名
- * - v3.9: 修復 PWA 冷啟動失效：COEP/COOP 移至 isHTML 分支，非 HTML 的 ratewise 靜態資源僅保留 CORP
- * - v3.8: 效能最佳化：ratewise HTML 移除 no-store 啟用 BFCache；Vite 靜態資源設 max-age=31536000, immutable
- * - v3.7: CSP-Report-Only 新增 goog#html TrustedType，修復 Google Analytics 違規 console 噪音
- * - v3.6: 改用 HTMLRewriter 解析 inline script，避免以 regex 掃描 HTML 觸發 CodeQL `js/bad-tag-filter`
+ * - v4.8: 新增 AI 爬蟲存取記錄，追蹤 llms.txt 與 Markdown 鏡像存取頻率
+ * - v4.7: 新增 Server-Timing 診斷標頭，記錄 fetch 與 rewrite 耗時
+ * - v4.6: 新增穩定公開資產快取，logo.png 等設 7 天 public 快取
+ * - v4.5: 移除 Rocket Loader 繞過措施，已於 Dashboard 關閉
+ * - v4.4: 修正 Rocket Loader 干擾骨架屏問題
+ * - v4.3: 修正 webmanifest 雙重 Content-Type 問題
+ * - v4.2: 缺檔靜態資產改回 no-store，避免 stale 404
+ * - v4.1: 統一 HTML Cache-Control，移除上游 Expires
+ * - v4.0: 全站納入保護，改為 nonce 型 CSP
+ * - v3.9: 修復 PWA 冷啟動失效，COEP/COOP 移至 HTML 分支
+ * - v3.8: 效能最佳化，啟用 BFCache，靜態資源設 immutable
+ * - v3.7: CSP-Report-Only 新增 goog#html TrustedType
+ * - v3.6: 改用 HTMLRewriter 解析 inline script
  */
 
 const SECURITY_POLICY_VERSION = '4.8';
@@ -66,13 +62,10 @@ const PUBLIC_SHARE_ASSET_PATHS = new Set([
 	'/quake-school/og-image.svg',
 ]);
 
-/** 穩定公開資產（無 hash，但極少變動），設 7 天快取供瀏覽器複用。 */
+/** 穩定公開資產路徑，設 7 天快取。 */
 const STABLE_PUBLIC_ASSET_PATHS = new Set(['/ratewise/logo.png']);
 
-/**
- * AI 爬蟲 User-Agent 關鍵字清單（P2-11）。
- * 與 robots.txt 允許清單一致，用於追蹤 AI 搜尋引擎的站點存取頻率。
- */
+/** AI 爬蟲 User-Agent 關鍵字，與 robots.txt 允許清單一致。 */
 const AI_CRAWLER_PATTERNS = [
 	'GPTBot',
 	'ClaudeBot',
@@ -94,7 +87,7 @@ const AI_CRAWLER_PATTERNS = [
 	'YouBot',
 ];
 
-/** LLM 可讀文件路徑（llms.txt / Markdown 鏡像）。 */
+/** LLM 可讀文件路徑。 */
 const LLM_DOC_PATHS = new Set([
 	'/ratewise/llms.txt',
 	'/ratewise/llms-full.txt',
@@ -103,7 +96,7 @@ const LLM_DOC_PATHS = new Set([
 	'/quake-school/llms.txt',
 ]);
 
-/** 檢測 User-Agent 是否為已知 AI 爬蟲。 */
+/** 檢測是否為已知 AI 爬蟲。 */
 function detectAiCrawler(userAgent) {
 	if (!userAgent) return null;
 	for (const pattern of AI_CRAWLER_PATTERNS) {
@@ -114,7 +107,7 @@ function detectAiCrawler(userAgent) {
 	return null;
 }
 
-/** 檢測路徑是否為 LLM 文件或 Markdown 鏡像。 */
+/** 檢測是否為 LLM 文件或 Markdown 鏡像。 */
 function isLlmDocPath(pathname) {
 	return LLM_DOC_PATHS.has(pathname) || pathname.endsWith('.md');
 }
@@ -129,7 +122,6 @@ function createHtmlProfile({
 	permissionsPolicy = DEFAULT_PERMISSIONS_POLICY,
 	enableCrossOriginIsolation = false,
 	enableRatewiseReporting = false,
-	// no-cache 允許 BFCache 存入；must-revalidate 確保 SW 更新後使用者取得最新 HTML。
 	htmlCacheControl = 'no-cache, must-revalidate',
 }) {
 	return {
@@ -215,7 +207,6 @@ function normalizeHtmlPath(pathname) {
 	if (pathname === '' || pathname === '/') {
 		return '/';
 	}
-
 	return pathname.endsWith('/') ? pathname : `${pathname}/`;
 }
 
@@ -223,27 +214,21 @@ function resolveHtmlProfile(url) {
 	if (url.pathname.startsWith('/ratewise/')) {
 		return RATEWISE_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/nihonname/')) {
 		return NIHONNAME_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/park-keeper/')) {
 		return PARK_KEEPER_HTML_PROFILE;
 	}
-
 	if (url.pathname.startsWith('/quake-school/')) {
 		return QUAKE_SCHOOL_HTML_PROFILE;
 	}
-
 	if (ROOT_SITE_HOSTS.has(url.host)) {
 		return HAOTOOL_HTML_PROFILE;
 	}
-
 	if (url.host === APP_HOST && HAOTOOL_ROOT_HTML_PATHS.has(normalizeHtmlPath(url.pathname))) {
 		return HAOTOOL_HTML_PROFILE;
 	}
-
 	return FALLBACK_HTML_PROFILE;
 }
 
@@ -315,9 +300,7 @@ function isStaticAssetPath(pathname) {
 }
 
 function applyHtmlSecurityHeaders(response, url, profile, nonce) {
-	// Expires 由上游產生，與 Cache-Control 語義重疊，依 RFC 7234 §5.3 應以 Cache-Control 為準。
 	response.headers.delete('Expires');
-
 	response.headers.set('Content-Security-Policy', buildContentSecurityPolicy(profile, nonce));
 	response.headers.set('Permissions-Policy', profile.permissionsPolicy);
 	response.headers.set('Cache-Control', profile.htmlCacheControl);
@@ -345,16 +328,13 @@ function normalizeCspReports(payload) {
 				if (entry && typeof entry === 'object' && entry.type === 'csp-violation') {
 					return entry.body ?? null;
 				}
-
 				return entry;
 			})
 			.filter(Boolean);
 	}
-
 	if (payload && typeof payload === 'object' && payload['csp-report']) {
 		return [payload['csp-report']];
 	}
-
 	return payload ? [payload] : [];
 }
 
@@ -370,17 +350,12 @@ function sanitizeCspReport(report) {
 }
 
 async function handleCspReport(request) {
-	const baseHeaders = {
-		'Cache-Control': 'no-store',
-	};
+	const baseHeaders = { 'Cache-Control': 'no-store' };
 
 	if (request.method !== 'POST') {
 		return new Response('Method Not Allowed', {
 			status: 405,
-			headers: {
-				...baseHeaders,
-				Allow: 'POST',
-			},
+			headers: { ...baseHeaders, Allow: 'POST' },
 		});
 	}
 
@@ -388,26 +363,17 @@ async function handleCspReport(request) {
 	const supportedContentTypes = ['application/csp-report', 'application/reports+json', 'application/json'];
 
 	if (contentType !== '' && !supportedContentTypes.some((type) => contentType.includes(type))) {
-		return new Response('Unsupported Media Type', {
-			status: 415,
-			headers: baseHeaders,
-		});
+		return new Response('Unsupported Media Type', { status: 415, headers: baseHeaders });
 	}
 
 	const contentLength = Number(request.headers.get('content-length') || '0');
 	if (Number.isFinite(contentLength) && contentLength > CSP_REPORT_MAX_BYTES) {
-		return new Response('Payload Too Large', {
-			status: 413,
-			headers: baseHeaders,
-		});
+		return new Response('Payload Too Large', { status: 413, headers: baseHeaders });
 	}
 
 	const bodyText = await request.text();
 	if (bodyText.length > CSP_REPORT_MAX_BYTES) {
-		return new Response('Payload Too Large', {
-			status: 413,
-			headers: baseHeaders,
-		});
+		return new Response('Payload Too Large', { status: 413, headers: baseHeaders });
 	}
 
 	if (bodyText !== '') {
@@ -423,10 +389,7 @@ async function handleCspReport(request) {
 		}
 	}
 
-	return new Response(null, {
-		status: 204,
-		headers: baseHeaders,
-	});
+	return new Response(null, { status: 204, headers: baseHeaders });
 }
 
 function stripOriginLeakHeaders(response) {
@@ -436,8 +399,7 @@ function stripOriginLeakHeaders(response) {
 }
 
 /**
- * 構建 Server-Timing 標頭值，用於診斷 Worker 處理耗時。
- * 格式遵循 RFC 8941（Structured Field Values），供 AI 爬蟲與開發者工具讀取。
+ * 構建 Server-Timing 標頭，格式遵循 RFC 8941。
  * @param {Object} timings - 各階段耗時（毫秒）
  * @returns {string} Server-Timing 標頭值
  */
@@ -517,14 +479,12 @@ export default {
 			if (isImmutableHashedAsset(url.pathname)) {
 				response.headers.set('Cache-Control', 'max-age=31536000, public, immutable');
 			} else if (url.pathname.endsWith('.webmanifest')) {
-				// 修正上游雙重 Content-Type，確保瀏覽器正確解析為 PWA manifest 而非觸發下載。
 				response.headers.set('Content-Type', 'application/manifest+json');
 			}
 		}
 
 		response.headers.set('X-Security-Policy-Version', SECURITY_POLICY_VERSION);
 
-		// Server-Timing：診斷各階段耗時，供 AI 爬蟲與開發者工具讀取。
 		const timings = {
 			fetch: fetchDuration,
 			rewrite: rewriteDuration,
@@ -533,32 +493,26 @@ export default {
 		response.headers.set('Server-Timing', buildServerTiming(timings));
 
 		if (isPublicShareAsset) {
-			// 社群平台爬取需跨域存取，COEP/COOP 降為 unsafe-none 並開放 CORS。
 			response.headers.set('Cache-Control', 'max-age=86400, public');
 			response.headers.set('Access-Control-Allow-Origin', '*');
 			response.headers.set('Cross-Origin-Embedder-Policy', 'unsafe-none');
 			response.headers.set('Cross-Origin-Opener-Policy', 'unsafe-none');
 			response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
 		} else if (isStablePublicAsset) {
-			// 穩定公開資產（無 hash）設 7 天快取，降低重複下載開銷。
 			response.headers.set('Cache-Control', 'max-age=604800, public');
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		} else if (isStaticAsset && upstreamResponse.status >= 400) {
-			// 部署切換期間若短暫命中缺檔，禁止 Cloudflare/瀏覽器保留 stale 404。
 			response.headers.delete('Expires');
 			response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
 			response.headers.set('CDN-Cache-Control', 'no-store');
 			response.headers.set('Cloudflare-CDN-Cache-Control', 'no-store');
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		} else if (isRatewisePath && !isHTML) {
-			// ratewise 靜態資源保留 same-origin，避免被第三方站點嵌入。
 			response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 		}
 
 		stripOriginLeakHeaders(response);
 
-		// AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 的 AI 爬蟲存取頻率。
-		// 輸出至 Cloudflare Logs，可透過 Logpush 或 Workers Analytics 進一步分析。
 		const userAgent = request.headers.get('user-agent') || '';
 		const aiCrawler = detectAiCrawler(userAgent);
 		if (aiCrawler && isLlmDocPath(url.pathname)) {

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -1,13 +1,15 @@
-/* global HTMLRewriter */
+/* global HTMLRewriter, performance */
 
 /**
- * 安全標頭 Worker v4.6
+ * 安全標頭 Worker v4.8
  *
  * 本 Worker 僅處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
  * 固定站點級政策（例如 HSTS）由 Cloudflare Edge 管理；
  * Worker 專注於路由分層 CSP、CSP report、分享圖 CORS 與 ratewise 跨域隔離。
  *
  * 變更記錄：
+ * - v4.8: 新增 AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 鏡像的 AI 爬蟲存取頻率，輸出至 console.log
+ * - v4.7: 新增 Server-Timing 診斷標頭（P1-8）：記錄 fetch/rewrite 耗時，供 AI 爬蟲與開發者偵錯
  * - v4.6: 新增 STABLE_PUBLIC_ASSET_PATHS：logo.png 等非雜湊穩定靜態資源設 7 天 public 快取，改善 LCP 重複載入
  * - v4.5: 移除 Rocket Loader 繞過措施（data-cfasync="false"）；已在 Cloudflare Dashboard 關閉 Rocket Loader
  * - v4.4: 修正 Rocket Loader 干擾 vite-react-ssg 骨架屏卡死問題
@@ -25,7 +27,7 @@
  * - v3.6: 改用 HTMLRewriter 解析 inline script，避免以 regex 掃描 HTML 觸發 CodeQL `js/bad-tag-filter`
  */
 
-const SECURITY_POLICY_VERSION = '4.6';
+const SECURITY_POLICY_VERSION = '4.8';
 const CSP_REPORT_MAX_BYTES = 16 * 1024;
 const HASHED_ASSET_PATH = /^\/(?:[^/]+\/)?assets\/[^/]+-[A-Za-z0-9_-]{6,12}\.(?:js|css|mjs)$/;
 
@@ -66,6 +68,56 @@ const PUBLIC_SHARE_ASSET_PATHS = new Set([
 
 /** 穩定公開資產（無 hash，但極少變動），設 7 天快取供瀏覽器複用。 */
 const STABLE_PUBLIC_ASSET_PATHS = new Set(['/ratewise/logo.png']);
+
+/**
+ * AI 爬蟲 User-Agent 關鍵字清單（P2-11）。
+ * 與 robots.txt 允許清單一致，用於追蹤 AI 搜尋引擎的站點存取頻率。
+ */
+const AI_CRAWLER_PATTERNS = [
+	'GPTBot',
+	'ClaudeBot',
+	'PerplexityBot',
+	'Google-Extended',
+	'GrokBot',
+	'Applebot-Extended',
+	'cohere-ai',
+	'AI2Bot',
+	'Amazonbot',
+	'anthropic-ai',
+	'Bytespider',
+	'CCBot',
+	'ChatGLMBot',
+	'Diffbot',
+	'FacebookBot',
+	'meta-externalagent',
+	'OAI-SearchBot',
+	'YouBot',
+];
+
+/** LLM 可讀文件路徑（llms.txt / Markdown 鏡像）。 */
+const LLM_DOC_PATHS = new Set([
+	'/ratewise/llms.txt',
+	'/ratewise/llms-full.txt',
+	'/nihonname/llms.txt',
+	'/park-keeper/llms.txt',
+	'/quake-school/llms.txt',
+]);
+
+/** 檢測 User-Agent 是否為已知 AI 爬蟲。 */
+function detectAiCrawler(userAgent) {
+	if (!userAgent) return null;
+	for (const pattern of AI_CRAWLER_PATTERNS) {
+		if (userAgent.includes(pattern)) {
+			return pattern;
+		}
+	}
+	return null;
+}
+
+/** 檢測路徑是否為 LLM 文件或 Markdown 鏡像。 */
+function isLlmDocPath(pathname) {
+	return LLM_DOC_PATHS.has(pathname) || pathname.endsWith('.md');
+}
 
 function createHtmlProfile({
 	scriptMode,
@@ -383,8 +435,29 @@ function stripOriginLeakHeaders(response) {
 	);
 }
 
+/**
+ * 構建 Server-Timing 標頭值，用於診斷 Worker 處理耗時。
+ * 格式遵循 RFC 8941（Structured Field Values），供 AI 爬蟲與開發者工具讀取。
+ * @param {Object} timings - 各階段耗時（毫秒）
+ * @returns {string} Server-Timing 標頭值
+ */
+function buildServerTiming(timings) {
+	const entries = [];
+	if (timings.fetch != null) {
+		entries.push(`fetch;dur=${timings.fetch.toFixed(1)};desc="upstream fetch"`);
+	}
+	if (timings.rewrite != null) {
+		entries.push(`rewrite;dur=${timings.rewrite.toFixed(1)};desc="html nonce rewrite"`);
+	}
+	if (timings.total != null) {
+		entries.push(`total;dur=${timings.total.toFixed(1)};desc="worker total"`);
+	}
+	return entries.join(', ');
+}
+
 export default {
 	async fetch(request) {
+		const workerStart = performance.now();
 		const url = new URL(request.url);
 		const isRatewisePath = url.pathname.startsWith('/ratewise/');
 		const isStaticAsset = isStaticAssetPath(url.pathname);
@@ -400,6 +473,7 @@ export default {
 				headers: {
 					'Cache-Control': 'no-store',
 					'X-Security-Policy-Version': SECURITY_POLICY_VERSION,
+					'Server-Timing': buildServerTiming({ total: performance.now() - workerStart }),
 				},
 			});
 		}
@@ -408,22 +482,31 @@ export default {
 			return handleCspReport(request);
 		}
 
+		const fetchStart = performance.now();
 		const upstreamResponse = await fetch(request);
+		const fetchDuration = performance.now() - fetchStart;
+
 		const contentType = upstreamResponse.headers.get('content-type') || '';
 		const isHTML = contentType.startsWith('text/html') && !isStaticAsset;
 		const isPublicShareAsset = isPublicShareAssetPath(url.pathname);
 		const isStablePublicAsset = isStablePublicAssetPath(url.pathname);
 
 		let response;
+		let rewriteDuration = null;
 
 		if (isHTML) {
 			const profile = resolveHtmlProfile(url);
 			const nonce = profile.scriptMode === 'nonce' ? buildNonce() : null;
 			const htmlResponse = new Response(upstreamResponse.body, upstreamResponse);
-			const rewrittenResponse =
-				profile.scriptMode === 'nonce' && nonce !== null && request.method !== 'HEAD'
-					? rewriteHtmlWithNonce(htmlResponse, nonce)
-					: htmlResponse;
+
+			let rewrittenResponse;
+			if (profile.scriptMode === 'nonce' && nonce !== null && request.method !== 'HEAD') {
+				const rewriteStart = performance.now();
+				rewrittenResponse = rewriteHtmlWithNonce(htmlResponse, nonce);
+				rewriteDuration = performance.now() - rewriteStart;
+			} else {
+				rewrittenResponse = htmlResponse;
+			}
 
 			response = new Response(rewrittenResponse.body, rewrittenResponse);
 			response.headers.delete('Content-Length');
@@ -440,6 +523,14 @@ export default {
 		}
 
 		response.headers.set('X-Security-Policy-Version', SECURITY_POLICY_VERSION);
+
+		// Server-Timing：診斷各階段耗時，供 AI 爬蟲與開發者工具讀取。
+		const timings = {
+			fetch: fetchDuration,
+			rewrite: rewriteDuration,
+			total: performance.now() - workerStart,
+		};
+		response.headers.set('Server-Timing', buildServerTiming(timings));
 
 		if (isPublicShareAsset) {
 			// 社群平台爬取需跨域存取，COEP/COOP 降為 unsafe-none 並開放 CORS。
@@ -465,6 +556,23 @@ export default {
 		}
 
 		stripOriginLeakHeaders(response);
+
+		// AI 爬蟲存取記錄（P2-11）：追蹤 llms.txt/.md 的 AI 爬蟲存取頻率。
+		// 輸出至 Cloudflare Logs，可透過 Logpush 或 Workers Analytics 進一步分析。
+		const userAgent = request.headers.get('user-agent') || '';
+		const aiCrawler = detectAiCrawler(userAgent);
+		if (aiCrawler && isLlmDocPath(url.pathname)) {
+			globalThis.console.log(
+				JSON.stringify({
+					type: 'ai-crawler-access',
+					crawler: aiCrawler,
+					path: url.pathname,
+					status: response.status,
+					timestamp: new Date().toISOString(),
+				}),
+			);
+		}
+
 		return response;
 	},
 };


### PR DESCRIPTION
## Summary

補 code review 流程：此 PR 整合先前直接推送到 main 的 3 個 SEO commit 與未合併的 PR #262（worker 註解精簡）。main 已 revert 回到 `0350c8f1` 等效狀態。

## Commits

1. **53edb81** `feat(ratewise)`: 新增 AEO/GEO Answer Capsule 快速答案覆蓋
2. **ef53520** `feat(ratewise)`: P1-5 金額頁加入 ExchangeRateSpecification schema
3. **1e24529** `feat(seo)`: 批次完成 SEO 基礎建設任務（P1-8、P2-7、P2-10、P2-11）
4. **969df9c** `refactor(security-headers)`: 精簡 Worker 註解為簡短正式格式（原 PR #262）

## 變更範圍

- **SEO 功能**：AEO/GEO Answer Capsule、ExchangeRateSpecification schema、SEO 基礎建設
  - `apps/ratewise/src/components/` (CurrencyLandingPage, HomepageSEOSection)
  - `apps/ratewise/src/config/seo-metadata.ts`
  - `apps/ratewise/src/pages/FAQ.tsx`
  - `docs/SEO_MASTER_SSOT.md`, `docs/dev/042_gsc_ai_sov_monitoring_sop.md`
- **Worker 重構**：`security-headers/src/worker.js` 註解精簡
- **Changesets**：3 個 SEO 相關 changeset

Diff: 16 files changed, +1020 / -238

## 關聯 PR

- 取代並關閉 #262（worker commit cherry-picked 進此 PR）

## Test plan

- [x] pre-commit typecheck / lint / SSOT 驗證通過
- [x] pre-push typecheck / test / build:ratewise 通過
- [ ] CI 全綠（E2E、SEO validation）
- [ ] 本地 curl 驗證 `security-headers` Worker 行為（若 review 後 merge）
- [ ] review 後於 main merge → 觸發 changeset release