### PR TITLE
fix(seo): 收斂 About FAQ 的結構化資料與 AI 搜尋敘述

### DIFF
--- a/.changeset/seo-about-faq-accuracy.md
+++ b/.changeset/seo-about-faq-accuracy.md
@@ -1,0 +1,9 @@
+---
+'@app/ratewise': patch
+---
+
+fix(seo): 校正 About 頁 FAQ 的結構化資料與 AI 搜尋支援說明
+
+- 將 About FAQ 改為反映目前的 FAQPage、ExchangeRateSpecification 與 AI crawler 支援現況
+- 移除容易過時的 AI crawler 固定數量描述，改用較穩定的透明度說法
+- 補強 SEO 守門測試，避免 rich result 與結構化資料敘述再次漂移

--- a/apps/ratewise/public/about.md
+++ b/apps/ratewise/public/about.md
@@ -52,13 +52,13 @@ HaoRate 是以臺灣銀行牌告匯率為基礎的換匯工具，重點是幫台
 
 匯差範例數據由 GitHub Actions 每日自動執行：同時抓取台灣銀行牌告匯率與 open.er-api.com 市場中間價（Google、XE、Wise、Apple 計算機的共同基準），進行雙重驗證（兩個中間價差距須在 2% 以內），生成靜態 TypeScript 常數，透過 Pull Request 自動審核後進入主分支。最終數字直接嵌入靜態 HTML（vite-react-ssg SSG 預渲染），Google 爬蟲無需執行 JavaScript 即可讀取所有匯差數字。
 
-### 6. 這個網站使用哪些結構化資料讓搜尋摘要顯示更豐富？
+### 6. 這個網站使用哪些結構化資料幫助搜尋引擎與 AI 系統理解內容？
 
-目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、HowTo（使用步驟）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、FinancialService（幣別頁金融服務標記）與 ImageObject（分享圖片授權資訊）。FAQ 內容保留為可讀 HTML 區塊，不額外輸出 FAQPage rich result 標記，以避免與目前搜尋引擎支援範圍不符。sitemap.xml 會只收錄公開可索引 URL，並同步 hreflang 與圖片資源資訊。
+目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、HowTo（使用步驟）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、FinancialService（幣別頁金融服務）、ExchangeRateSpecification（全 34 個幣別頁，注入臺灣銀行現金賣出價供 AI 引擎提取具體匯率數字）、FAQPage（全 34 個幣別頁，提供 AI／語音助理快速摘要）、CurrencyConversionService（首頁）與 ImageObject（分享圖片授權）。內容頁（FAQ 頁、About 頁、指南頁）的 FAQ 以可讀 HTML 呈現，不額外重複輸出 FAQPage schema；幣別換算頁則全面啟用 FAQPage JSON-LD，提升 AEO 覆蓋率。Google 是否顯示 rich result 仍取決於頁面類型與搜尋引擎支援範圍，本站對金融頁 FAQPage 的定位以機器理解與 AI 摘要為主。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。
 
 ### 7. HaoRate 是否支援 AI 搜尋引擎與 LLM 引用？
 
-robots.txt 明確允許 18 種 AI 爬蟲（GPTBot、ClaudeBot、PerplexityBot、Google-Extended、GrokBot、Applebot-Extended 等）全站讀取；另提供 llms.txt 與 llms-full.txt 供大型語言模型快速理解站點架構，openapi.json 供 AI Agent 呼叫即時匯率 API。FAQ 文案中的匯差數字採雙幣標示（外幣 + 台幣），針對 LLM 引用語意設計，確保 AI 回答換匯問題時能引用精確數字而非中間價。
+robots.txt 明確允許多種主流 AI 爬蟲（GPTBot、ClaudeBot、PerplexityBot、Google-Extended、GrokBot、Applebot-Extended 等）全站讀取；另提供 llms.txt 與 llms-full.txt 供大型語言模型快速理解站點架構，openapi.json 供 AI Agent 呼叫即時匯率 API。FAQ 文案中的匯差數字採雙幣標示（外幣 + 台幣），針對 LLM 引用語意設計，確保 AI 回答換匯問題時能引用精確數字而非中間價。
 
 ---
 

--- a/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ABOUT_PAGE_FAQ,
   ABOUT_PAGE_SEO,
   APP_ONLY_PAGE_SEO,
   CARD_RATE_GUIDE_PAGE,
@@ -412,6 +413,61 @@ describe('SEO SSOT', () => {
     it('APP_ONLY_PAGE_SEO.seoTech robots 應為 index, follow（可索引頁面，不應含 noindex）', () => {
       expect(APP_ONLY_PAGE_SEO.seoTech.robots).toMatch(/^index/);
       expect(APP_ONLY_PAGE_SEO.seoTech.robots).not.toContain('noindex');
+    });
+  });
+
+  // ─── ABOUT_PAGE_FAQ AI 爬蟲說明準確性 ────────────────────────────────────────
+  // AI crawler 清單持續擴充，FAQ 不應硬編碼數量。
+  describe('ABOUT_PAGE_FAQ AI 爬蟲支援說明準確性', () => {
+    const aiAnswer = ABOUT_PAGE_FAQ.find((q) => q.question.includes('AI 搜尋引擎'));
+
+    it('應存在「AI 搜尋引擎」相關問答', () => {
+      expect(aiAnswer).toBeDefined();
+    });
+
+    it('答案不應硬編碼 AI 爬蟲數量', () => {
+      // 具體數字容易隨 robots.txt SSOT 漂移。
+      expect(aiAnswer!.answer).not.toMatch(/\d+\s*種(?:以上)?主流?\s*AI\s*爬蟲/);
+    });
+
+    it('答案應明確表達支援多種主流 AI 爬蟲', () => {
+      expect(aiAnswer!.answer).toContain('多種主流 AI 爬蟲');
+    });
+
+    it('答案應涵蓋 GPTBot、ClaudeBot、PerplexityBot 等主要 AI 爬蟲名稱', () => {
+      expect(aiAnswer!.answer).toContain('GPTBot');
+      expect(aiAnswer!.answer).toContain('ClaudeBot');
+      expect(aiAnswer!.answer).toContain('PerplexityBot');
+    });
+  });
+
+  // ─── ABOUT_PAGE_FAQ 結構化資料說明準確性 ──────────────────────────────────────
+  // 幣別頁（全 34 頁）實際部署 FAQPage 與 ExchangeRateSpecification JSON-LD。
+  // ABOUT_PAGE_FAQ 必須反映現況，避免 AI 引擎引用到過時資訊。
+  describe('ABOUT_PAGE_FAQ 結構化資料說明準確性', () => {
+    const schemaAnswer = ABOUT_PAGE_FAQ.find((q) => q.question.includes('結構化資料'));
+
+    it('應存在「結構化資料」相關問答', () => {
+      expect(schemaAnswer).toBeDefined();
+    });
+
+    it('答案應明確提及 FAQPage（幣別頁全面啟用，不應聲稱「不輸出」）', () => {
+      // 34 個幣別頁（17 正向 + 17 反向）均透過 buildFaqPageJsonLd() 輸出 FAQPage JSON-LD。
+      // 若 AI 引擎引用此 FAQ 答案，不得誤導使用者認為站內無 FAQPage schema。
+      expect(schemaAnswer!.answer).toContain('FAQPage');
+    });
+
+    it('答案不得聲稱「不額外輸出 FAQPage」（與實際幣別頁部署矛盾）', () => {
+      expect(schemaAnswer!.answer).not.toContain('不額外輸出 FAQPage');
+    });
+
+    it('答案應明確提及 ExchangeRateSpecification（幣別頁核心 YMYL schema）', () => {
+      // 每個幣對頁注入即時匯率，ExchangeRateSpecification 是金融頁面的關鍵信號。
+      expect(schemaAnswer!.answer).toContain('ExchangeRateSpecification');
+    });
+
+    it('答案不應把金融頁 FAQPage 描述成保證取得 rich result', () => {
+      expect(schemaAnswer!.answer).toContain('機器理解與 AI 摘要');
     });
   });
 });

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -785,9 +785,10 @@ export function buildAlternativeProviderFaq(
 
 /**
  * 將 FAQEntry 陣列轉換為 schema.org FAQPage JSON-LD 格式。
- * 僅對高流量幣別啟用（USD / JPY / KRW / EUR / HKD），用於 AI/AEO 引擎（ChatGPT、Perplexity、語音助理）。
- * 注意：Google 自 2023 年 9 月起不再為金融/醫療等 YMYL 頁面顯示 FAQ Rich Results，
- *       但結構化資料仍有助於 AI 理解與摘要。
+ * 全 34 個幣別頁（17 正向 xxx-twd + 17 反向 twd-xxx）均啟用，
+ * 用於 AI/AEO 引擎（ChatGPT、Perplexity、語音助理）快速摘要。
+ * 注意：Google FAQ rich result 目前主要限於政府與醫療權威站，
+ *       金融頁 FAQPage 應以機器可理解性與 AI 摘要為主要目標。
  * @param faqEntries FAQ 條目列表
  * @param maxItems 最多取幾則（預設 5，避免 schema 過長）
  */
@@ -1316,13 +1317,13 @@ export const ABOUT_PAGE_FAQ = [
       '匯差範例數據由 GitHub Actions 每日自動執行：同時抓取台灣銀行牌告匯率與 open.er-api.com 市場中間價（Google、XE、Wise、Apple 計算機的共同基準），進行雙重驗證（兩個中間價差距須在 2% 以內），生成靜態 TypeScript 常數，透過 Pull Request 自動審核後進入主分支。最終數字直接嵌入靜態 HTML（vite-react-ssg SSG 預渲染），Google 爬蟲無需執行 JavaScript 即可讀取所有匯差數字。',
   },
   {
-    question: '這個網站使用哪些結構化資料讓搜尋摘要顯示更豐富？',
-    answer: `目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、HowTo（使用步驟）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、FinancialService（幣別頁金融服務標記）與 ImageObject（分享圖片授權資訊）。FAQ 內容保留為可讀 HTML 區塊，不額外輸出 FAQPage rich result 標記，以避免與目前搜尋引擎支援範圍不符。sitemap.xml 會只收錄公開可索引 URL，並同步 hreflang 與圖片資源資訊。`,
+    question: '這個網站使用哪些結構化資料幫助搜尋引擎與 AI 系統理解內容？',
+    answer: `目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、HowTo（使用步驟）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、FinancialService（幣別頁金融服務）、ExchangeRateSpecification（全 34 個幣別頁，注入臺灣銀行現金賣出價供 AI 引擎提取具體匯率數字）、FAQPage（全 34 個幣別頁，提供 AI／語音助理快速摘要）、CurrencyConversionService（首頁）與 ImageObject（分享圖片授權）。內容頁（FAQ 頁、About 頁、指南頁）的 FAQ 以可讀 HTML 呈現，不額外重複輸出 FAQPage schema；幣別換算頁則全面啟用 FAQPage JSON-LD，提升 AEO 覆蓋率。Google 是否顯示 rich result 仍取決於頁面類型與搜尋引擎支援範圍，本站對金融頁 FAQPage 的定位以機器理解與 AI 摘要為主。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。`,
   },
   {
     question: `${APP_INFO.shortName} 是否支援 AI 搜尋引擎與 LLM 引用？`,
     answer:
-      'robots.txt 明確允許 18 種 AI 爬蟲（GPTBot、ClaudeBot、PerplexityBot、Google-Extended、GrokBot、Applebot-Extended 等）全站讀取；另提供 llms.txt 與 llms-full.txt 供大型語言模型快速理解站點架構，openapi.json 供 AI Agent 呼叫即時匯率 API。FAQ 文案中的匯差數字採雙幣標示（外幣 + 台幣），針對 LLM 引用語意設計，確保 AI 回答換匯問題時能引用精確數字而非中間價。',
+      'robots.txt 明確允許多種主流 AI 爬蟲（GPTBot、ClaudeBot、PerplexityBot、Google-Extended、GrokBot、Applebot-Extended 等）全站讀取；另提供 llms.txt 與 llms-full.txt 供大型語言模型快速理解站點架構，openapi.json 供 AI Agent 呼叫即時匯率 API。FAQ 文案中的匯差數字採雙幣標示（外幣 + 台幣），針對 LLM 引用語意設計，確保 AI 回答換匯問題時能引用精確數字而非中間價。',
   },
 ] as const satisfies readonly FAQEntry[];
 
@@ -1770,7 +1771,7 @@ export const APP_ONLY_PAGE_SEO = {
           '搜尋可見性',
           `${APP_INFO.shortName} 技術架構`,
         ],
-        articleBody: `${APP_INFO.shortName} 採用現代化 SEO 最佳實踐，包括預先渲染靜態 HTML（SSG）以提升首頁效能與可爬性、完整的 JSON-LD Schema 標記（包括 Article、Organization、BreadcrumbList、FAQPage、SoftwareApplication 等 8 種類型）以強化搜尋結果展示、優化的網站結構（${SEO_PATHS.length} 個索引路徑與 ${PRERENDER_PATHS.length} 個預渲染頁面）、自動化資料管線（每 5 分鐘從台灣銀行同步即時匯率）、與 PWA 離線支援以確保使用者體驗。技術實現包括使用 Vite + React 進行高效打包、Tailwind CSS 的原子類樣式、Workbox 的靜態資源快取策略、Cloudflare Worker 的邊緣安全標頭注入，以及搜尋可見性的完整監測與驗證流程。`,
+        articleBody: `${APP_INFO.shortName} 採用現代化 SEO 最佳實踐，包括預先渲染靜態 HTML（SSG）以提升首頁效能與可爬性、完整的 JSON-LD Schema 標記（涵蓋 Article、Organization、BreadcrumbList、FAQPage、SoftwareApplication 等多種類型）以強化搜尋引擎與 AI 系統的內容理解、優化的網站結構（${SEO_PATHS.length} 個索引路徑與 ${PRERENDER_PATHS.length} 個預渲染頁面）、自動化資料管線（每 5 分鐘從台灣銀行同步即時匯率）、與 PWA 離線支援以確保使用者體驗。技術實現包括使用 Vite + React 進行高效打包、Tailwind CSS 的原子類樣式、Workbox 的靜態資源快取策略、Cloudflare Worker 的邊緣安全標頭注入，以及搜尋可見性的完整監測與驗證流程。`,
       },
     ),
   },
@@ -2548,7 +2549,7 @@ export function getCurrencyLandingPageContent(
     },
   };
 
-  // 全幣別啟用 FAQPage JSON-LD，提升 AI/AEO 引擎覆蓋率與 Rich Result 曝光機會。
+  // 全幣別啟用 FAQPage JSON-LD，強化機器可理解性與 AI 摘要覆蓋。
 
   const faqEntries: FAQEntry[] = [
     {
@@ -2890,7 +2891,7 @@ export function getReverseCurrencyLandingPageContent(
         `台幣換${displayName}匯率分享圖片`,
         `${APP_INFO.name} TWD/${code} 出國換匯即時計算`,
       ),
-      // 全幣別啟用 FAQPage JSON-LD，提升 AI/AEO 引擎覆蓋率與 Rich Result 曝光機會。
+      // 全幣別啟用 FAQPage JSON-LD，強化機器可理解性與 AI 摘要覆蓋。
       buildFaqPageJsonLd(faqEntries),
       // ExchangeRateSpecification：注入即時匯率，讓 AI 引擎可提取並顯示具體數字。
       // 反向頁（TWD→外幣）：currency 為 TWD，priceCurrency 為外幣代碼。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,60 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-10T15:30:00+08:00
-> **當前總分**: 1207（初始分: 100）
+> **最後更新**: 2026-04-24T16:06:37+08:00
+> **當前總分**: 1208（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: ratewise-about-faq-seo-truthfulness-refresh
+date: 2026-04-24
+title: 收斂 About FAQ 的 schema 與 AI crawler 說法，避免過時數字與 rich result 誤導
+score: +1
+type: improvement
+content_type: seo
+scope: ratewise, about, faq
+topics: [seo, faq, schema, ai-search, content-truthfulness]
+keywords:
+[about-page-faq, faqpage, exchangeratespecification, ai-crawlers, rich-result, truthfulness]
+aliases: [About FAQ SEO truthfulness refresh, FAQPage 語意校正]
+related_entries:
+[ratewise-seo-title-truthfulness-lastmod-tdd, ci-data-branch-post-push-refresh-hardening]
+summary: About 頁 FAQ 近期已更新為反映目前的 FAQPage、ExchangeRateSpecification 與 AI crawler 支援現況，但內容仍殘留兩個不穩定訊號：一是 AI crawler 數量若以固定數字描述，之後隨 robots.txt SSOT 擴充容易再次過時；二是金融頁 FAQPage 若被描述成以 rich result 為主要目標，會與 Google 現行 FAQ rich result 範圍產生語意偏差。本次將文案與守門測試一起收斂為「實際部署 + 不脆弱措辭 + 機器理解優先」三原則。
+root_cause:
+
+- `ABOUT_PAGE_FAQ` 先前的 AI 搜尋引擎答案使用固定數量描述 AI crawler，容易在 `robots.txt` / `llms.txt` SSOT 擴充後再次失真。
+- 結構化資料答案與內部註解雖已回到 FAQPage 實際有輸出的現況，但部分措辭仍容易被解讀為金融頁 FAQPage 以 Google rich result 為主要預期。
+- `seo-ssot.test.ts` 缺少對「避免硬編碼 bot 數量」與「金融頁 FAQPage 應以機器理解為主」的回歸守門。
+  impact:
+
+- About 頁屬於 SEO 透明度頁面，若文案再次落後於實際部署，AI 引擎與人工 reviewer 都可能引用到過時資訊。
+- 若把金融頁 FAQPage 說成 rich result 導向，會弱化內容真實性，並增加後續 SEO 審查的爭議成本。
+  actions:
+
+- 將 `ABOUT_PAGE_FAQ` 的 AI crawler 敘述改為「多種主流 AI 爬蟲」，保留 GPTBot、ClaudeBot、PerplexityBot 等代表名稱，不再硬編碼數量。
+- 將結構化資料問答改寫為「幫助搜尋引擎與 AI 系統理解內容」，並明確補上金融頁 FAQPage 以機器理解與 AI 摘要為主要定位。
+- 更新 `buildFaqPageJsonLd()` 與幣別頁註解，移除不精確的 Rich Result 曝光描述。
+- 同步收斂 `public/about.md` Markdown 鏡像，避免公開產物與 `seo-metadata.ts` 文字不同步。
+- 在 `seo-ssot.test.ts` 新增守門：禁止硬編碼 AI crawler 數量、要求保留主要 crawler 名稱、要求結構化資料答案提及 FAQPage / ExchangeRateSpecification 與機器理解定位。
+  prevention:
+
+- About / FAQ / Guide 這類透明度內容若提及 bot 數量、schema 支援範圍或 rich result，應優先使用不易漂移的敘述，必要時回指 SSOT，而不是手寫固定數字。
+- SEO 透明度文案每次調整後，應同步補對應的 truthfulness / SSOT 測試，避免只改內容不加守門。
+- 金融頁 FAQPage 的對外說法應固定為「幫助搜尋引擎與 AI 系統理解內容」，不得把 rich result 視為既定結果。
+  verification:
+
+- `pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-ssot.test.ts`
+- `pnpm --filter @app/ratewise test -- --run src/seo-best-practices.test.ts src/seo-truthfulness.test.ts src/config/__tests__/seo-faq-quality.test.ts`
+- `pnpm --filter @app/ratewise typecheck`
+- `pnpm exec prettier --check apps/ratewise/src/config/seo-metadata.ts apps/ratewise/src/config/__tests__/seo-ssot.test.ts`
+  references:
+
+- apps/ratewise/src/config/seo-metadata.ts
+- apps/ratewise/public/about.md
+- apps/ratewise/src/config/**tests**/seo-ssot.test.ts
+- https://developers.google.com/search/docs/appearance/structured-data/faqpage
+- https://developers.google.com/search/blog/2023/08/howto-faq-changes
+- https://developers.google.com/search/docs/appearance/structured-data/sd-policies
 
 ---
 


### PR DESCRIPTION
## 摘要
- 收斂 About FAQ 的結構化資料與 AI crawler 敘述，移除容易過時的固定數量說法
- 將金融頁 FAQPage 的對外語意校正為機器理解與 AI 摘要導向
- 補上 SEO SSOT 守門測試與 patch changeset

## 驗證
- pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-ssot.test.ts
- pnpm --filter @app/ratewise test -- --run src/seo-best-practices.test.ts src/seo-truthfulness.test.ts src/config/__tests__/seo-faq-quality.test.ts
- pnpm --filter @app/ratewise typecheck
- pnpm exec prettier --check apps/ratewise/src/config/seo-metadata.ts apps/ratewise/src/config/__tests__/seo-ssot.test.ts
- pre-commit
- pre-push