### PR TITLE
ci(release): 修正發版 tag 卡住

### DIFF
--- a/.changeset/fix-release-tagging-timeout.md
+++ b/.changeset/fix-release-tagging-timeout.md
@@ -1,0 +1,10 @@
+---
+'@app/haotool': patch
+'@app/nihonname': patch
+'@app/park-keeper': patch
+'@app/quake-school': patch
+'@app/ratewise': patch
+'@app/split-meow': patch
+---
+
+修正 Release workflow 的 tag 建立與快取設定，避免發版卡在 tag 推送並移除 Node 20 action warning。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,6 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
-      - name: Locate pnpm store
-        id: pnpm-store
-        run: echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-store.outputs.dir }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
-
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
@@ -130,9 +118,10 @@ jobs:
 
       - name: Create release tags
         if: steps.check_changesets.outputs.has_changesets == 'false' && steps.detect_version.outputs.changed == 'true'
+        timeout-minutes: 5
         run: |
           set -euo pipefail
-          pnpm changeset tag 2>/dev/null || true
+          git fetch --tags --force origin
 
           echo '${{ steps.detect_version.outputs.changed_apps }}' | node -e "
             const apps = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
@@ -140,15 +129,35 @@ jobs:
               console.log(app.packageName + '@' + app.version);
               console.log(app.name + '-v' + app.version);
             }
-          " | while IFS= read -r tag; do
-            if ! git rev-parse "$tag" >/dev/null 2>&1; then
-              git tag "$tag"
+          " | sort -u | while IFS= read -r tag; do
+            if [ -z "$tag" ]; then
+              continue
             fi
-            git push origin "$tag" 2>/dev/null || echo "Tag $tag already pushed or failed"
+
+            if ! git check-ref-format --allow-onelevel "$tag"; then
+              echo "::error::Invalid release tag: $tag"
+              exit 1
+            fi
+
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "Tag ${tag} already exists on origin"
+              continue
+            fi
+
+            if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "Creating tag ${tag}"
+              git tag "$tag"
+            else
+              echo "Tag ${tag} already exists locally"
+            fi
+
+            echo "Pushing tag ${tag}"
+            git push origin "refs/tags/${tag}:refs/tags/${tag}"
           done
 
       - name: Create GitHub releases
         if: steps.check_changesets.outputs.has_changesets == 'false' && steps.detect_version.outputs.changed == 'true'
+        timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -164,7 +173,13 @@ jobs:
           " | while IFS= read -r meta; do
             TAG=$(echo "$meta" | jq -r '.tag')
             TITLE=$(echo "$meta" | jq -r '.title')
-            gh release create "$TAG" --title "$TITLE" --notes "Automated release via Changesets workflow." --verify-tag 2>/dev/null || echo "Release for $TAG already exists or skipped"
+
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Release for $TAG already exists"
+              continue
+            fi
+
+            gh release create "$TAG" --title "$TITLE" --notes "Automated release via Changesets workflow." --verify-tag
           done
 
       # Cloudflare Security Headers Worker 同步部署

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,8 +441,16 @@ git push origin main     # pre-push 自動驗證
 
 1. `changesets/action` 的 `commit` / `title` 必須使用 commitlint 豁免格式：`chore(release): 更新版本套件`。
 2. release PR 建立失敗時 workflow 必須 `exit 1`，不得讓 release run 顯示 success。
-3. root `README.md` 必須說明 changeset / release PR 流程；公開指令、workflow、部署或使用者可見行為變更時，必須同步更新 README。
-4. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
+3. release tag 建立必須使用 `scripts/get-release-metadata.mjs --changed` 的 SSOT 輸出；CI 內禁止直接呼叫 `pnpm changeset tag`。
+4. tag push 必須使用完整 refspec（`refs/tags/<tag>:refs/tags/<tag>`）並設定 timeout，避免模糊 ref 或互動式工具造成 workflow 卡住。
+5. GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning。
+6. root `README.md` 必須說明 changeset / release PR 流程；公開指令、workflow、部署或使用者可見行為變更時，必須同步更新 README。
+7. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
+
+**GitHub Actions Node 24 控制**：
+
+- Node 24 workflow 優先使用官方 action 內建快取（例如 `actions/setup-node@v6` 的 `cache: pnpm`）。
+- 若 action 已被內建快取取代，禁止額外加入 `actions/cache@v4` 等 Node 20 JavaScript action，避免 release run 產生可預防的 deprecation warning。
 
 ### Dependabot 安全警告處理流程
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,10 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
 
 - `changesets/action` 的 release commit 必須使用 commitlint 豁免格式：`chore(release): 更新版本套件`
 - release workflow 若建立 release PR 失敗，必須讓 workflow 失敗，不得用 `continue-on-error` 將失敗偽裝為 success
+- release tag 建立必須使用 `scripts/get-release-metadata.mjs --changed` 的 SSOT 輸出；CI 內禁止直接呼叫 `pnpm changeset tag`
+- tag push 必須使用完整 refspec（`refs/tags/<tag>:refs/tags/<tag>`）並設定 timeout，避免模糊 ref 或互動式工具造成 workflow 卡住
+- GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning
+- Node 24 workflow 優先使用 `actions/setup-node@v6` 內建 pnpm cache；不要再額外加入 `actions/cache@v4` 造成 Node 20 action warning
 - 若 main 累積 changeset 但版本未變，先查 `gh run view <RUN_ID> --log` 是否卡在 `Create Release Pull Request`
 - README 同步規則：公開指令、workflow、部署、版本流程或使用者可見行為變更時，必須更新 root `README.md` 與受影響 app README
 
@@ -266,6 +270,8 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 **排程資料 workflow 在 post-push refresh 報 GitHub 500**：若 `Commit and push changes` 已成功、失敗發生在 `Refresh ... from remote data branch`，視為 GitHub 瞬時錯誤。修法：post-push refresh 使用 3 次重試並設為 `continue-on-error: true`；summary warning 必須看 `steps.<id>.outcome == 'failure'`，不得用 `conclusion`，否則會把失敗誤判成 success。
 
 **Release workflow 顯示 success 但沒有語意升版**：先查 `.changeset/*.md` 是否仍存在，再查 release run log。若 `Create Release Pull Request` 在 `git commit` 階段被 commitlint 擋下，將 `changesets/action` 的 `commit` / `title` 改為 `chore(release): 更新版本套件`，且失敗回報步驟必須 `exit 1`，避免 release PR 未建立卻顯示綠燈。
+
+**Release workflow 卡在 Create release tags**：取消卡住 run 後檢查是否在 CI 內呼叫 `pnpm changeset tag`。修法是移除該呼叫，改由 `scripts/get-release-metadata.mjs --changed` 顯式輸出 package tag 與 app tag，先驗證 `git check-ref-format`，再用完整 refspec 推送 tag，並為步驟設定 timeout。
 
 **Cloudflare 邊緣同步**：release 需確認 `security-headers` worker 也已部署；`wrangler deploy` 需 `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`；secret 缺失時明確 `skip` 並回報，不可假設 edge 已同步。完整 SOP 見 `AGENTS.md` § security-headers Worker 部署 SOP。
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19.2-61dafb?logo=react)](https://react.dev/)
-[![Vite](https://img.shields.io/badge/Vite-7.3-646cff?logo=vite)](https://vitejs.dev/)
+[![Vite](https://img.shields.io/badge/Vite-8.0-646cff?logo=vite)](https://vitejs.dev/)
 [![pnpm](https://img.shields.io/badge/pnpm-9.10.0-yellow?logo=pnpm)](https://pnpm.io/)
 
 [English](#english) · [繁體中文](#繁體中文)
@@ -102,24 +102,24 @@ GPS 輔助的停車場路徑指引工具
 | 類別         | 技術                         |
 | ------------ | ---------------------------- |
 | **框架**     | React 19.2 + TypeScript 5.9  |
-| **建置工具** | Vite 7.3 + vite-react-ssg    |
+| **建置工具** | Vite 8.0 + vite-react-ssg    |
 | **樣式**     | Tailwind CSS 3.4             |
-| **測試**     | Vitest 4.0 + Playwright 1.57 |
+| **測試**     | Vitest 4.1 + Playwright 1.57 |
 | **套件管理** | pnpm 9.10.0 (Monorepo)       |
-| **CI/CD**    | GitHub Actions (6 workflows) |
+| **CI/CD**    | GitHub Actions (9 workflows) |
 | **部署**     | Docker + Zeabur / Vercel     |
 | **安全**     | Gitleaks + Trivy + SARIF     |
 
 ### 品質指標
 
-| 指標           | 數值        |
-| -------------- | ----------- |
-| **測試數量**   | 1700+       |
-| **測試覆蓋率** | 92%+        |
-| **TypeScript** | Strict Mode |
-| **ESLint**     | 0 警告      |
-| **Lighthouse** | 95+ 全類別  |
-| **CI 管線**    | 6 個全通過  |
+| 指標           | 數值          |
+| -------------- | ------------- |
+| **測試數量**   | 1700+         |
+| **測試覆蓋率** | 92%+          |
+| **TypeScript** | Strict Mode   |
+| **ESLint**     | 0 警告        |
+| **Lighthouse** | 95+ 全類別    |
+| **CI 管線**    | 9 個 workflow |
 
 ### 快速開始
 
@@ -166,6 +166,21 @@ pnpm typecheck
 pnpm lint
 ```
 
+#### 版本與發版
+
+```bash
+# 每個 PR 都要建立 changeset，描述使用者可見影響
+pnpm changeset
+
+# release PR 由 GitHub Actions 自動建立
+pnpm changeset:status
+```
+
+Release workflow 以 `pnpm changeset:version` 作為版本 SSOT，並由
+`scripts/get-release-metadata.mjs --changed` 產生 release tag 與 GitHub
+release 清單。禁止手動修改版本號、手動編輯 CHANGELOG，或在 CI 內直接呼叫
+`pnpm changeset tag` 建 tag。
+
 ### 專案結構
 
 ```
@@ -186,8 +201,11 @@ haotool-app/
 │       ├── release.yml                 # 版本發布
 │       ├── seo-audit.yml               # SEO 審查
 │       ├── seo-production.yml          # 生產環境 SEO
+│       ├── update-committed-seo-files.yml # SEO 產出物同步
 │       ├── update-historical-rates.yml # 歷史匯率更新
-│       └── update-latest-rates.yml     # 最新匯率更新
+│       ├── update-latest-rates.yml     # 最新匯率更新
+│       ├── update-moneybox-rates.yml   # MoneyBox 匯率更新
+│       └── update-seo-rate-examples.yml # SEO 範例匯率更新
 ├── package.json          # Monorepo 根配置
 ├── pnpm-workspace.yaml   # pnpm workspace 配置
 └── tsconfig.base.json    # 共用 TypeScript 配置
@@ -242,11 +260,11 @@ haotool Apps is a professional pnpm Monorepo containing multiple high-quality Re
 ### Tech Stack
 
 - **Framework**: React 19.2 + TypeScript 5.9
-- **Build**: Vite 7.3 + vite-react-ssg
+- **Build**: Vite 8.0 + vite-react-ssg
 - **Styling**: Tailwind CSS 3.4
-- **Testing**: Vitest 4.0 + Playwright 1.57
+- **Testing**: Vitest 4.1 + Playwright 1.57
 - **Package Manager**: pnpm 9.10.0 (Monorepo)
-- **CI/CD**: GitHub Actions (6 workflows)
+- **CI/CD**: GitHub Actions (9 workflows)
 - **Deployment**: Docker + Zeabur / Vercel
 - **Security**: Gitleaks + Trivy + SARIF
 
@@ -263,6 +281,12 @@ pnpm install
 # Start development
 pnpm dev
 ```
+
+### Release
+
+Every PR must include a changeset. GitHub Actions creates the release PR with
+`pnpm changeset:version`; release tags and GitHub releases are generated from
+`scripts/get-release-metadata.mjs --changed`.
 
 ### License
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,75 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-28T14:21:09+08:00
-> **當前總分**: 1222（初始分: 100）
+> **最後更新**: 2026-04-28T16:04:19+08:00
+> **當前總分**: 1223（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: release-tag-timeout-ssot
+date: 2026-04-28
+title: 修正 Release tag 建立卡住，移除 Node 20 cache action warning
+score: +1
+type: fix
+content_type: incident
+scope: release, github-actions, changesets, docs
+topics: [release-workflow, release-tags, changesets, node24-actions, readme-sync]
+keywords:
+[release-tags, changeset-tag, refspec, timeout, setup-node-cache, node20-warning]
+aliases: [Release tag 卡住, Create release tags timeout, actions/cache Node20 warning]
+related_entries: [release-pr-commitlint-masked-success]
+summary: Release PR #289 合併後，main 的 `Release` workflow 已進入正式發版分支，但卡在 `Create release tags` 步驟。追查確認 workflow 仍在 CI 內呼叫 `pnpm changeset tag`，該指令會嘗試讀取 tty 並依 workspace 產生不完整且含非目標 package 的 tag；同時 workflow 已使用 `actions/setup-node@v6` 內建 pnpm cache，卻額外保留 `actions/cache@v4`，造成 Node 20 JavaScript action deprecation warning。本次改為只從 release metadata SSOT 顯式建立 package tag 與 app tag，並設定 timeout、tag 格式檢查與完整 refspec push。
+root_cause:
+
+- `pnpm changeset tag` 適合人工 release 流程，不適合在此 repo 的多 app release workflow 內當作 tag SSOT。
+- release workflow 已透過 `scripts/get-release-metadata.mjs --changed` 取得精準 app 清單，卻又額外呼叫 changesets tag 產生第二套 tag 行為。
+- `actions/setup-node@v6` 已提供 pnpm cache，額外使用 `actions/cache@v4` 只增加 Node 20 action warning 與維護成本。
+
+impact:
+
+- Release workflow 可建立 release PR，但正式發版階段可能卡住，導致 tag、GitHub release、Cloudflare purge 與 live precache 驗證無法收斂。
+- 卡住 run 需要人工取消，延長生產發布時間。
+- workflow warning 讓 Node 24 遷移狀態不乾淨，容易掩蓋真正需要處理的 release 訊號。
+
+actions:
+
+- 移除 `.github/workflows/release.yml` 內冗餘的 `actions/cache@v4` pnpm store cache，保留 `actions/setup-node@v6` 內建 cache。
+- 移除 `Create release tags` 中的 `pnpm changeset tag`，改由 `scripts/get-release-metadata.mjs --changed` 產生 tag 清單。
+- 對每個 tag 執行 `git check-ref-format --allow-onelevel`，並以 `refs/tags/<tag>:refs/tags/<tag>` 完整 refspec 推送。
+- 為 `Create release tags` 設定 5 分鐘 timeout，避免 workflow 無限卡住。
+- 將 GitHub release 建立改為先查 `gh release view`；只有 release 已存在才跳過，其他 `gh release create` 失敗維持阻塞。
+- 同步更新 root `README.md`、`AGENTS.md` 與 `CLAUDE.md` 的 release tag 與 Node 24 cache 控制規則。
+
+prevention:
+
+- release tag 來源只能有一份 SSOT：`scripts/get-release-metadata.mjs --changed`。
+- CI 內不得呼叫會讀 tty 或會自行推導 workspace tag 的互動式 release 指令。
+- GitHub release 建立失敗不得被廣義 catch 成 warning；只能明確處理已存在的 release。
+- Node 24 workflow 若已由官方 setup action 提供 cache，不再疊加舊版 cache action。
+- 之後查 release 狀態時，必須分別確認 release PR、tag、GitHub release 與部署驗證，不得只看其中一段成功。
+
+verification:
+
+- `gh run cancel 25040677441 --repo haotool/app`（已取消卡住的 release run）
+- `node scripts/get-release-metadata.mjs --changed`（確認 changed app 清單為 haotool、nihonname、park-keeper、quake-school、ratewise、split-meow）
+- `git check-ref-format --allow-onelevel`（確認 package tag 與 app tag 格式可用）
+- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`（release workflow YAML 可解析）
+- Node 24 環境下執行 `pnpm format`（通過）
+- Node 24 環境下執行 `pnpm typecheck`（通過）
+- Node 24 環境下執行 `pnpm changeset:status`（通過；確認 6 個 app 為 patch bump）
+- `git diff --check`（通過）
+- `git diff -- | rg -n "<PII patterns>"`（無輸出；PR diff 未新增本機路徑、帳號、email 或工具目錄）
+- 待本 PR CI 通過後，以 main release run 驗證 tag 建立、GitHub release 與 RateWise live precache
+
+references:
+
+- .github/workflows/release.yml
+- scripts/get-release-metadata.mjs
+- README.md
+- AGENTS.md
+- CLAUDE.md
+- https://github.com/changesets/action
+- https://github.com/actions/setup-node
 
 ---
 


### PR DESCRIPTION
## 摘要
- 移除 Release workflow 中冗餘的 actions/cache@v4，改用 actions/setup-node@v6 內建 pnpm cache
- 移除 CI 內的 pnpm changeset tag，改由 release metadata SSOT 顯式建立 package tag 與 app tag
- 補上 tag/release timeout、完整 tag refspec、GitHub release 已存在檢查與文件/changeset/002 稽核紀錄

## 驗證
- pnpm format
- pnpm typecheck
- pnpm changeset:status
- git diff --check
- ruby YAML parse for .github/workflows/release.yml
- pre-push hook: typecheck + test + build:ratewise
- staged diff PII scan: no output