### PR TITLE
fix(ratewise): 修正 SITE_CONFIG.description SSOT 漂移與 FAQ email obfuscation

### DIFF
--- a/.changeset/seo-ssot-faq-email.md
+++ b/.changeset/seo-ssot-faq-email.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 SITE_CONFIG.description SSOT 漂移與 FAQ 頁 email Cloudflare obfuscation。

--- a/apps/ratewise/public/index.md
+++ b/apps/ratewise/public/index.md
@@ -1,6 +1,6 @@
 # HaoRate 匯率好工具
 
-> HaoRate 顯示臺灣銀行牌告的實際買賣價（非中間價），支援 TWD、USD、JPY、EUR 等 18 種貨幣，讓你換匯前就知道真正要付多少台幣。
+> HaoRate 顯示臺灣銀行牌告的實際買賣價（非中間價），讓你換匯前知道真正要付多少台幣。支援 18 種貨幣，每 5 分鐘同步，免費無廣告。
 
 - Canonical: https://app.haotool.org/ratewise/
 - Version: v2.22.7

--- a/apps/ratewise/seo-paths.config.mjs
+++ b/apps/ratewise/seo-paths.config.mjs
@@ -293,7 +293,7 @@ export const SITE_CONFIG = {
   url: withTrailingSlash('https://app.haotool.org/ratewise/'),
   name: APP_INFO.name,
   title: `${APP_INFO.shortName} — 台灣最精準匯率換算器`,
-  description: `${APP_INFO.shortName} 顯示臺灣銀行牌告的實際買賣價（非中間價），支援 TWD、USD、JPY、EUR 等 18 種貨幣，讓你換匯前就知道真正要付多少台幣。`,
+  description: `${APP_INFO.shortName} 顯示臺灣銀行牌告的實際買賣價（非中間價），讓你換匯前知道真正要付多少台幣。支援 18 種貨幣，每 5 分鐘同步，免費無廣告。`,
 };
 
 /**

--- a/apps/ratewise/src/config/seo-paths.ts
+++ b/apps/ratewise/src/config/seo-paths.ts
@@ -193,7 +193,7 @@ export const SITE_CONFIG = {
   url: normalizeSiteUrl('https://app.haotool.org/ratewise/'),
   name: APP_INFO.name,
   title: `${APP_INFO.shortName} — 台灣最精準匯率換算器`,
-  description: `${APP_INFO.shortName} 顯示臺灣銀行牌告的實際買賣價（非中間價），支援 TWD、USD、JPY、EUR 等 18 種貨幣，讓你換匯前就知道真正要付多少台幣。`,
+  description: `${APP_INFO.shortName} 顯示臺灣銀行牌告的實際買賣價（非中間價），讓你換匯前知道真正要付多少台幣。支援 18 種貨幣，每 5 分鐘同步，免費無廣告。`,
 } as const satisfies Readonly<{
   url: string;
   name: string;

--- a/apps/ratewise/src/pages/FAQ.tsx
+++ b/apps/ratewise/src/pages/FAQ.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { SEOHelmet } from '../components/SEOHelmet';
@@ -6,6 +7,18 @@ import { APP_INFO } from '../config/app-info';
 import { MailtoLink } from '../components/MailtoLink';
 import { AnswerCapsule } from '../components/AnswerCapsule';
 import { FAQ_PAGE_SEO, SITE_SEO } from '../config/seo-metadata';
+
+// 將 FAQ 答案中的 email 位址替換為 MailtoLink，防止 CF Email Obfuscation 將其改寫為爬蟲不可讀的 /cdn-cgi/... 連結。
+const EMAIL_RE = /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/;
+function renderFaqAnswer(answer: string): React.ReactNode {
+  const parts = answer.split(EMAIL_RE);
+  if (parts.length === 1) return answer;
+  return (
+    <>
+      {parts.map((part, i) => (EMAIL_RE.test(part) ? <MailtoLink key={i} email={part} /> : part))}
+    </>
+  );
+}
 
 const FAQ_ENTRIES = FAQ_PAGE_SEO.faqContent ?? [];
 const LAST_UPDATED = new Date(SITE_SEO.updatedTime).toLocaleDateString('zh-TW', {
@@ -95,7 +108,7 @@ export default function FAQ() {
                   </svg>
                 </summary>
                 <div className="border-t border-border px-6 pb-6 pt-4 leading-relaxed text-text-muted">
-                  {entry.answer}
+                  {renderFaqAnswer(entry.answer)}
                 </div>
               </details>
             ))}


### PR DESCRIPTION
## 摘要

- **M1 (SSOT 漂移)**：`SITE_CONFIG.description` 在 `seo-paths.config.mjs` 與 `seo-paths.ts` 的文字與 `DEFAULT_DESCRIPTION` 不一致（句序不同、缺少「每 5 分鐘同步，免費無廣告」），導致 Markdown mirror `index.md` 對 AI 爬蟲呈現的摘要與 HTML `<meta name="description">` 不同。統一對齊為 `DEFAULT_DESCRIPTION` 的文字。
- **M2 (CF Email Obfuscation)**：FAQ 頁 `entry.answer` 直接渲染包含 `APP_INFO.email` 的字串，Cloudflare Email Obfuscation 在邊緣將 `@` email 改寫為 `/cdn-cgi/l/email-protection#...`，爬蟲存取 404。新增 `renderFaqAnswer` helper，將 FAQ 答案中的 email 位址替換為 `MailtoLink` 渲染，SSR 不輸出 raw email，hydration 後才注入可點擊連結。

## 測試計畫

- [x] `vitest run markdown-mirror.test.ts` — 驗證 `index.md` 描述與新 `SITE_CONFIG.description` 一致
- [x] `vitest run seo-best-practices.test.ts seo-truthfulness.test.ts` — SEO schema 與真實性測試（155 通過）
- [x] `vitest run seo-paths.test.ts OpenData.test.tsx` — 58 通過
- [x] TypeScript check — 全 workspace 無錯誤
- [x] SSOT 同步驗證 — 249 canonical paths 一致

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)