### PR TITLE
test(ratewise): 補齊 SEO truthfulness 與 public surface regression gates

### DIFF
--- a/.changeset/seo-audit-n1-n2-n3-fix.md
+++ b/.changeset/seo-audit-n1-n2-n3-fix.md
@@ -1,0 +1,9 @@
+---
+'@app/ratewise': patch
+---
+
+修復 2026-04-27 Live SEO 稽核發現的三個問題（N1 CDN 快取、N2 description 截斷、N3 H1/H2 重複）
+
+- N2：縮短 34 幣對頁 meta description 模板（最差情況 ≤57 全形字，符合 Google SERP 65 字上限）；保留「台銀現金賣出價（非中間價）」核心差異化訊息
+- N3：`HomepageContent` 新增 `sectionHeading` 欄位，首頁卡片 H2 改用 `'台銀牌告實際買賣價，換匯不必猜'`，消除與 sr-only H1 的文字重複
+- N1（Worker）：security-headers v4.9 新增 `CDN-Cache-Control / Cloudflare-CDN-Cache-Control: max-age=300, stale-while-revalidate=3600`（僅 ratewise HTML profile），預期 TTFB 從 438ms 降至 ~50ms（edge 命中）

--- a/apps/ratewise/package.json
+++ b/apps/ratewise/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "test": "vitest",
+    "test:seo-surface": "vitest run src/__tests__/seo-public-surface.test.ts",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/apps/ratewise/src/__tests__/seo-public-surface.test.ts
+++ b/apps/ratewise/src/__tests__/seo-public-surface.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Public SEO surface regression suite
+ *
+ * 目標：集中驗證公開可見輸出，避免 route 順序、sitemap 與公開揭露頁再次漂移。
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { APP_INFO } from '../config/app-info';
+import { SEO_PATHS, PRERENDER_PATHS } from '../config/seo-paths';
+import { getCurrencyLandingPageContent } from '../config/seo-metadata';
+import { SEO_SCHEMA_REGISTRY } from '../config/seo-schema-registry';
+
+const appRoot = resolve(__dirname, '../..');
+const distRoot = resolve(appRoot, 'dist');
+const sitemapPath = resolve(appRoot, 'public/sitemap.xml');
+
+const readDistHtml = (path: string): string => {
+  const htmlPath = resolve(
+    distRoot,
+    path === '/' ? 'index.html' : `${path.replace(/^\/+/, '')}index.html`,
+  );
+
+  if (!existsSync(htmlPath)) {
+    throw new Error(`prerender route html missing: ${htmlPath}`);
+  }
+
+  return readFileSync(htmlPath, 'utf-8');
+};
+
+const extractVisibleText = (html: string): string =>
+  html
+    .replace(/<script[\s\S]*?<\/script>/g, ' ')
+    .replace(/<style[\s\S]*?<\/style>/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const textBefore = (text: string, marker: string): string => {
+  const index = text.indexOf(marker);
+  return index >= 0 ? text.slice(0, index) : text;
+};
+
+beforeAll(() => {
+  const indexHtml = resolve(distRoot, 'index.html');
+  if (!existsSync(indexHtml)) {
+    throw new Error(
+      'prerender dist is missing. please run pnpm --filter @app/ratewise build before this test.',
+    );
+  }
+
+  if (!existsSync(sitemapPath)) {
+    throw new Error(`sitemap missing: ${sitemapPath}`);
+  }
+});
+
+describe('SEO public surface regression suite', () => {
+  it.each([
+    { path: '/', h1: `${APP_INFO.name} 即時匯率換算` },
+    { path: '/about/', h1: `關於 ${APP_INFO.name}` },
+    {
+      path: '/usd-twd/',
+      h1: `${getCurrencyLandingPageContent('USD').currencyName}對台幣匯率換算器`,
+    },
+    { path: '/seo-tech/', h1: `${APP_INFO.shortName} SEO 架構` },
+  ])('%s route H1 應早於 fallback 與通用殼層文案', ({ path, h1 }) => {
+    const text = extractVisibleText(readDistHtml(path));
+    const prefix = textBefore(text, h1);
+
+    expect(text).toContain(h1);
+    expect(prefix).not.toContain('載入匯率資料中...');
+    expect(prefix).not.toContain('主要功能');
+    expect(prefix).not.toContain('Exchange Rate Tool');
+    expect(prefix).not.toContain('Built with React');
+    expect(prefix).not.toContain('©');
+  });
+
+  it('/seo-tech/ 應揭露當前 SSOT，而非舊 sitemap / schema 說法', () => {
+    const text = extractVisibleText(readDistHtml('/seo-tech/'));
+
+    expect(text).toContain(String(SEO_PATHS.length));
+    expect(text).toContain(String(PRERENDER_PATHS.length));
+    expect(text).toContain(String(SEO_SCHEMA_REGISTRY.filter((schema) => schema.enabled).length));
+    expect(text).toContain('generate-sitemap-2025.mjs');
+    expect(text).not.toContain('248 個 SEO URL');
+    expect(text).not.toContain('priority 欄位');
+    expect(text).not.toContain('FinancialService');
+  });
+
+  it('sitemap.xml 不得回歸輸出 priority / changefreq', () => {
+    const sitemap = readFileSync(sitemapPath, 'utf-8');
+
+    expect(sitemap).toContain('<lastmod>');
+    expect(sitemap).not.toContain('<priority>');
+    expect(sitemap).not.toContain('<changefreq>');
+  });
+});

--- a/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CONTENT_LASTMOD_POLICY, RATE_PAGE_LASTMOD_POLICY } from '../seo-lastmod-policy';
+import { SEO_RATE_EXAMPLES_DATE } from '../generated/seo-rate-examples';
 // @ts-expect-error 直接驗證 root sitemap script 的 fallback 行為。
 import { getFallbackLastModDate } from '../../../../../scripts/generate-sitemap-2025.mjs';
 
@@ -29,7 +30,11 @@ describe('seo lastmod policy', () => {
   });
 
   it('幣別頁與金額頁 fallback 應採用可驗證的匯率內容日期', () => {
-    expect(getFallbackLastModDate('/usd-twd/')?.toISOString().slice(0, 10)).toBe('2026-04-25');
-    expect(getFallbackLastModDate('/usd-twd/100/')?.toISOString().slice(0, 10)).toBe('2026-04-25');
+    expect(getFallbackLastModDate('/usd-twd/')?.toISOString().slice(0, 10)).toBe(
+      SEO_RATE_EXAMPLES_DATE,
+    );
+    expect(getFallbackLastModDate('/usd-twd/100/')?.toISOString().slice(0, 10)).toBe(
+      SEO_RATE_EXAMPLES_DATE,
+    );
   });
 });

--- a/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { CONTENT_LASTMOD_POLICY, RATE_PAGE_LASTMOD_POLICY } from '../seo-lastmod-policy';
 import { SEO_RATE_EXAMPLES_DATE } from '../generated/seo-rate-examples';
 // @ts-expect-error 直接驗證 root sitemap script 的 fallback 行為。
 import { getFallbackLastModDate } from '../../../../../scripts/generate-sitemap-2025.mjs';
+
+const repoRoot = resolve(process.cwd(), '../..');
+const rateSourcePath = resolve(repoRoot, RATE_PAGE_LASTMOD_POLICY.source);
+const sourceContent = readFileSync(rateSourcePath, 'utf-8');
+const rateTimestampMatch = /匯率時間：(\d{4})\/(\d{2})\/(\d{2})/.exec(sourceContent);
+const expectedRateFallbackDate = rateTimestampMatch
+  ? `${rateTimestampMatch[1]}-${rateTimestampMatch[2]}-${rateTimestampMatch[3]}`
+  : SEO_RATE_EXAMPLES_DATE;
 
 describe('seo lastmod policy', () => {
   it('應為 /seo-tech/ 定義公開揭露頁的 content lastmod policy', () => {
@@ -31,10 +41,10 @@ describe('seo lastmod policy', () => {
 
   it('幣別頁與金額頁 fallback 應採用可驗證的匯率內容日期', () => {
     expect(getFallbackLastModDate('/usd-twd/')?.toISOString().slice(0, 10)).toBe(
-      SEO_RATE_EXAMPLES_DATE,
+      expectedRateFallbackDate,
     );
     expect(getFallbackLastModDate('/usd-twd/100/')?.toISOString().slice(0, 10)).toBe(
-      SEO_RATE_EXAMPLES_DATE,
+      expectedRateFallbackDate,
     );
   });
 });

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -6,6 +6,48 @@
 
 ---
 
+id: ratewise-lastmod-fallback-test-precedence
+date: 2026-04-27
+title: 補強 lastmod fallback 測試，明確驗證匯率時間優先於生成日期
+score: +1
+type: fix
+content_type: test
+scope: ratewise, seo, sitemap, lastmod
+topics: [ratewise, seo, sitemap-lastmod, fallback-precedence, vitest]
+keywords:
+[rate-timestamp, generated-date, fallback-order, seo-rate-examples, lastmod]
+aliases: [Lastmod fallback 優先序測試, 匯率時間優先規則]
+related_entries:
+[ratewise-lastmod-fallback-test-ssot-alignment, ratewise-sitemap-lastmod-policy]
+summary: 第一輪把硬編日期改為 `SEO_RATE_EXAMPLES_DATE` 後，進一步驗證時發現 sitemap generator 的真實規則不是直接使用生成日期，而是優先解析 `seo-rate-examples.ts` 檔頭內的「匯率時間」，只有抓不到時才退回 `SEO_RATE_EXAMPLES_DATE`。本次將測試同步升級為驗證這個優先序，確保測試對齊 generator 的實際 fallback 邏輯，而不是對齊某個較弱的近似值。
+root_cause:
+
+- `generate-sitemap-2025.mjs` 的 `getRatePageFallbackDate()` 先讀 `匯率時間`，再讀 `生成日期`。
+- 前一輪修補只把測試從硬編常數換成 `SEO_RATE_EXAMPLES_DATE`，仍少了一層對 fallback precedence 的理解。
+  impact:
+
+- 當匯率時間與生成日期跨日時，測試仍會產生假陰性。
+- 使 `lastmod` policy regression 判讀不穩定，降低測試對真規則的保護力。
+  actions:
+
+- 在 `seo-lastmod-policy.test.ts` 直接從 `RATE_PAGE_LASTMOD_POLICY.source` 讀取檔頭註記。
+- 若存在 `匯率時間`，以其日期作為預期值；否則退回 `SEO_RATE_EXAMPLES_DATE`。
+  prevention:
+
+- 測試若要驗證 fallback precedence，應直接對齊產生 precedence 的來源格式，不得只驗較表層的導出常數。
+- 任何涉及 build 生成檔頭 metadata 的邏輯，都應考慮跨日與時區差異。
+  verification:
+
+- `pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-lastmod-policy.test.ts`
+- `pnpm --filter @app/ratewise test:seo-surface`
+  references:
+
+- apps/ratewise/src/config/**tests**/seo-lastmod-policy.test.ts
+- apps/ratewise/src/config/generated/seo-rate-examples.ts
+- scripts/generate-sitemap-2025.mjs
+
+---
+
 id: ratewise-seo-public-surface-suite
 date: 2026-04-27
 title: 新增集中式 SEO public surface regression suite，鎖住 route 順序與 sitemap 公開輸出

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -6,6 +6,49 @@
 
 ---
 
+id: ratewise-seo-public-surface-suite
+date: 2026-04-27
+title: 新增集中式 SEO public surface regression suite，鎖住 route 順序與 sitemap 公開輸出
+score: +1
+type: fix
+content_type: test
+scope: ratewise, seo, regression, public-surface
+topics: [ratewise, seo, regression-suite, sitemap, public-surface, prerender]
+keywords:
+[seo-public-surface, route-h1-order, seotech-ssot, sitemap-truthfulness, vitest]
+aliases: [SEO public surface suite, 公開 SEO 表面回歸測試]
+related_entries:
+[ratewise-seotech-ssot-registry-alignment, ratewise-seo-doc-ssot-drift-gate, ratewise-schema-truthfulness-gate]
+summary: 雖然 P0 的修復已分散在多支測試中，但缺少一個能直接回答「公開 SEO 表面現在還乾不乾淨」的單一 regression suite。本次新增 `seo-public-surface.test.ts`，集中驗證 route 專屬 H1 是否早於 fallback、`/seo-tech/` 是否仍對齊當前 SSOT、以及 sitemap 是否重新長回 `priority` / `changefreq`。同步新增 `test:seo-surface` script，讓這組公開表面檢查可被單獨執行。
+root_cause:
+
+- 現有 SEO 測試分散在 route order、schema、truthfulness、best-practices 等檔案，沒有一個集中入口對公開表面做快速回歸。
+- `/seo-tech/`、SSG 首屏順序與 sitemap 標籤都是高可見度 surface，一旦回歸，影響會直接暴露給 Google 與使用者。
+  impact:
+
+- 維護者需要記住多支測試才能確認公開 SEO 輸出是否仍乾淨，容易漏跑。
+- 缺少集中 suite 時，公開表面回歸不容易在本地第一時間被發現。
+  actions:
+
+- 新增 `apps/ratewise/src/__tests__/seo-public-surface.test.ts`。
+- 將 route H1 順序、SeoTech SSOT 揭露與 sitemap `priority/changefreq` 禁止規則收斂進同一 suite。
+- 在 `apps/ratewise/package.json` 新增 `test:seo-surface` script。
+  prevention:
+
+- 之後只要動到 prerender、public disclosure、sitemap 或 head 輸出，可先跑 `pnpm --filter @app/ratewise test:seo-surface` 做快速回歸。
+- 高可見度 SEO surface 的規則應持續用單一 suite 鎖定，而不是只散落在個別單元測試中。
+  verification:
+
+- `pnpm --filter @app/ratewise test -- --run src/__tests__/seo-public-surface.test.ts`
+  references:
+
+- apps/ratewise/src/**tests**/seo-public-surface.test.ts
+- apps/ratewise/package.json
+- apps/ratewise/public/sitemap.xml
+- apps/ratewise/dist/seo-tech/index.html
+
+---
+
 id: ratewise-lastmod-fallback-test-ssot-alignment
 date: 2026-04-27
 title: 將 sitemap lastmod fallback 測試改為依附匯率 SSOT 日期，移除硬編日期回歸

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,49 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-27T02:56:05+08:00
+> **最後更新**: 2026-04-27T21:47:00+08:00
 > **當前總分**: 1218（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: ratewise-lastmod-fallback-test-ssot-alignment
+date: 2026-04-27
+title: 將 sitemap lastmod fallback 測試改為依附匯率 SSOT 日期，移除硬編日期回歸
+score: +1
+type: fix
+content_type: test
+scope: ratewise, seo, sitemap, lastmod
+topics: [ratewise, seo, sitemap-lastmod, ssot, vitest]
+keywords:
+[seo-rate-examples-date, lastmod-fallback, hardcoded-date, regression, ssot-alignment]
+aliases: [RateWise lastmod fallback 測試對齊, sitemap lastmod 日期硬編修復]
+related_entries:
+[ratewise-sitemap-lastmod-policy, cicd-security-scan-lastmod-fallback-fix]
+summary: 驗證 RateWise SEO 修復是否真正完成時，發現 `seo-lastmod-policy.test.ts` 仍將匯率頁 fallback 日期硬寫為 `2026-04-25`，但目前 `seo-rate-examples.ts` 已由 build 生成為 `2026-04-27`，導致 policy 與可驗證資料來源正確、測試卻誤報失敗。本次改為直接引用 `SEO_RATE_EXAMPLES_DATE`，讓測試跟隨 SSOT 的匯率日期來源，而不是跟隨某一次人工快照。
+root_cause:
+
+- `seo-lastmod-policy.test.ts` 將匯率頁 fallback 日期寫死在單一日期字串，沒有依附 `seo-rate-examples.ts` 的生成值。
+- `generate-sitemap-2025.mjs` 的 fallback 行為已改為讀取匯率內容日期，但測試沒有同步從同一來源取值。
+  impact:
+
+- 會在 RateWise SEO regression 驗證時產生假陰性，誤以為 sitemap lastmod policy 已退化。
+- 阻擋後續真實 SEO 修復的驗證節奏，讓測試結果失去判讀價值。
+  actions:
+
+- 在 `apps/ratewise/src/config/__tests__/seo-lastmod-policy.test.ts` 改為引用 `SEO_RATE_EXAMPLES_DATE`。
+- 保留對 `/usd-twd/` 與 `/usd-twd/100/` 的雙路徑斷言，確保幣別頁與金額頁都共用同一 fallback 真相來源。
+  prevention:
+
+- 只要驗證目標是由生成檔或 SSOT 輸出的日期、版本、路徑數，就不得在測試中硬編具時效性的常數。
+- sitemap / schema / README 類 SEO gate 一律優先引用對應 SSOT 常數或生成產物。
+  verification:
+
+- `pnpm --filter @app/ratewise test -- --run src/config/__tests__/seo-lastmod-policy.test.ts`
+  references:
+
+- apps/ratewise/src/config/**tests**/seo-lastmod-policy.test.ts
+- apps/ratewise/src/config/generated/seo-rate-examples.ts
+- scripts/generate-sitemap-2025.mjs
 
 ---
 


### PR DESCRIPTION
## 摘要\n- 對齊 sitemap lastmod 測試與匯率 SSOT 日期來源\n- 新增公開 SEO surface regression suite，鎖住 H1 順序與 SeoTech SSOT 輸出\n- 補強 lastmod fallback 測試，改為驗證匯率時間優先序\n\n## 驗證\n- pnpm --filter @app/ratewise build\n- pnpm --filter @app/ratewise test --run src/config/__tests__/seo-lastmod-policy.test.ts src/__tests__/seo-public-surface.test.ts src/__tests__/seo-surface-order.test.ts src/components/__tests__/CurrencyLandingPage.truthfulness.test.tsx src/pages/__tests__/SeoTech.ssot.test.tsx src/config/__tests__/schema-truthfulness.test.ts src/seo-best-practices.test.ts\n- node apps/ratewise/scripts/verify-doc-ssot-drift.mjs