### PR TITLE
fix(ratewise): index.html 改用 __BASE_PATH__ 佔位符（修復 base=/ 下 404）

### DIFF
--- a/.changeset/fix-ratewise-index-html-base-path.md
+++ b/.changeset/fix-ratewise-index-html-base-path.md
@@ -1,0 +1,10 @@
+---
+'@app/ratewise': patch
+---
+
+修復 `index.html` 硬編 `/ratewise/` 路徑在非預設 base 部署下 404：改以 `__BASE_PATH__` 佔位符於 `vite.config.ts` 的 `transformIndexHtml` 依 base（SSOT: `VITE_RATEWISE_BASE_PATH`）動態替換，恢復 CI E2E/Lighthouse（base=`/`）情境下的 manifest / icon / preload 可用性。
+
+- 根因：PR #264 前置修補於 index.html 加入 `<link rel="manifest" href="/ratewise/manifest.webmanifest">`；`.github/workflows/ci.yml` 的 E2E/Lighthouse job 以 `VITE_RATEWISE_BASE_PATH=/` 建置，實際 manifest 路徑為 `/manifest.webmanifest`，造成 HTML 連結 404、瀏覽器無法發現 manifest、PWA 安裝能力退化。
+- 修法：index.html 將 `href="/ratewise/..."` 改為 `href="__BASE_PATH__..."`（涵蓋 manifest / favicon.ico / favicon.svg / apple-touch-icon / preload logo），並於 `inject-version-meta` plugin 追加 `replace(/__BASE_PATH__/g, base)`，維持既有 `__APP_VERSION__` / `__BRAND_*` 注入模式的一致性。
+- 補強：`src/pwa-offline.test.ts` 新增 3 項回歸測試，鎖定 index.html 必須使用佔位符、vite plugin 必須替換、禁止 `/ratewise/` 硬編重新出現。
+- 驗證：以 `VITE_RATEWISE_BASE_PATH=/ratewise/` 建置輸出 `/ratewise/manifest.webmanifest`，以 `VITE_RATEWISE_BASE_PATH=/` 建置輸出 `/manifest.webmanifest`，皆正確。

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -20,11 +20,13 @@
 
     <!-- PWA -->
     <!-- manifest 連結為靜態注入；檔案由 prebuild 的 generate-manifest.mjs（SSOT）產出。
-         vite.config.ts 設 manifest:false 禁用 vite-plugin-pwa 重複生成，故需在此手動維持 <link rel="manifest">。 -->
-    <link rel="manifest" href="/ratewise/manifest.webmanifest" />
-    <link rel="icon" href="/ratewise/favicon.ico?v=20251208" sizes="48x48" />
-    <link rel="icon" href="/ratewise/favicon.svg?v=20251208" sizes="any" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/ratewise/apple-touch-icon.png?v=20251208" />
+         vite.config.ts 設 manifest:false 禁用 vite-plugin-pwa 重複生成，故需在此手動維持 <link rel="manifest">。
+         路徑使用 __BASE_PATH__ 佔位符由 vite.config.ts 在 build 時注入（SSOT: VITE_RATEWISE_BASE_PATH），
+         避免 base=/ 時硬編 /ratewise/ 造成 404 與 PWA 安裝能力失效。 -->
+    <link rel="manifest" href="__BASE_PATH__manifest.webmanifest" />
+    <link rel="icon" href="__BASE_PATH__favicon.ico?v=20251208" sizes="48x48" />
+    <link rel="icon" href="__BASE_PATH__favicon.svg?v=20251208" sizes="any" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="__BASE_PATH__apple-touch-icon.png?v=20251208" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <!-- iOS PWA Status Bar Configuration
@@ -35,7 +37,7 @@
     <meta name="apple-mobile-web-app-title" content="__BRAND_SHORT__" />
 
     <!-- LCP 關鍵資源預載入：logo 是首頁 LCP 元素，preload 可提前請求避免 render-blocking 延遲。 -->
-    <link rel="preload" href="/ratewise/logo.png" as="image" fetchpriority="high" />
+    <link rel="preload" href="__BASE_PATH__logo.png" as="image" fetchpriority="high" />
 
     <!-- Resource Hints（僅保留實際使用的來源） -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -62,11 +62,26 @@ describe('PWA 離線功能測試', () => {
 
     // 因 vite.config.ts 設 manifest:false，vite-plugin-pwa 不會注入 <link rel="manifest">。
     // index.html 必須手動保留該連結，否則瀏覽器無法發現 manifest、PWA 安裝能力失效。
-    it('should contain static <link rel="manifest"> pointing to SSOT manifest in index.html', () => {
+    // href 必須使用 __BASE_PATH__ 佔位符（由 vite.config.ts 在 build 時依 base 替換），
+    // 避免寫死 /ratewise/ 在 base=/ 部署（CI E2E/Lighthouse）下 404 造成 PWA 失效。
+    it('should contain <link rel="manifest"> with __BASE_PATH__ placeholder in index.html', () => {
       const html = readFileSync(resolve(ROOT_PATH, 'index.html'), 'utf-8');
       expect(html).toMatch(
-        /<link\s+rel="manifest"\s+href="\/ratewise\/manifest\.webmanifest"\s*\/?>/,
+        /<link\s+rel="manifest"\s+href="__BASE_PATH__manifest\.webmanifest"\s*\/?>/,
       );
+    });
+
+    // inject-version-meta plugin 必須實際把 __BASE_PATH__ 替換為 base 值，
+    // 否則 build 產出的 HTML 會殘留佔位符導致資源 404。
+    it('should replace __BASE_PATH__ with base config in transformIndexHtml', () => {
+      expect(viteConfig).toMatch(/\.replace\(\s*\/__BASE_PATH__\/g\s*,\s*base\s*\)/);
+    });
+
+    // 防回歸：index.html 禁止硬編 /ratewise/ 絕對路徑於 <link>/preload；
+    // 必須透過 __BASE_PATH__ 佔位符以尊重 VITE_RATEWISE_BASE_PATH SSOT。
+    it('should not hardcode /ratewise/ prefix in index.html asset links', () => {
+      const html = readFileSync(resolve(ROOT_PATH, 'index.html'), 'utf-8');
+      expect(html).not.toMatch(/(?:href|src)="\/ratewise\//);
     });
 
     it('should use prompt registerType to avoid autoUpdate version tearing', () => {

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -239,7 +239,9 @@ export default defineConfig(({ mode }) => {
           return new URLSearchParams();
         },
       }),
-      // 版本號與品牌佔位符注入 HTML meta 標籤
+      // 版本號、品牌與 base path 佔位符注入 HTML
+      // __BASE_PATH__ 由此處以 vite config 的 base（SSOT: VITE_RATEWISE_BASE_PATH）替換，
+      // 支援 production（/ratewise/）與 CI E2E/Lighthouse（/）雙部署情境。
       {
         name: 'inject-version-meta',
         transformIndexHtml(html) {
@@ -248,7 +250,8 @@ export default defineConfig(({ mode }) => {
             .replace(/__APP_VERSION__/g, appVersion)
             .replace(/__BUILD_TIME__/g, buildTime)
             .replace(/__BRAND_FULL__/g, APP_INFO.name)
-            .replace(/__BRAND_SHORT__/g, APP_INFO.shortName);
+            .replace(/__BRAND_SHORT__/g, APP_INFO.shortName)
+            .replace(/__BASE_PATH__/g, base);
         },
       },
       // Brotli 壓縮


### PR DESCRIPTION
## Summary
- 修復 index.html 硬編 `/ratewise/` 在 `VITE_RATEWISE_BASE_PATH=/` 部署下 404
- 影響資源：`<link rel=\"manifest\">` / favicon.ico / favicon.svg / apple-touch-icon / preload logo
- CI E2E / Lighthouse job 目前即以 `VITE_RATEWISE_BASE_PATH: '/'` 建置（`.github/workflows/ci.yml` L159/168/232）

## Root Cause
PR #263 前置修補於 index.html 補回 `<link rel=\"manifest\" href=\"/ratewise/manifest.webmanifest\">`，但 href 寫死 `/ratewise/`：
- base=`/ratewise/`（production）→ `/ratewise/manifest.webmanifest` ✓
- base=`/`（CI/預覽）→ 實際 manifest 位於 `/manifest.webmanifest`，HTML 連結 404 → 瀏覽器無法發現 manifest → PWA 安裝 / A2HS 失效

## Fix
1. `apps/ratewise/index.html`：所有硬編 `/ratewise/` 改為 `__BASE_PATH__` 佔位符
2. `apps/ratewise/vite.config.ts`：`inject-version-meta` plugin 追加 `.replace(/__BASE_PATH__/g, base)`（與既有 `__APP_VERSION__` / `__BRAND_*` 注入同模式，SSOT: `VITE_RATEWISE_BASE_PATH`）
3. `apps/ratewise/src/pwa-offline.test.ts`：3 項回歸測試
   - index.html 必須含 `__BASE_PATH__manifest.webmanifest`
   - vite.config.ts 必須替換 `__BASE_PATH__` 為 `base`
   - index.html 禁止硬編 `/ratewise/` 於 href/src

## Verification
**Regression tests**
```
pnpm vitest run src/pwa-offline.test.ts → 25/25 passed
```

**雙 base 實測 build**
```
# default base=/ratewise/
<link rel=\"manifest\" href=\"/ratewise/manifest.webmanifest\">
<link rel=\"icon\" href=\"/ratewise/favicon.ico?v=20251208\" ...>

# VITE_RATEWISE_BASE_PATH=/
<link rel=\"manifest\" href=\"/manifest.webmanifest\">
<link rel=\"icon\" href=\"/favicon.ico?v=20251208\" ...>
```

## Test plan
- [ ] CI Quality Checks 綠燈
- [ ] CI E2E（base=/）綠燈
- [ ] CI Lighthouse（base=/）綠燈
- [ ] CodeQL / Dependency Review 綠燈