### PR TITLE
docs(ratewise): 補充正式站部署驗證

### DIFF
--- a/apps/ratewise/README.md
+++ b/apps/ratewise/README.md
@@ -68,6 +68,13 @@ src/
 | ESLint     | 0 警告      |
 | Lighthouse | 95+ 全類別  |
 
+## 🚢 發版驗證
+
+RateWise 正式站由 Zeabur production deployment 發布，Release 完成後需確認
+`https://app.haotool.org/ratewise/` 的 `app-version` 已切到目標版本，並再執行 live
+precache 驗證。若 GitHub Release 已建立但正式站仍回舊版，先查 GitHub deployments
+的 active SHA，再以 app 範圍 PR 重新觸發最新 main 部署。
+
 ## 📄 授權
 
 GPL-3.0 © [haotool](https://app.haotool.org/)

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -1,6 +1,6 @@
 # 開發獎懲與決策記錄 (2025-2026)
 
-> **最後更新**: 2026-04-28T19:10:51+08:00
+> **最後更新**: 2026-04-28T19:32:57+08:00
 > **當前總分**: 1226（初始分: 100）
 > **目標**: >120（優秀）| <80（警示）
 
@@ -33,7 +33,8 @@ actions:
 
 - 使用 GitHub deployments API 查出 Zeabur production deployment active SHA 順序。
 - 更新 README / AGENTS / CLAUDE，要求 release PR 前確認前一個 main deployment 完成，並記錄失敗時以最小 PR 重新觸發最新 main 部署。
-- 本 PR 作為最小 redeploy trigger，讓 Zeabur 重新部署包含 `@app/ratewise@2.22.5` 的最新 main。
+- root docs / empty changeset PR #300 合併後未產生新的 Zeabur deployment，推定 Zeabur 只監看 app 範圍路徑。
+- 追加 app-scoped README PR 作為最小 redeploy trigger，讓 Zeabur 重新部署包含 `@app/ratewise@2.22.5` 的最新 main。
 
 prevention:
 
@@ -45,11 +46,12 @@ verification:
 - `gh api repos/haotool/app/deployments`
 - `gh api repos/haotool/app/deployments/<id>/statuses`
 - `curl -s --compressed https://app.haotool.org/ratewise/ ...`（確認失敗時仍為 2.22.4）
-- 本 PR 合併後待驗證：正式站 `app-version=2.22.5`、Release rerun / live precache、main CI。
+- app-scoped PR 合併後待驗證：正式站 `app-version=2.22.5`、Zeabur deployment active SHA、live precache、main CI。
 
 references:
 
 - README.md
+- apps/ratewise/README.md
 - AGENTS.md
 - CLAUDE.md
 - docs/dev/002_development_reward_penalty_log.md


### PR DESCRIPTION
## 摘要
- 補充 RateWise README 的正式站部署驗證流程
- 記錄 root docs PR #300 未觸發 Zeabur deployment，改以 app 範圍 README PR 重新觸發
- 保持 empty changeset 狀態，不新增語意升版

## 驗證
- pnpm format
- pnpm changeset:status
- git diff --check
- pre-commit hook：lint-staged、typecheck、format
- pre-push hook：typecheck、test、build:ratewise
- diff PII scan：no output

## 生產收斂目標
- 合併後確認 Zeabur production deployment active SHA 為最新 main
- 正式站 /ratewise/ app-version 切到 2.22.5
- 重新執行 live precache 驗證