### PR TITLE
ci(release): 修正 live precache base path

### DIFF
--- a/.changeset/fix-release-live-precache-base.md
+++ b/.changeset/fix-release-live-precache-base.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 Release workflow 的 live precache 驗證 base path，避免誤抓 root Service Worker。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,10 @@ jobs:
 
       - name: Verify RateWise live precache
         if: success() && steps.ratewise_release.outputs.changed == 'true'
-        run: VERIFY_PRECACHE_SOURCE=live node scripts/verify-precache-assets.mjs
+        env:
+          VERIFY_PRECACHE_SOURCE: live
+          VERIFY_BASE_URL: https://app.haotool.org/ratewise/
+        run: node scripts/verify-precache-assets.mjs
 
       # Cloudflare CDN 快取清除
       # 參考: Context7 /websites/developers_cloudflare - Cache Purge API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,7 +603,7 @@ git push origin main     # pre-push 自動驗證
 - 必須直接從 `resources.seoFiles` 與 `resources.images` 展開 URL；禁止重複維護第二份名單
 - 輸出必須明確分類為 `200`、`non200`、`timeout`
 - `SEO Production Validation` workflow 的 `health-check` 必須先跑此腳本，再跑 `verify-all-apps.mjs`
-- RateWise PWA 發版後，`health-check` 必須再跑 `VERIFY_PRECACHE_SOURCE=live node scripts/verify-precache-assets.mjs`
+- RateWise PWA 發版後，`health-check` 必須再跑 `VERIFY_PRECACHE_SOURCE=live VERIFY_BASE_URL=https://app.haotool.org/ratewise/ node scripts/verify-precache-assets.mjs`
 - live precache 驗證若出現「querystring 可 200、原 URL 為 404」，必須判定為 Cloudflare stale edge 404，先 purge CDN 再視為部署完成
 - RateWise release 若涉及正式站資產更新，必須先用 cache-busting probe 確認 `/ratewise/` 的 `app-version` 已切到目標版本，再執行 Cloudflare purge
 - RateWise Cloudflare purge 必須使用目標 URL + prefix（至少涵蓋 `/ratewise/`、`sw.js`、`registerSW.js`、`manifest.webmanifest`、`offline.html`、`assets`、`workbox-`、`static-loader-data-manifest`），purge 後立即重跑 live precache 驗證

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 - app 清單 **必須**由 `discoverApps()` 自動發現；禁止在腳本或 workflow 硬編碼 app 名稱
 - 此腳本只負責 `200 / non200 / timeout` 資源可用性；`verify-all-apps.mjs` 保持 sitemap / robots / llms / 404 等語義驗證
 - `SEO Production Validation` workflow 的 `health-check` 應先跑資源可用性檢查，再跑語義檢查
-- RateWise 發版後必須額外執行 `VERIFY_PRECACHE_SOURCE=live node scripts/verify-precache-assets.mjs`
+- RateWise 發版後必須額外執行 `VERIFY_PRECACHE_SOURCE=live VERIFY_BASE_URL=https://app.haotool.org/ratewise/ node scripts/verify-precache-assets.mjs`
 - 若 live precache 驗證出現「原 URL 404，但 querystring 後可 200」，應判定為 Cloudflare stale edge 404，先 purge CDN 再視為正式站可用
 - RateWise release 若涉及正式站資產更新，必須先用 cache-busting probe 確認 `/ratewise/` 的 `app-version` 已切到目標版本，再執行 Cloudflare purge
 - RateWise Cloudflare purge 必須使用目標 URL + prefix（至少涵蓋 `/ratewise/`、`sw.js`、`registerSW.js`、`manifest.webmanifest`、`offline.html`、`assets`、`workbox-`、`static-loader-data-manifest`），purge 後立即重跑 live precache 驗證

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -39,6 +39,7 @@ actions:
 - 為 `Create release tags` 設定 5 分鐘 timeout，避免 workflow 無限卡住。
 - CI 內部 tag push 使用 `HUSKY=0`，避免每個 tag push 重複觸發 `.husky/pre-push` 的 typecheck/test/build。
 - 將 GitHub release 建立改為先查 `gh release view`；只有 release 已存在才跳過，其他 `gh release create` 失敗維持阻塞。
+- 修正 live precache verifier 的預設 base URL，並在 release workflow 顯式設定 `VERIFY_BASE_URL=https://app.haotool.org/ratewise/`，避免誤抓 root `sw.js`。
 - 同步更新 root `README.md`、`AGENTS.md` 與 `CLAUDE.md` 的 release tag 與 Node 24 cache 控制規則。
 
 prevention:
@@ -46,6 +47,7 @@ prevention:
 - release tag 來源只能有一份 SSOT：`scripts/get-release-metadata.mjs --changed`。
 - CI 內不得呼叫會讀 tty 或會自行推導 workspace tag 的互動式 release 指令。
 - CI 內部 release tag push 必須 batch push 且停用 Husky；PR / main checks 已提供品質閘門，不應在 tag push 重複執行。
+- live precache 驗證必須明確指定 RateWise base path `/ratewise/`，不得依賴 root host 預設值。
 - GitHub release 建立失敗不得被廣義 catch 成 warning；只能明確處理已存在的 release。
 - Node 24 workflow 若已由官方 setup action 提供 cache，不再疊加舊版 cache action。
 - 之後查 release 狀態時，必須分別確認 release PR、tag、GitHub release 與部署驗證，不得只看其中一段成功。
@@ -54,6 +56,7 @@ verification:
 
 - `gh run cancel 25040677441 --repo haotool/app`（已取消卡住的 release run）
 - `gh run cancel 25042456742 --repo haotool/app`（取消會被 tag push pre-push hook 拖長的 release run）
+- `gh run view 25043744937 --repo haotool/app --job 73353304929 --log`（確認 tag/release/deploy 通過，live precache 誤用 root `sw.js`）
 - `node scripts/get-release-metadata.mjs --changed`（確認 changed app 清單為 haotool、nihonname、park-keeper、quake-school、ratewise、split-meow）
 - `git check-ref-format --allow-onelevel`（確認 package tag 與 app tag 格式可用）
 - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`（release workflow YAML 可解析）

--- a/scripts/verify-precache-assets.mjs
+++ b/scripts/verify-precache-assets.mjs
@@ -6,8 +6,8 @@ import { readFile, existsSync } from 'node:fs';
 import { readFile as readFileAsync } from 'node:fs/promises';
 import path from 'node:path';
 
-const BASE_URL = process.env.VERIFY_BASE_URL ?? 'https://app.haotool.org/';
 const VERIFY_SOURCE = process.env.VERIFY_PRECACHE_SOURCE ?? 'local';
+const BASE_URL = process.env.VERIFY_BASE_URL ?? getDefaultBaseUrl(VERIFY_SOURCE);
 const PROJECT_ROOT = process.cwd();
 const DIST_DIR = path.resolve(PROJECT_ROOT, 'apps/ratewise/dist');
 const SW_PATH = path.resolve(PROJECT_ROOT, 'apps/ratewise/dist/sw.js');


### PR DESCRIPTION
## 摘要
- 將 live precache verifier 預設 base 對齊 RateWise 子路徑
- Release workflow 顯式設定 VERIFY_BASE_URL=https://app.haotool.org/ratewise/
- 同步 changeset 與 SOP 稽核紀錄

## 驗證
- VERIFY_PRECACHE_SOURCE=live VERIFY_BASE_URL=https://app.haotool.org/ratewise/ node scripts/verify-precache-assets.mjs
- pnpm format
- pnpm typecheck
- pnpm changeset:status
- ruby YAML parse for .github/workflows/release.yml
- pre-push hook: typecheck + test + build:ratewise
- staged diff PII scan: no output

## 稽核
- 以 Codex noreply 身分提交，避免本機帳號個資進入 commit metadata
- PR 內容避免使用本機絕對路徑、私人 email、shell/profile 或工具設定資訊