### PR TITLE
fix(security): 修補 follow-redirects CVE (Alert #82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
       "rollup@>=4.0.0 <4.59.0": "4.59.0",
       "rollup@<2.80.0": "2.80.0",
       "basic-ftp@<5.2.1": ">=5.2.1",
+      "follow-redirects@<1.16.0": ">=1.16.0",
       "serialize-javascript": ">=7.0.5",
       "path-to-regexp@<0.1.13": "0.1.13",
       "node-forge@<=1.3.3": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: 4.59.0
   rollup@<2.80.0: 2.80.0
   basic-ftp@<5.2.1: '>=5.2.1'
+  follow-redirects@<1.16.0: '>=1.16.0'
   serialize-javascript: '>=7.0.5'
   path-to-regexp@<0.1.13: 0.1.13
   node-forge@<=1.3.3: 1.4.0
@@ -5301,8 +5302,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -13342,7 +13343,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -14804,7 +14805,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fontaine@0.7.0:
     dependencies:


### PR DESCRIPTION
## Summary
- 新增 `pnpm.overrides`: `follow-redirects@<1.16.0` → `>=1.16.0`
- 解除 Dependabot Alert #82（medium severity）
- 依賴鏈僅存在 devDependencies：`unlighthouse → @unlighthouse/core → axios@1.15.0 → follow-redirects`
- 不影響 production runtime（Lighthouse CI 審計用）

## Verification
- `pnpm why follow-redirects` 全部升至 `1.16.0`
- pre-commit 通過（typecheck / prettier）
- pre-push 通過（全域 typecheck / test / build）

## Test plan
- [ ] CI typecheck / test 綠燈
- [ ] CI build（ratewise + 其他 apps）綠燈
- [ ] Dependabot alert #82 自動關閉