### PR TITLE
fix(seo): 清除 markdown negotiation 繼承的 noindex（PR #325 P1 follow-up）

### DIFF
--- a/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
+++ b/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
@@ -413,6 +413,7 @@ describe('security-headers worker', () => {
       new Response('# ratewise markdown mirror', {
         headers: {
           'content-type': 'text/markdown; charset=utf-8',
+          'x-robots-tag': 'noindex',
         },
       }),
     );

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -653,3 +653,8 @@
 - ID：ratewise-markdown-mirror-noindex-guard-2026-05-02
 - 原因：正式站 `.md` mirrors 雖已正確回 `text/markdown` 並供 AI crawler 讀取，但未明確宣告 `noindex`，存在 mirror 與 canonical HTML 重複索引風險。
 - 解法：依 Google Search Central 非 HTML `X-Robots-Tag` 規範，於 Cloudflare Worker v5.1 與 `_headers` 對直連 `.md` 補 `X-Robots-Tag: noindex`，同時以測試鎖定 markdown negotiation 不得誤傷 canonical URL 索引。
+
+- 日期：2026-05-02
+- ID：pr325-markdown-negotiation-noindex-inheritance-fix
+- 原因：Codex P1 指出 markdown negotiation 會繼承上游 `.md` 的 `X-Robots-Tag: noindex`，導致 canonical URL 的 markdown 變體誤帶 noindex。
+- 解法：在 Worker 的 markdown negotiation 分支明確刪除繼承而來的 `X-Robots-Tag`，並把測試改成模擬上游實際帶 `noindex` 的情況，鎖住這個回歸。

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -813,6 +813,10 @@ export default {
 				response.headers.set('Content-Type', 'text/markdown; charset=utf-8');
 			}
 
+			if (isMarkdownNegotiation) {
+				response.headers.delete('X-Robots-Tag');
+			}
+
 			if (url.pathname.endsWith('.md')) {
 				response.headers.set('X-Robots-Tag', 'noindex');
 			}


### PR DESCRIPTION
## Summary

針對 PR #325 後 Codex 兩則 P1 unresolved review thread（[#325 r3176526260](https://github.com/haotool/app/pull/325#discussion_r3176526260)、[#325 r3176541036](https://github.com/haotool/app/pull/325#discussion_r3176541036)）：

當 `Accept: text/markdown` 用於 `/ratewise/` 等 canonical 路徑時，Worker 會抓取上游 `.md` 並複製其 headers；本次 commit 同時為 `.md` 加上 `X-Robots-Tag: noindex`，於是 markdown negotiation 變體會把 noindex 帶回 canonical 回應，違反「canonical URL 仍可索引」目標。

## Fix

在 `security-headers/src/worker.js` 對 markdown negotiation 分支加入 `response.headers.delete('X-Robots-Tag')`，確保 negotiation 回應永遠不繼承上游 `.md` 的 noindex；直連 `.md` 仍維持 noindex 不變。

## Test plan

- [x] `securityHeadersWorker.test.ts` 新增「上游 markdown mirror 已帶 noindex」情境，斷言 negotiation 回應不再帶 noindex
- [x] `pnpm --filter @app/ratewise exec vitest run src/__tests__/securityHeadersWorker.test.ts` 全綠
- [x] 002 稽核紀錄已同步更新

## Codex Resolution Sweep（近 20 個未回覆 thread 同步盤點）

本 PR 對應的 2 個 thread（#325 P1）即為「仍需 follow-up 修復」的部分。剩餘 21 個 thread 已在後續 commits 修復，本 PR description 一併標註各 thread 對應修復點，方便逐一 resolve：

| # | PR | P | Path | 修復狀態 | 證據 |
|---|----|----|------|---------|------|
| 1-2 | #325 | P1 | `worker.js:817-822` | **本 PR 修復** | `139ca898` `delete X-Robots-Tag` |
| 3-5 | #320 | P1/P2 | seo-public-surface / seo-surface-order / CurrencyLandingPage.truthfulness | ✅ main | `ensurePrerenderDist` helper + `beforeAll` |
| 6-7 | #319 | P1 | homepage-modulepreload.test.ts | ✅ main | `distExists` skip + `npm_lifecycle_event` (PR #322 `5b9c25ec`) |
| 8 | #317 | P1 | seo-iteration-orchestrator.mjs:131-136 | ✅ main | `maxBuffer: 50 * 1024 * 1024` |
| 9 | #317 | P1 | collect-seo-metrics.mjs:240-269 | ✅ main | `productionResourcesHealthOk && lighthouseHealthOk` |
| 10 | #317 | P2 | seo-iteration-orchestrator.mjs:344-396 | ✅ main | `shouldStopRun` 跳出外層 round 迴圈 |
| 11 | #315 | P2 | AppLayout.tsx:177-186 | ✅ main | `transitionForRender` render-time 計算 |
| 12-13 | #315 | P1 | AppLayout.tsx + Layout.tsx | ✅ main | `NonCriticalLazyBoundary` 包覆 lazy 全域提示 |
| 14-15 | #315 | P2 | NonCriticalLazyBoundary.tsx | ✅ main | `attempt`/`resetKey`/`online` retry + `useMemo([attempt])` 重建 lazy |
| 16-17 | #314 | P2 | AGENTS.md / CLAUDE.md | ✅ main | 002 已遷移至 `outline-v2-ultra` 4 行模板 |
| 18-20 | #306 | P2 | SEO_MASTER_SSOT.md / 002 | ✅ main | 4 行格式無需 `---` 分隔 / 無 impact 欄位；SSOT footer 對齊 header |
| 21 | #303 | P1 | SEO_MASTER_SSOT.md | ✅ main | 002 已補 v2.7.1 稽核條目（line 98） |
| 22 | #303 | P2 | seo-rate-examples.ts | ✅ main | `SEO_RATE_EXAMPLES_DATE` 與 `UPDATE_TIME` 已同日對齊 |
| 23 | #303 | P2 | SEO_MASTER_SSOT.md | ✅ main | 同 #18 |

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>