### PR TITLE
fix(security): 修正 fast-xml-parser 警告

### DIFF
--- a/.changeset/fix-fast-xml-parser-alert.md
+++ b/.changeset/fix-fast-xml-parser-alert.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 fast-xml-parser transitive security alert，將安全版本下限提升到 5.7.0 以上。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,8 +1,62 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-28T17:45:08+08:00
-> **當前總分**: 1224（初始分: 100）
+> **最後更新**: 2026-04-28T18:31:19+08:00
+> **當前總分**: 1225（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
+
+---
+
+id: dependabot-moderate-fast-xml-parser
+date: 2026-04-28
+title: 修正 fast-xml-parser moderate Dependabot 警告並評估 uuid alert
+score: +1
+type: fix
+content_type: incident
+scope: dependency-security, dependabot, pnpm-overrides
+topics: [dependabot, fast-xml-parser, uuid, security-overrides, lhci]
+keywords:
+[GHSA-gh4j-gqv2-49f6, CVE-2026-41650, fast-xml-parser, GHSA-w5hq-g745-h8pq, uuid]
+aliases: [Dependabot moderate alerts, fast-xml-parser XMLBuilder, uuid buf bounds]
+related_entries: [ci-gitleaks-cli-node24]
+summary: Release 後 GitHub 回報 2 個 open moderate Dependabot alerts。`fast-xml-parser` 由 `unlighthouse -> sitemapper` 帶入，patched 版本為 5.7.0；本次將 pnpm override 從 `>=5.5.7` 提升到 `>=5.7.0` 並更新 lockfile。`uuid` 由 `@lhci/cli@0.15.1` 帶入，最新 `uuid@14` 為 ESM 且會破壞 `@lhci/cli` 的 CommonJS `require('uuid')`；實際使用點只呼叫 `uuid.v4()` 且未傳入 advisory 指出的 `buf` 參數，因此採「不安全強升級，另以 GitHub alert dismissal 記錄未使用 vulnerable code path」策略。
+root_cause:
+
+- 既有 override 只要求 `fast-xml-parser >=5.5.7`，低於 GHSA-gh4j-gqv2-49f6 / CVE-2026-41650 的 patched 版本 5.7.0。
+- `@lhci/cli@0.15.1` 最新版仍依賴 `uuid@^8.3.1`，而 patched `uuid@14` 改為 ESM，直接 override 會破壞 `node-runner.js` 的 `const uuid = require('uuid')`。
+
+impact:
+
+- Dependabot 仍顯示 open moderate alerts，降低 release 後安全狀態可信度。
+- 對 `uuid` 做不相容 major override 會讓 Lighthouse CI 有回歸風險，且無法以 patched version 安全替換。
+
+actions:
+
+- 更新 root `package.json` 的 `pnpm.overrides.fast-xml-parser` 到 `>=5.7.0`。
+- 執行 `pnpm install --no-frozen-lockfile` 更新 `pnpm-lock.yaml`，確認解析到 `fast-xml-parser@5.7.2`。
+- 保留 `uuid@8.3.2`，因 `@lhci/cli` 只使用 `uuid.v4()` 且未使用 advisory 影響的 v3/v5/v6 `buf` code path。
+- 將 Dependabot alert #85 以 `not_used` dismiss，comment 記錄 `uuid.v4()` 使用點與 `uuid@14` CommonJS 不相容風險。
+
+prevention:
+
+- 可相容升級的 transitive security alert 以 override + lockfile 收斂。
+- 不可相容升級的 dev-only transitive alert 必須先查實際使用點；只有確認 vulnerable code path 未使用時才可 dismiss。
+
+verification:
+
+- `gh api repos/haotool/app/dependabot/alerts`（確認 open alerts：fast-xml-parser #84、uuid #85）
+- `pnpm why fast-xml-parser`（確認已解析到 5.7.2）
+- `pnpm why uuid`（確認來源為 `@lhci/cli@0.15.1`）
+- `rg "require\\('uuid'\\)|uuid" node_modules/@lhci/cli`（確認使用點為 `uuid.v4()`）
+- `gh api --method PATCH repos/haotool/app/dependabot/alerts/85 ...`（以 `not_used` dismiss uuid alert）
+- 本 PR 待執行：format/typecheck/audit/PR checks。
+
+references:
+
+- package.json
+- pnpm-lock.yaml
+- https://github.com/advisories/GHSA-gh4j-gqv2-49f6
+- https://github.com/advisories/GHSA-w5hq-g745-h8pq
+- https://www.npmjs.com/package/@lhci/cli
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
       "brace-expansion@>=5.0.0 <5.0.5": "5.0.5",
       "@isaacs/brace-expansion@<5.0.1": "5.0.1",
-      "fast-xml-parser": ">=5.5.7",
+      "fast-xml-parser": ">=5.7.0",
       "flatted": ">=3.4.2",
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.0.3: 2.0.3
   brace-expansion@>=5.0.0 <5.0.5: 5.0.5
   '@isaacs/brace-expansion@<5.0.1': 5.0.1
-  fast-xml-parser: '>=5.5.7'
+  fast-xml-parser: '>=5.7.0'
   flatted: '>=3.4.2'
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
@@ -2184,6 +2184,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5183,11 +5186,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastq@1.19.1:
@@ -7142,8 +7145,8 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  path-expression-matcher@1.2.0:
-    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -8172,8 +8175,8 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  strnum@2.2.1:
-    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -10923,6 +10926,8 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14671,15 +14676,16 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.5:
     dependencies:
-      path-expression-matcher: 1.2.0
+      path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.8:
+  fast-xml-parser@5.7.2:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.1
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.19.1:
     dependencies:
@@ -16321,7 +16327,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 5.0.5
 
   minimatch@3.1.4:
     dependencies:
@@ -16763,7 +16769,7 @@ snapshots:
 
   path-exists@5.0.0: {}
 
-  path-expression-matcher@1.2.0: {}
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -17639,7 +17645,7 @@ snapshots:
 
   sitemapper@4.0.2:
     dependencies:
-      fast-xml-parser: 5.5.8
+      fast-xml-parser: 5.7.2
       got: 11.8.6
       is-gzip: 2.0.0
       p-limit: 6.2.0
@@ -17877,7 +17883,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@2.2.1: {}
+  strnum@2.2.3: {}
 
   stubborn-fs@2.0.0:
     dependencies:


### PR DESCRIPTION
## 摘要
- 將 pnpm override 的 fast-xml-parser 下限提升到 patched 5.7.0 以上
- 更新 lockfile，確認 transitive fast-xml-parser 解析到 5.7.2
- 針對 uuid alert #85 完成 not_used dismiss：@lhci/cli 只使用 uuid.v4()，未使用 advisory 影響的 buf code path；uuid@14 會破壞 CommonJS require，因此不做破壞性 override

## 驗證
- pnpm why fast-xml-parser
- pnpm why uuid
- pnpm audit --prod --audit-level=moderate
- pnpm format
- pnpm typecheck
- pnpm changeset:status
- pre-push hook：typecheck + test + build:ratewise
- diff PII scan：no output

## 稽核
- Dependabot #84 fast-xml-parser 將由此 PR 關閉
- Dependabot #85 uuid 已以 not_used dismiss，原因記錄在 alert comment 與 002
