### PR TITLE
fix(ci): 修復 Security Scan 的 sitemap lastmod 誤判

### DIFF
--- a/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { CONTENT_LASTMOD_POLICY, RATE_PAGE_LASTMOD_POLICY } from '../seo-lastmod-policy';
+// @ts-expect-error 直接驗證 root sitemap script 的 fallback 行為。
+import { getFallbackLastModDate } from '../../../../../scripts/generate-sitemap-2025.mjs';
 
 describe('seo lastmod policy', () => {
   it('應為 /seo-tech/ 定義公開揭露頁的 content lastmod policy', () => {
@@ -24,5 +26,10 @@ describe('seo lastmod policy', () => {
     expect(CONTENT_LASTMOD_POLICY['/sell-rate-vs-mid-rate/'].fallbackDate).toBe('2026-04-20');
     expect(CONTENT_LASTMOD_POLICY['/cash-vs-spot-rate/'].fallbackDate).toBe('2026-04-20');
     expect(CONTENT_LASTMOD_POLICY['/card-rate-guide/'].fallbackDate).toBe('2026-04-20');
+  });
+
+  it('幣別頁與金額頁 fallback 應採用可驗證的匯率內容日期', () => {
+    expect(getFallbackLastModDate('/usd-twd/')?.toISOString().slice(0, 10)).toBe('2026-04-25');
+    expect(getFallbackLastModDate('/usd-twd/100/')?.toISOString().slice(0, 10)).toBe('2026-04-25');
   });
 });

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,53 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-27T01:13:00+08:00
-> **當前總分**: 1217（初始分: 100）
+> **最後更新**: 2026-04-27T02:56:05+08:00
+> **當前總分**: 1218（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: cicd-security-scan-lastmod-fallback-fix
+date: 2026-04-27
+title: 修復 Security Scan 在 Docker build 內因缺 git 歷史誤觸發 sitemap lastmod gate
+score: +1
+type: fix
+content_type: ci
+scope: ci, docker, sitemap, ratewise
+topics: [github-actions, docker-build, sitemap-lastmod, security-scan, ratewise]
+keywords:
+[security-scan, docker-build, shallow-history, lastmod-diversity, semantic-fallback]
+aliases: [Security Scan lastmod fallback fix, Docker build sitemap gate 修復]
+related_entries:
+[ratewise-sitemap-lastmod-policy, ratewise-seo-prepush-truthfulness-gate-fix]
+summary: 最近 `main` 上多個 CI run 不是壞在 Trivy 本身，而是 `Security Scan` 先用 root `Dockerfile` 建 image 時，容器內缺少完整 git 歷史，讓 `generate-sitemap-2025.mjs` 對 rate pages 退回到不具語義的單日時間戳，最後被 `lastmod` 多樣性 gate 擋下。本次改為在 git commit 日期不可得時，優先使用 content policy fallback 與 `seo-rate-examples.ts` 內可驗證的匯率日期，避免安全掃描因 SEO 驗證前置條件不足而誤 fail。
+root_cause:
+
+- `Security Scan` 的 Docker build context 受 `.dockerignore` 控制，不保證攜帶可用的 git 歷史。
+- 舊版 `generate-sitemap-2025.mjs` 在拿不到 git commit 日期後，對匯率頁仍回退到 checkout mtime，導致容器內 249 個 URL 很容易壓成同一天。
+- `lastmod` 多樣性 gate 本意是保護 SEO 真實性，但在缺歷史的非正式部署場景中，少了語義化 fallback 就會誤判。
+  impact:
+
+- `CI` workflow 的 `Security Scan` job 在 `Build Docker image for scan` 階段失敗，即使 `Quality Checks`、`E2E Tests`、`Lighthouse CI` 都已通過，整體 `CI` 仍為紅燈。
+- 合併到 `main` 的 PR 會看起來像部署失敗，實際上是容器內 sitemap gate 無法取得可驗證日期來源。
+  actions:
+
+- 在 `scripts/generate-sitemap-2025.mjs` 新增 rate content fallback 解析：優先讀取 `seo-rate-examples.ts` 的 `匯率時間`，其次使用 `生成日期`。
+- 將 sitemap generator 的語義 fallback 順序改為：git commit 日期 → policy / rate content fallback → 檔案 mtime。
+- 在 `seo-lastmod-policy.test.ts` 補上對 `/usd-twd/` 與金額頁 fallback 日期的直接測試，鎖住容器 / 無 git 歷史場景。
+  prevention:
+
+- 任何依賴 git history 的 SEO / build 驗證，都必須有「無 git 歷史」時的可驗證 fallback，不能退回 current time 或 checkout mtime 當作真實內容日期。
+- 安全掃描 workflow 若只為建 image 掃描，不能被與正式部署等級相同、但前置條件不同的時間戳來源假設誤擋。
+  verification:
+
+- `pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-lastmod-policy.test.ts`
+- `pnpm build:ratewise`
+- GitHub Actions `CI` / `Security Scan`
+  references:
+
+- scripts/generate-sitemap-2025.mjs
+- apps/ratewise/src/config/**tests**/seo-lastmod-policy.test.ts
+- apps/ratewise/src/config/generated/seo-rate-examples.ts
 
 ---
 

--- a/scripts/generate-sitemap-2025.mjs
+++ b/scripts/generate-sitemap-2025.mjs
@@ -19,7 +19,7 @@
  * BDD 階段: Stage 2 GREEN (實作階段)
  */
 
-import { statSync, writeFileSync, existsSync } from 'fs';
+import { statSync, writeFileSync, existsSync, readFileSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
@@ -69,6 +69,7 @@ const IS_SHALLOW_REPOSITORY = (() => {
   });
   return result.status === 0 && result.stdout.trim() === 'true';
 })();
+let cachedRatePageFallbackDate = undefined;
 
 /**
  * 每個公開 URL 對應一組「重大內容依賴」。
@@ -302,6 +303,9 @@ function getLastModDate(path) {
   );
   if (gitDate) return gitDate;
 
+  const semanticFallbackDate = getFallbackLastModDate(path);
+  if (semanticFallbackDate) return semanticFallbackDate;
+
   const mtimes = existingFiles.map((file) => statSync(resolve(REPO_ROOT, file)).mtime.getTime());
   return new Date(Math.max(...mtimes));
 }
@@ -319,6 +323,38 @@ function getGitCommitDate(files) {
 
   const gitDate = new Date(gitTimestamp);
   return Number.isNaN(gitDate.getTime()) ? null : gitDate;
+}
+
+function parseDateInTaipei(dateText) {
+  if (!dateText) return null;
+  const normalized = dateText.replace(/\//g, '-');
+  const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  return new Date(`${year}-${month}-${day}T00:00:00.000Z`);
+}
+
+function getRatePageFallbackDate() {
+  if (cachedRatePageFallbackDate !== undefined) {
+    return cachedRatePageFallbackDate;
+  }
+
+  const rateSourcePath = resolve(REPO_ROOT, RATE_PAGE_LASTMOD_POLICY.source);
+  if (!existsSync(rateSourcePath)) {
+    cachedRatePageFallbackDate = null;
+    return cachedRatePageFallbackDate;
+  }
+
+  const sourceContent = readFileSync(rateSourcePath, 'utf-8');
+  const rateTimestampMatch = sourceContent.match(/匯率時間：(\d{4}\/\d{2}\/\d{2})/);
+  const generatedDateMatch = sourceContent.match(/生成日期：(\d{4}-\d{2}-\d{2})/);
+
+  cachedRatePageFallbackDate =
+    parseDateInTaipei(rateTimestampMatch?.[1] ?? '') ??
+    parseDateInTaipei(generatedDateMatch?.[1] ?? '') ??
+    null;
+
+  return cachedRatePageFallbackDate;
 }
 
 function resolveLookupPath(path) {
@@ -355,10 +391,10 @@ function getFallbackLastModDate(path) {
   const lookupPath = resolveLookupPath(path);
   const policyFallback = CONTENT_LASTMOD_POLICY[lookupPath]?.fallbackDate;
   if (policyFallback) return new Date(`${policyFallback}T00:00:00.000Z`);
-  if (isRateContentPath(path) && RATE_PAGE_LASTMOD_POLICY.fallbackDate) {
-    return new Date(`${RATE_PAGE_LASTMOD_POLICY.fallbackDate}T00:00:00.000Z`);
+  if (isRateContentPath(path)) {
+    return getRatePageFallbackDate();
   }
-  return new Date();
+  return null;
 }
 
 function hasStableFallbackLastMod(path) {
@@ -366,7 +402,7 @@ function hasStableFallbackLastMod(path) {
   if (CONTENT_LASTMOD_POLICY[lookupPath]?.fallbackDate) {
     return true;
   }
-  return isRateContentPath(path) && Boolean(RATE_PAGE_LASTMOD_POLICY.fallbackDate);
+  return isRateContentPath(path) && Boolean(getRatePageFallbackDate());
 }
 
 /**


### PR DESCRIPTION
## 摘要
- 修正 Docker build 缺少 git 歷史時，RateWise sitemap lastmod fallback 仍誤觸發多樣性 gate
- 對 rate pages 改用 seo-rate-examples 內可驗證日期作為 semantic fallback
- 修正 fallback date 的 UTC off-by-one 問題並補測試

## 根因
- CI 的 Security Scan 會在 Docker build 內執行 `pnpm build:ratewise`
- Docker build context 不含 `.git`，sitemap generator 無法可靠取得 git commit 日期
- 先前 fallback 會讓大量 URL 收斂成同一天，導致 `時間戳多樣性不足（<3個不同日期）`

## 官方依據
- GitHub Actions checkout: `fetch-depth: 0` 只影響 runner 工作目錄，不會改變 `.dockerignore` 排除 `.git` 後的 Docker build context
- Docker `.dockerignore`：被排除的檔案不會進入 build context
- Google Search Central：`lastmod` 應反映可驗證的重要更新，不應用不可驗證的假新鮮時間戳

## 驗證
- `pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-lastmod-policy.test.ts`
- `pnpm build:ratewise`
- `pre-push`（typecheck / test / build:ratewise）
