### PR TITLE
ci(security): 改用 Gitleaks CLI 掃描

### DIFF
--- a/.changeset/fix-ci-gitleaks-cli.md
+++ b/.changeset/fix-ci-gitleaks-cli.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 CI secret scan，改用固定版本 Gitleaks CLI，移除 GitHub Action license 與 Node 20 註記。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,25 @@ jobs:
           echo "✅ No critical or high severity vulnerabilities found"
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          set -euo pipefail
+
+          GITLEAKS_ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl --retry 6 --retry-delay 2 --retry-all-errors -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_ARCHIVE}" \
+            -o "/tmp/${GITLEAKS_ARCHIVE}"
+          curl --retry 6 --retry-delay 2 --retry-all-errors -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
+            -o /tmp/gitleaks_checksums.txt
+
+          (cd /tmp && grep "${GITLEAKS_ARCHIVE}" gitleaks_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${GITLEAKS_ARCHIVE}" -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+          gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --verbose
+        continue-on-error: true
 
       - name: Generate SBOM (Software Bill of Materials)
         if: github.ref == 'refs/heads/main'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,7 @@ git push origin main     # pre-push 自動驗證
 
 - Node 24 workflow 優先使用官方 action 內建快取（例如 `actions/setup-node@v6` 的 `cache: pnpm`）。
 - 若 action 已被內建快取取代，禁止額外加入 `actions/cache@v4` 等 Node 20 JavaScript action，避免 release run 產生可預防的 deprecation warning。
+- secret scan 使用固定版本 Gitleaks CLI + checksum 驗證；組織 repo 不使用 `gitleaks/gitleaks-action@v2`，避免 license secret 缺失與 Node 20 action warning。
 
 ### Dependabot 安全警告處理流程
 
@@ -508,9 +509,10 @@ git push origin main     # pre-push 自動驗證
 
 1. 官方 action 需優先升到最新的 Node 24 相容 major（目前 `actions/checkout@v6`、`actions/setup-node@v6`）。
 2. 升版前必須查官方 release 或 `action.yml` 的 `runs.using`，不得只靠 warning 文字猜測。
-3. 若官方 action 最新穩定版仍停留在 `node20`，受影響 job 必須加上 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` 作為過渡控制。
-4. 過渡控制只保留在仍依賴 Node 20 action 的 job；上游提供 Node 24 版本後應回到直接升版。
-5. workflow 版本升級後，必須至少做 YAML 解析與相關 workflow / `gh` checks 驗證，確認未引入語意漂移。
+3. 若官方 action 可被 CLI 安全替代，優先使用固定版本 CLI + checksum 驗證，移除 action deprecation 與授權 secret 依賴。
+4. 若官方 action 最新穩定版仍停留在 `node20` 且不可替代，受影響 job 必須加上 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` 作為過渡控制。
+5. 過渡控制只保留在仍依賴 Node 20 action 的 job；上游提供 Node 24 版本後應回到直接升版。
+6. workflow 版本升級後，必須至少做 YAML 解析與相關 workflow / `gh` checks 驗證，確認未引入語意漂移。
 
 ### SEO 最佳實踐遷移（Schema.org @graph）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
 - CI 內部 tag push 必須一次推送全部 tag，且明確設定 `HUSKY=0`，避免 tag push 重複觸發 repo pre-push hook
 - GitHub release 建立必須先查既有 release；除「已存在」外，不得把 `gh release create` 失敗吞成 warning
 - Node 24 workflow 優先使用 `actions/setup-node@v6` 內建 pnpm cache；不要再額外加入 `actions/cache@v4` 造成 Node 20 action warning
+- secret scan 使用固定版本 Gitleaks CLI 並驗證 release checksum；組織 repo 不使用需要 license secret 的 `gitleaks/gitleaks-action@v2`
 - 若 main 累積 changeset 但版本未變，先查 `gh run view <RUN_ID> --log` 是否卡在 `Create Release Pull Request`
 - README 同步規則：公開指令、workflow、部署、版本流程或使用者可見行為變更時，必須更新 root `README.md` 與受影響 app README
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ GPS 輔助的停車場路徑指引工具
 | **套件管理** | pnpm 9.10.0 (Monorepo)       |
 | **CI/CD**    | GitHub Actions (9 workflows) |
 | **部署**     | Docker + Zeabur / Vercel     |
-| **安全**     | Gitleaks + Trivy + SARIF     |
+| **安全**     | Gitleaks CLI + Trivy + SARIF |
 
 ### 品質指標
 
@@ -267,7 +267,7 @@ haotool Apps is a professional pnpm Monorepo containing multiple high-quality Re
 - **Package Manager**: pnpm 9.10.0 (Monorepo)
 - **CI/CD**: GitHub Actions (9 workflows)
 - **Deployment**: Docker + Zeabur / Vercel
-- **Security**: Gitleaks + Trivy + SARIF
+- **Security**: Gitleaks CLI + Trivy + SARIF
 
 ### Quick Start
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,65 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-28T16:04:19+08:00
-> **當前總分**: 1223（初始分: 100）
+> **最後更新**: 2026-04-28T17:45:08+08:00
+> **當前總分**: 1224（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: ci-gitleaks-cli-node24
+date: 2026-04-28
+title: 移除 Gitleaks action license 與 Node 20 註記，改用固定版本 CLI 掃描
+score: +1
+type: fix
+content_type: incident
+scope: ci, security, github-actions, docs
+topics: [secret-scanning, gitleaks, node24-actions, ci-quality]
+keywords:
+[gitleaks-cli, checksum, gitleaks-license, node20-warning, secret-scan]
+aliases: [Gitleaks license warning, Node 20 action warning, secret scan CI]
+related_entries: [release-tag-timeout-ssot]
+summary: main CI 已通過，但 `Run Gitleaks` 留下 `gitleaks/gitleaks-action@v2` 的 Node 20 過渡警告與缺 `GITLEAKS_LICENSE` 註記。官方文件指出組織 repo 使用 v2 action 需 license；本次改為固定版本 Gitleaks CLI，下載官方 release tarball 與 checksum 後執行 `gitleaks detect`，保留 secret scan 並移除授權 secret 與 Node 20 action 依賴。
+root_cause:
+
+- `gitleaks/gitleaks-action@v2` 對組織 repo 需要 `GITLEAKS_LICENSE`，repo secrets 未設定時會在 CI annotation 留下 license 問題。
+- 該 action 仍觸發 GitHub Actions Node 20 deprecation 過渡警告，需要 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 補償。
+- CI 的安全掃描需求只需要執行 Gitleaks 規則，並不依賴 action 的 PR comment / notification 功能。
+
+impact:
+
+- CI 雖然成功，但 release 後仍有可預防的安全掃描註記，降低生產監控訊號品質。
+- 長期依賴 Node 20 JavaScript action 會讓 GitHub Actions Node 24 遷移狀態不乾淨。
+
+actions:
+
+- 將 `.github/workflows/ci.yml` 的 `Run Gitleaks` 從 `gitleaks/gitleaks-action@v2` 改為固定版本 `gitleaks` CLI。
+- 下載官方 `gitleaks_8.30.1_linux_x64.tar.gz` 與 checksums，使用 `sha256sum -c` 驗證後安裝。
+- GitHub release 下載加入 `curl --retry 6 --retry-delay 2 --retry-all-errors`，避免暫時性 5xx 造成 CI 假失敗。
+- 執行 `gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --verbose`，保留既有 `continue-on-error` 行為。
+- 同步更新 root `README.md`、`AGENTS.md` 與 `CLAUDE.md` 的安全掃描 / Node 24 控制規則。
+
+prevention:
+
+- 組織 repo 的 secret scan 優先使用固定版本 CLI + checksum 驗證，不依賴需要額外 license secret 的 action。
+- CI 從 GitHub release 下載工具時必須有重試與 checksum 驗證，避免網路暫時錯誤或供應鏈風險。
+- CI annotation 必須在 main release 後回看；即使 workflow success，也要處理可預防的安全與 Node 版本註記。
+
+verification:
+
+- `gh run watch 25045101606 --repo haotool/app --interval 20`（確認 main CI 全部成功，但存在 Gitleaks license / Node 20 annotation）
+- `gh api repos/gitleaks/gitleaks/releases/latest`（確認官方最新 release 為 v8.30.1）
+- `curl` 下載測試曾遇 GitHub 502，因此已補上 retry 控制。
+- 本 PR 待執行：YAML 解析、Gitleaks CLI 掃描、format/typecheck、PR checks。
+
+references:
+
+- .github/workflows/ci.yml
+- .gitleaks.toml
+- README.md
+- AGENTS.md
+- CLAUDE.md
+- https://github.com/gitleaks/gitleaks
+- https://github.com/gitleaks/gitleaks-action
 
 ---
 


### PR DESCRIPTION
## 摘要
- 將 CI secret scan 從 `gitleaks/gitleaks-action@v2` 改為固定版本 Gitleaks CLI
- 下載官方 release tarball 並用 checksum 驗證，加入 retry 避免 GitHub release 暫時性 5xx
- 移除 `GITLEAKS_LICENSE` secret 依賴與 Node 20 action warning 來源
- 同步 README、AGENTS、CLAUDE、changeset 與 002 稽核紀錄

## 驗證
- ruby YAML parse for .github/workflows/ci.yml
- Gitleaks CLI 本地掃描：no leaks found
- Gitleaks Linux tarball checksum 驗證通過
- pnpm format
- pnpm typecheck
- pnpm changeset:status
- pre-push hook：typecheck + test + build:ratewise
- diff PII scan：no output

## 依據
- 官方 Gitleaks release：v8.30.1
- 官方 gitleaks-action 文件：組織 repo 使用 v2 action 需要 license key