### PR TITLE
fix(seo): 清除 markdown negotiation 繼承的 noindex

### DIFF
--- a/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
+++ b/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
@@ -413,6 +413,7 @@ describe('security-headers worker', () => {
       new Response('# ratewise markdown mirror', {
         headers: {
           'content-type': 'text/markdown; charset=utf-8',
+          'x-robots-tag': 'noindex',
         },
       }),
     );

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -653,3 +653,8 @@
 - ID：ratewise-markdown-mirror-noindex-guard-2026-05-02
 - 原因：正式站 `.md` mirrors 雖已正確回 `text/markdown` 並供 AI crawler 讀取，但未明確宣告 `noindex`，存在 mirror 與 canonical HTML 重複索引風險。
 - 解法：依 Google Search Central 非 HTML `X-Robots-Tag` 規範，於 Cloudflare Worker v5.1 與 `_headers` 對直連 `.md` 補 `X-Robots-Tag: noindex`，同時以測試鎖定 markdown negotiation 不得誤傷 canonical URL 索引。
+
+- 日期：2026-05-02
+- ID：pr325-markdown-negotiation-noindex-inheritance-fix
+- 原因：Codex P1 指出 markdown negotiation 會繼承上游 `.md` 的 `X-Robots-Tag: noindex`，導致 canonical URL 的 markdown 變體誤帶 noindex。
+- 解法：在 Worker 的 markdown negotiation 分支明確刪除繼承而來的 `X-Robots-Tag`，並把測試改成模擬上游實際帶 `noindex` 的情況，鎖住這個回歸。

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -813,6 +813,10 @@ export default {
 				response.headers.set('Content-Type', 'text/markdown; charset=utf-8');
 			}
 
+			if (isMarkdownNegotiation) {
+				response.headers.delete('X-Robots-Tag');
+			}
+
 			if (url.pathname.endsWith('.md')) {
 				response.headers.set('X-Robots-Tag', 'noindex');
 			}


### PR DESCRIPTION
## 摘要
- 清除 Accept: text/markdown 協商回應繼承自 upstream markdown mirror 的 X-Robots-Tag: noindex
- 保持直連 .md mirror 仍為 noindex，不改變既有 indexation 邊界
- 補強 securityHeadersWorker 回歸測試，模擬 upstream 已帶 noindex 的情境

## 根因
- PR #325 已將 .md mirror 設為 noindex，但 markdown negotiation 會抓取 upstream *.md 並複製 header
- 若不在 negotiation 分支主動刪除 X-Robots-Tag，canonical URL 的 markdown 變體會誤帶 noindex

## 驗證
- pnpm typecheck
- pnpm test
- pnpm build:ratewise

## 關聯
- follow-up for #325