### PR TITLE
ci(release): 修正 tag push 觸發 hooks

### DIFF
--- a/.changeset/fix-release-tag-push-hooks.md
+++ b/.changeset/fix-release-tag-push-hooks.md
@@ -1,0 +1,10 @@
+---
+'@app/haotool': patch
+'@app/nihonname': patch
+'@app/park-keeper': patch
+'@app/quake-school': patch
+'@app/ratewise': patch
+'@app/split-meow': patch
+---
+
+修正 Release workflow 的 tag 推送方式，避免 CI tag push 重複觸發 pre-push hook。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,13 +123,16 @@ jobs:
           set -euo pipefail
           git fetch --tags --force origin
 
-          echo '${{ steps.detect_version.outputs.changed_apps }}' | node -e "
+          mapfile -t release_tags < <(echo '${{ steps.detect_version.outputs.changed_apps }}' | node -e "
             const apps = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
             for (const app of apps) {
               console.log(app.packageName + '@' + app.version);
               console.log(app.name + '-v' + app.version);
             }
-          " | sort -u | while IFS= read -r tag; do
+          " | sort -u)
+
+          tag_refspecs=()
+          for tag in "${release_tags[@]}"; do
             if [ -z "$tag" ]; then
               continue
             fi
@@ -151,9 +154,16 @@ jobs:
               echo "Tag ${tag} already exists locally"
             fi
 
-            echo "Pushing tag ${tag}"
-            git push origin "refs/tags/${tag}:refs/tags/${tag}"
+            tag_refspecs+=("refs/tags/${tag}:refs/tags/${tag}")
           done
+
+          if [ "${#tag_refspecs[@]}" -eq 0 ]; then
+            echo "No new release tags to push"
+            exit 0
+          fi
+
+          echo "Pushing ${#tag_refspecs[@]} release tags"
+          HUSKY=0 git push origin "${tag_refspecs[@]}"
 
       - name: Create GitHub releases
         if: steps.check_changesets.outputs.has_changesets == 'false' && steps.detect_version.outputs.changed == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,9 +443,10 @@ git push origin main     # pre-push 自動驗證
 2. release PR 建立失敗時 workflow 必須 `exit 1`，不得讓 release run 顯示 success。
 3. release tag 建立必須使用 `scripts/get-release-metadata.mjs --changed` 的 SSOT 輸出；CI 內禁止直接呼叫 `pnpm changeset tag`。
 4. tag push 必須使用完整 refspec（`refs/tags/<tag>:refs/tags/<tag>`）並設定 timeout，避免模糊 ref 或互動式工具造成 workflow 卡住。
-5. GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning。
-6. root `README.md` 必須說明 changeset / release PR 流程；公開指令、workflow、部署或使用者可見行為變更時，必須同步更新 README。
-7. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
+5. CI 內部 tag push 必須一次推送全部 tag，且明確設定 `HUSKY=0`，避免 tag push 重複觸發 repo pre-push hook。
+6. GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning。
+7. root `README.md` 必須說明 changeset / release PR 流程；公開指令、workflow、部署或使用者可見行為變更時，必須同步更新 README。
+8. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
 
 **GitHub Actions Node 24 控制**：
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
 - release workflow 若建立 release PR 失敗，必須讓 workflow 失敗，不得用 `continue-on-error` 將失敗偽裝為 success
 - release tag 建立必須使用 `scripts/get-release-metadata.mjs --changed` 的 SSOT 輸出；CI 內禁止直接呼叫 `pnpm changeset tag`
 - tag push 必須使用完整 refspec（`refs/tags/<tag>:refs/tags/<tag>`）並設定 timeout，避免模糊 ref 或互動式工具造成 workflow 卡住
+- CI 內部 tag push 必須一次推送全部 tag，且明確設定 `HUSKY=0`，避免 tag push 重複觸發 repo pre-push hook
 - GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning
 - Node 24 workflow 優先使用 `actions/setup-node@v6` 內建 pnpm cache；不要再額外加入 `actions/cache@v4` 造成 Node 20 action warning
 - 若 main 累積 changeset 但版本未變，先查 `gh run view <RUN_ID> --log` 是否卡在 `Create Release Pull Request`
@@ -271,7 +272,7 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 
 **Release workflow 顯示 success 但沒有語意升版**：先查 `.changeset/*.md` 是否仍存在，再查 release run log。若 `Create Release Pull Request` 在 `git commit` 階段被 commitlint 擋下，將 `changesets/action` 的 `commit` / `title` 改為 `chore(release): 更新版本套件`，且失敗回報步驟必須 `exit 1`，避免 release PR 未建立卻顯示綠燈。
 
-**Release workflow 卡在 Create release tags**：取消卡住 run 後檢查是否在 CI 內呼叫 `pnpm changeset tag`。修法是移除該呼叫，改由 `scripts/get-release-metadata.mjs --changed` 顯式輸出 package tag 與 app tag，先驗證 `git check-ref-format`，再用完整 refspec 推送 tag，並為步驟設定 timeout。
+**Release workflow 卡在 Create release tags**：取消卡住 run 後檢查是否在 CI 內呼叫 `pnpm changeset tag`，或 tag push 是否觸發 `.husky/pre-push`。修法是移除互動式 changeset tag 呼叫，改由 `scripts/get-release-metadata.mjs --changed` 顯式輸出 package tag 與 app tag，先驗證 `git check-ref-format`，再用完整 refspec 一次推送全部 tag；CI tag push 必須設定 `HUSKY=0` 並為步驟設定 timeout。
 
 **Cloudflare 邊緣同步**：release 需確認 `security-headers` worker 也已部署；`wrangler deploy` 需 `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`；secret 缺失時明確 `skip` 並回報，不可假設 edge 已同步。完整 SOP 見 `AGENTS.md` § security-headers Worker 部署 SOP。
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ pnpm changeset:status
 Release workflow 以 `pnpm changeset:version` 作為版本 SSOT，並由
 `scripts/get-release-metadata.mjs --changed` 產生 release tag 與 GitHub
 release 清單。禁止手動修改版本號、手動編輯 CHANGELOG，或在 CI 內直接呼叫
-`pnpm changeset tag` 建 tag。
+`pnpm changeset tag` 建 tag；CI 內部 tag push 會以 `HUSKY=0` 單次推送，避免重複觸發
+pre-push hook。
 
 ### 專案結構
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -35,8 +35,9 @@ actions:
 
 - 移除 `.github/workflows/release.yml` 內冗餘的 `actions/cache@v4` pnpm store cache，保留 `actions/setup-node@v6` 內建 cache。
 - 移除 `Create release tags` 中的 `pnpm changeset tag`，改由 `scripts/get-release-metadata.mjs --changed` 產生 tag 清單。
-- 對每個 tag 執行 `git check-ref-format --allow-onelevel`，並以 `refs/tags/<tag>:refs/tags/<tag>` 完整 refspec 推送。
+- 對每個 tag 執行 `git check-ref-format --allow-onelevel`，收集完整 `refs/tags/<tag>:refs/tags/<tag>` refspec 後一次推送。
 - 為 `Create release tags` 設定 5 分鐘 timeout，避免 workflow 無限卡住。
+- CI 內部 tag push 使用 `HUSKY=0`，避免每個 tag push 重複觸發 `.husky/pre-push` 的 typecheck/test/build。
 - 將 GitHub release 建立改為先查 `gh release view`；只有 release 已存在才跳過，其他 `gh release create` 失敗維持阻塞。
 - 同步更新 root `README.md`、`AGENTS.md` 與 `CLAUDE.md` 的 release tag 與 Node 24 cache 控制規則。
 
@@ -44,6 +45,7 @@ prevention:
 
 - release tag 來源只能有一份 SSOT：`scripts/get-release-metadata.mjs --changed`。
 - CI 內不得呼叫會讀 tty 或會自行推導 workspace tag 的互動式 release 指令。
+- CI 內部 release tag push 必須 batch push 且停用 Husky；PR / main checks 已提供品質閘門，不應在 tag push 重複執行。
 - GitHub release 建立失敗不得被廣義 catch 成 warning；只能明確處理已存在的 release。
 - Node 24 workflow 若已由官方 setup action 提供 cache，不再疊加舊版 cache action。
 - 之後查 release 狀態時，必須分別確認 release PR、tag、GitHub release 與部署驗證，不得只看其中一段成功。
@@ -51,6 +53,7 @@ prevention:
 verification:
 
 - `gh run cancel 25040677441 --repo haotool/app`（已取消卡住的 release run）
+- `gh run cancel 25042456742 --repo haotool/app`（取消會被 tag push pre-push hook 拖長的 release run）
 - `node scripts/get-release-metadata.mjs --changed`（確認 changed app 清單為 haotool、nihonname、park-keeper、quake-school、ratewise、split-meow）
 - `git check-ref-format --allow-onelevel`（確認 package tag 與 app tag 格式可用）
 - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`（release workflow YAML 可解析）


### PR DESCRIPTION
## 摘要
- 將 release tag refspec 收集後一次推送，避免逐一 push tag
- CI tag push 明確設定 HUSKY=0，避免觸發 repo pre-push hook
- 同步 README、SOP、changeset 與 002 稽核紀錄

## 驗證
- pnpm format
- pnpm typecheck
- pnpm changeset:status
- ruby YAML parse for .github/workflows/release.yml
- git diff --check
- pre-push hook: typecheck + test + build:ratewise
- staged diff PII scan: no output