### PR TITLE
feat(tooling): 新增 Codex review thread 全域稽核腳本

### DIFF
--- a/.changeset/ratewise-mailto-crawlable-anchor-fix.md
+++ b/.changeset/ratewise-mailto-crawlable-anchor-fix.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 Lighthouse `crawlable-anchors` SEO 扣分：`MailtoLink` 改用 `<button>` 取代無 `href` 的 `<a>`，避免 `/about/`、`/faq/` 等含 email 的 SEO 頁面在 Lighthouse 被扣 5-8 分；同時保留繞過 Cloudflare Email Obfuscation 與防 email 收割的設計目的（SSG 仍輸出 `[at]` 形式、無 `mailto:`、hydration 後 click 開 `mailto:`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,7 @@ Agent **必須**先完成：
 
 - 推送前 **必須**通過 `pre-push` hook
 - 合併主支 **必須**透過 PR 與 `gh`（避免本地未審查直推 `main`）
+- 發生 PR / review / checks 事件時，**必須**先使用 repo 既有 review 稽核腳本（如 `pnpm review:codex:audit`）盤點 review threads，再配合 `gh` 逐條回覆並轉為 `resolved`；不得留下未回覆或未關閉的審查狀態
 - 若 PR checks 未完成或失敗，**不得**強制合併（除非維護者批准例外）
 
 ## Quality Gates (Repo SSOT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 
 **注意**：若 checks pending / failing，應先等待或修復，不應跳過審查控制。
 
+- 發生 PR / review / checks 事件時，必須先使用 repo 既有 review 稽核腳本（如 `pnpm review:codex:audit`）盤點 review threads，再配合 `gh` 逐條回覆處理證據並標記 `resolved`；不得只改碼不收斂 thread 狀態。
+
 ## SEO 生產資源可用性檢查（SSOT）
 
 - 使用 `node scripts/verify-production-resources.mjs` 驗證所有 app 的 `resources.seoFiles` 與 `resources.images`

--- a/apps/ratewise/src/components/MailtoLink.tsx
+++ b/apps/ratewise/src/components/MailtoLink.tsx
@@ -6,29 +6,39 @@ interface MailtoLinkProps {
 }
 
 /**
- * Renders an email address as a mailto link, but defers the href to client-side
- * hydration so Cloudflare Email Obfuscation cannot transform it during SSG.
+ * Renders an email "link" that:
+ *   1. Avoids Cloudflare Email Obfuscation (no `mailto:` href in SSG HTML).
+ *   2. Avoids raw email in SSG HTML (anti-scraper, displays "x [at] y").
+ *   3. Stays crawlable for Lighthouse SEO (uses `<button>`, so the
+ *      `crawlable-anchors` audit does not flag a missing `href`).
  *
- * Without this, Cloudflare rewrites `mailto:` hrefs into
- * `/cdn-cgi/l/email-protection#…` which returns 404 for crawlers without JS.
- *
- * SSG output  → <a>email [at] example.com</a>      (no href, no raw email)
- * After hydration → <a href="mailto:…">email@example.com</a>  (works for users)
+ * SSG output       → <button>email [at] example.com</button>
+ * After hydration  → <button data-email="email@example.com">email@example.com</button>
+ * On click         → opens `mailto:email@example.com`
  */
 export function MailtoLink({ email, className }: MailtoLinkProps) {
-  const ref = useRef<HTMLAnchorElement>(null);
+  const ref = useRef<HTMLButtonElement>(null);
   const safeLabel = email.replace('@', ' [at] ');
 
   useEffect(() => {
     if (ref.current) {
-      ref.current.setAttribute('href', `mailto:${email}`);
+      ref.current.dataset['email'] = email;
       ref.current.textContent = email;
     }
   }, [email]);
 
+  const handleClick = () => {
+    window.location.href = `mailto:${email}`;
+  };
+
   return (
-    <a ref={ref} className={className}>
+    <button
+      ref={ref}
+      type="button"
+      onClick={handleClick}
+      className={`bg-transparent border-0 p-0 cursor-pointer ${className ?? ''}`.trim()}
+    >
       {safeLabel}
-    </a>
+    </button>
   );
 }

--- a/apps/ratewise/src/components/__tests__/MailtoLink.test.tsx
+++ b/apps/ratewise/src/components/__tests__/MailtoLink.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { MailtoLink } from '../MailtoLink';
+
+describe('MailtoLink', () => {
+  it('renders as <button> (so Lighthouse crawlable-anchors is not triggered)', () => {
+    render(<MailtoLink email="test@example.com" />);
+    const el = screen.getByRole('button');
+    expect(el.tagName).toBe('BUTTON');
+    expect(el).toHaveAttribute('type', 'button');
+  });
+
+  it('hides the @ symbol in SSG output to avoid raw email harvesting', () => {
+    // SSG output (renderToString does not execute useEffect)
+    const ssg = renderToString(<MailtoLink email="test@example.com" />);
+    expect(ssg).toContain('test [at] example.com');
+    expect(ssg).not.toContain('test@example.com');
+    expect(ssg).not.toContain('mailto:');
+  });
+
+  it('does not emit an <a> element (avoids Cloudflare Email Obfuscation rewrite)', () => {
+    const { container } = render(<MailtoLink email="test@example.com" />);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('opens mailto when clicked', () => {
+    const originalLocation = window.location;
+    const setHrefMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(_target, prop, value) {
+          if (prop === 'href') setHrefMock(value);
+          return true;
+        },
+        get(target, prop) {
+          return Reflect.get(target, prop);
+        },
+      }),
+    });
+
+    render(<MailtoLink email="test@example.com" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(setHrefMock).toHaveBeenCalledWith('mailto:test@example.com');
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('applies provided className alongside reset styles', () => {
+    render(<MailtoLink email="x@y.z" className="text-primary underline" />);
+    const el = screen.getByRole('button');
+    expect(el.className).toContain('text-primary');
+    expect(el.className).toContain('underline');
+    // baseline reset classes still applied
+    expect(el.className).toContain('bg-transparent');
+    expect(el.className).toContain('cursor-pointer');
+  });
+});

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-03
+- ID：codex-review-audit-unknown-author-guard
+- 原因：PR #330 後續 Codex review 指出 `author: null` 的留言會先被轉成字串，再被誤判為人類回覆，讓 `no-reply` 分類失真。
+- 解法：將未知作者保留為 `null`，並要求 comment 必須有明確 login 才能算人類回覆，避免刪帳或停用帳號留言清掉待處理 thread。
+
+- 日期：2026-05-03
 - ID：codex-review-audit-thread-classification-followup
 - 原因：PR #330 的 Codex review 指出新稽核腳本將 bot 視為人類回覆、僅看第一則 Codex 評論判定 no-reply，且未補抓超過 100 筆的 thread comments。
 - 解法：補上 thread comments 分頁抓取，將 no-reply 基準改為最後一則 Codex 評論，並排除 `github-actions` 與 `[bot]` 類非人類回覆。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -12,6 +12,11 @@
 
 ## 條目（新→舊）
 
+- 日期：2026-05-03
+- ID：repo-codex-review-thread-audit-automation
+- 原因：既有 Codex review 腳本只覆蓋單 PR 或近幾天留言，無法對整個 repo 穩定盤點 unresolved / no-reply review threads。
+- 解法：新增全 repo GraphQL 分頁稽核腳本與 `pnpm review:codex:audit` 入口，自動依 thread 狀態與人類回覆情況分類，並輸出可供後續自動回覆與清掃流程重用的文字/JSON 結果。
+
 - 日期：2026-05-02
 - ID：ratewise-homepage-lcp-build-time-rates
 - 原因：首頁首屏仍同步觸發趨勢圖歷史資料、GA 與 PWA icon 暖機，Lighthouse Performance 停在 73-74 且 LCP 超過 7 秒。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-03
+- ID：codex-review-audit-thread-classification-followup
+- 原因：PR #330 的 Codex review 指出新稽核腳本將 bot 視為人類回覆、僅看第一則 Codex 評論判定 no-reply，且未補抓超過 100 筆的 thread comments。
+- 解法：補上 thread comments 分頁抓取，將 no-reply 基準改為最後一則 Codex 評論，並排除 `github-actions` 與 `[bot]` 類非人類回覆。
+
+- 日期：2026-05-03
 - ID：pr-review-script-enforcement-doc-sync
 - 原因：PR / review 事件的回覆與 resolved 收斂責任先前只分散在口頭流程，未明確要求優先使用 repo 既有稽核腳本盤點 threads。
 - 解法：在 `AGENTS.md` 與 `CLAUDE.md` 補上強制規則，要求先執行 `pnpm review:codex:audit` 類腳本盤點，再配合 `gh` 逐條回覆並轉為 resolved。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -658,3 +658,8 @@
 - ID：pr325-markdown-negotiation-noindex-inheritance-fix
 - 原因：Codex P1 指出 markdown negotiation 會繼承上游 `.md` 的 `X-Robots-Tag: noindex`，導致 canonical URL 的 markdown 變體誤帶 noindex。
 - 解法：在 Worker 的 markdown negotiation 分支明確刪除繼承而來的 `X-Robots-Tag`，並把測試改成模擬上游實際帶 `noindex` 的情況，鎖住這個回歸。
+
+- 日期：2026-05-02
+- ID：ratewise-mailto-crawlable-anchor-seo-fix
+- 原因：第 2 輪 SEO iteration 發現 `/about/`、`/faq/` Lighthouse SEO 從 100→92，根因為 `MailtoLink` SSG 輸出 `<a>` 無 `href`（為避開 Cloudflare Email Obfuscation），觸發 `crawlable-anchors` 扣分。
+- 解法：將 `MailtoLink` 改用 `<button type="button">` 取代 `<a>`，繼續無 `mailto:`/raw email SSG 輸出避開 CF 與 scraper，並補上 5 個 vitest 守門 button-only / 無 mailto / SSG label 等不變式。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-03
+- ID：pr-review-script-enforcement-doc-sync
+- 原因：PR / review 事件的回覆與 resolved 收斂責任先前只分散在口頭流程，未明確要求優先使用 repo 既有稽核腳本盤點 threads。
+- 解法：在 `AGENTS.md` 與 `CLAUDE.md` 補上強制規則，要求先執行 `pnpm review:codex:audit` 類腳本盤點，再配合 `gh` 逐條回覆並轉為 resolved。
+
+- 日期：2026-05-03
 - ID：repo-codex-review-thread-audit-automation
 - 原因：既有 Codex review 腳本只覆蓋單 PR 或近幾天留言，無法對整個 repo 穩定盤點 unresolved / no-reply review threads。
 - 解法：新增全 repo GraphQL 分頁稽核腳本與 `pnpm review:codex:audit` 入口，自動依 thread 狀態與人類回覆情況分類，並輸出可供後續自動回覆與清掃流程重用的文字/JSON 結果。

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "monitor:history": "node scripts/check-history-manifest.mjs",
     "monitor:schedule-drift": "node scripts/monitor-schedule-drift.mjs",
     "review:codex": "node scripts/codex-review.mjs",
+    "review:codex:audit": "node scripts/audit-codex-review-threads.mjs",
     "review:codex:once": "node scripts/monitor-codex-review.mjs --once",
     "review:codex:watch": "node scripts/monitor-codex-review.mjs --follow --interval 30",
     "seo:collect-metrics": "node scripts/collect-seo-metrics.mjs",

--- a/scripts/audit-codex-review-threads.mjs
+++ b/scripts/audit-codex-review-threads.mjs
@@ -298,7 +298,7 @@ function classifyThread(pr, thread) {
   const allComments = fetchAllThreadComments(thread.id, thread.comments);
   const comments = allComments.map((comment) => ({
     id: comment.id,
-    author: comment.author?.login ?? '(unknown)',
+    author: comment.author?.login ?? null,
     body: comment.body,
     createdAt: comment.createdAt,
     updatedAt: comment.updatedAt,
@@ -313,6 +313,7 @@ function classifyThread(pr, thread) {
   const hasHumanReplyAfterCodex = comments.some(
     (comment) =>
       comment.createdAt > latestCodex.createdAt &&
+      Boolean(comment.author) &&
       !isCodexLogin(comment.author) &&
       !isNonHumanReplyLogin(comment.author),
   );

--- a/scripts/audit-codex-review-threads.mjs
+++ b/scripts/audit-codex-review-threads.mjs
@@ -11,6 +11,7 @@ const DEFAULT_THREAD_BATCH = 100;
 const DEFAULT_COMMENT_BATCH = 100;
 const DEFAULT_STATES = ['OPEN', 'MERGED'];
 const CODEX_BOT_PATTERNS = ['chatgpt-codex-connector', 'codex', 'openai-codex'];
+const NON_HUMAN_REPLY_PATTERNS = ['github-actions', '[bot]'];
 
 function parseArgs(argv) {
   const opts = {
@@ -97,6 +98,11 @@ function isCodexLogin(login = '') {
   return CODEX_BOT_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 
+function isNonHumanReplyLogin(login = '') {
+  const normalized = String(login).toLowerCase();
+  return NON_HUMAN_REPLY_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
 function buildPrListQuery(states) {
   const statesLiteral = states.join(', ');
   return `
@@ -144,7 +150,36 @@ function buildThreadQuery() {
                   url
                   author { login }
                 }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+function buildThreadCommentsQuery() {
+  return `
+    query($threadId: ID!, $first: Int!, $after: String) {
+      node(id: $threadId) {
+        ... on PullRequestReviewThread {
+          comments(first: $first, after: $after) {
+            nodes {
+              id
+              body
+              createdAt
+              updatedAt
+              url
+              author { login }
             }
             pageInfo {
               hasNextPage
@@ -228,8 +263,40 @@ function fetchReviewThreads(repo, prNumber) {
   return threads;
 }
 
+function fetchAllThreadComments(threadId, initialComments) {
+  const commentQuery = buildThreadCommentsQuery();
+  const nodes = [...(initialComments?.nodes ?? [])];
+  let pageInfo = initialComments?.pageInfo ?? { hasNextPage: false, endCursor: null };
+
+  while (pageInfo.hasNextPage) {
+    const payload = ghJson(
+      [
+        'api',
+        'graphql',
+        '-F',
+        `threadId=${threadId}`,
+        '-F',
+        `first=${DEFAULT_COMMENT_BATCH}`,
+        '-F',
+        `after=${pageInfo.endCursor ?? ''}`,
+        '-F',
+        'query=@-',
+      ],
+      commentQuery,
+    );
+
+    const group = payload.data?.node?.comments;
+    if (!group) break;
+    nodes.push(...group.nodes);
+    pageInfo = group.pageInfo ?? { hasNextPage: false, endCursor: null };
+  }
+
+  return nodes;
+}
+
 function classifyThread(pr, thread) {
-  const comments = thread.comments.nodes.map((comment) => ({
+  const allComments = fetchAllThreadComments(thread.id, thread.comments);
+  const comments = allComments.map((comment) => ({
     id: comment.id,
     author: comment.author?.login ?? '(unknown)',
     body: comment.body,
@@ -241,9 +308,13 @@ function classifyThread(pr, thread) {
   if (codexComments.length === 0) return null;
 
   const firstCodex = codexComments[0];
+  const latestCodex = codexComments.at(-1) ?? firstCodex;
   const lastComment = comments.at(-1) ?? null;
   const hasHumanReplyAfterCodex = comments.some(
-    (comment) => comment.createdAt > firstCodex.createdAt && !isCodexLogin(comment.author),
+    (comment) =>
+      comment.createdAt > latestCodex.createdAt &&
+      !isCodexLogin(comment.author) &&
+      !isNonHumanReplyLogin(comment.author),
   );
   const classes = [];
   if (!thread.isResolved) classes.push('unresolved');
@@ -265,15 +336,16 @@ function classifyThread(pr, thread) {
     isOutdated: thread.isOutdated,
     hasHumanReplyAfterCodex,
     firstCodexAt: firstCodex.createdAt,
+    latestCodexAt: latestCodex.createdAt,
     lastCommentAuthor: lastComment?.author ?? null,
     lastCommentAt: lastComment?.createdAt ?? null,
     lastCommentUrl: lastComment?.url ?? null,
     codexCommentCount: codexComments.length,
     latestCodexComment: {
-      author: codexComments.at(-1)?.author ?? null,
-      createdAt: codexComments.at(-1)?.createdAt ?? null,
-      url: codexComments.at(-1)?.url ?? null,
-      body: codexComments.at(-1)?.body ?? '',
+      author: latestCodex.author ?? null,
+      createdAt: latestCodex.createdAt ?? null,
+      url: latestCodex.url ?? null,
+      body: latestCodex.body ?? '',
     },
     classes,
   };

--- a/scripts/audit-codex-review-threads.mjs
+++ b/scripts/audit-codex-review-threads.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+/* globals console, process */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_PR_BATCH = 25;
+const DEFAULT_PR_LIMIT = 200;
+const DEFAULT_THREAD_BATCH = 100;
+const DEFAULT_COMMENT_BATCH = 100;
+const DEFAULT_STATES = ['OPEN', 'MERGED'];
+const CODEX_BOT_PATTERNS = ['chatgpt-codex-connector', 'codex', 'openai-codex'];
+
+function parseArgs(argv) {
+  const opts = {
+    repo: null,
+    states: [...DEFAULT_STATES],
+    prLimit: DEFAULT_PR_LIMIT,
+    json: false,
+    output: null,
+    filter: 'all',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo' && argv[i + 1]) {
+      opts.repo = argv[++i];
+    } else if (arg === '--states' && argv[i + 1]) {
+      opts.states = argv[++i]
+        .split(',')
+        .map((value) => value.trim().toUpperCase())
+        .filter(Boolean);
+    } else if (arg === '--pr-limit' && argv[i + 1]) {
+      const value = Number(argv[++i]);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error('--pr-limit 必須是正整數');
+      }
+      opts.prLimit = value;
+    } else if (arg === '--filter' && argv[i + 1]) {
+      opts.filter = argv[++i];
+    } else if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--output' && argv[i + 1]) {
+      opts.output = argv[++i];
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Codex review thread 稽核
+
+用法：
+  node scripts/audit-codex-review-threads.mjs
+  node scripts/audit-codex-review-threads.mjs --filter unresolved
+  node scripts/audit-codex-review-threads.mjs --states OPEN,MERGED --pr-limit 100 --json
+  node scripts/audit-codex-review-threads.mjs --output .cache/codex-thread-audit.json
+
+參數：
+  --repo <owner/name>      指定 repo；未提供時自動使用目前 gh repo
+  --states <list>          PR 狀態，預設 OPEN,MERGED
+  --pr-limit <n>           最多掃描多少張 PR，預設 ${DEFAULT_PR_LIMIT}
+  --filter <type>          all | unresolved | no-reply | unresolved-no-reply | resolved-no-reply
+  --json                   以 JSON 輸出
+  --output <file>          將結果寫入檔案
+`);
+}
+
+function ghJson(args, stdin) {
+  const output = execFileSync('gh', args, {
+    input: stdin,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(output);
+}
+
+function resolveRepo(repoArg) {
+  if (repoArg) {
+    const [owner, name] = repoArg.split('/');
+    if (!owner || !name) {
+      throw new Error('--repo 必須是 owner/name');
+    }
+    return { owner, name, nameWithOwner: `${owner}/${name}` };
+  }
+  const repo = ghJson(['repo', 'view', '--json', 'nameWithOwner']);
+  const [owner, name] = repo.nameWithOwner.split('/');
+  return { owner, name, nameWithOwner: repo.nameWithOwner };
+}
+
+function isCodexLogin(login = '') {
+  const normalized = String(login).toLowerCase();
+  return CODEX_BOT_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function buildPrListQuery(states) {
+  const statesLiteral = states.join(', ');
+  return `
+    query($owner: String!, $repo: String!, $first: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: $first, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }, states: [${statesLiteral}]) {
+          nodes {
+            number
+            title
+            state
+            url
+            updatedAt
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `;
+}
+
+function buildThreadQuery() {
+  return `
+    query($owner: String!, $repo: String!, $number: Int!, $first: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          number
+          reviewThreads(first: $first, after: $after) {
+            nodes {
+              id
+              isResolved
+              isOutdated
+              path
+              line
+              originalLine
+              diffSide
+              comments(first: ${DEFAULT_COMMENT_BATCH}) {
+                nodes {
+                  id
+                  body
+                  createdAt
+                  updatedAt
+                  url
+                  author { login }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+function fetchPullRequests(repo, states, limit) {
+  const query = buildPrListQuery(states);
+  const prs = [];
+  let after = null;
+
+  while (prs.length < limit) {
+    const first = Math.min(DEFAULT_PR_BATCH, limit - prs.length);
+    const payload = ghJson(
+      [
+        'api',
+        'graphql',
+        '-F',
+        `owner=${repo.owner}`,
+        '-F',
+        `repo=${repo.name}`,
+        '-F',
+        `first=${first}`,
+        '-F',
+        `after=${after ?? ''}`,
+        '-F',
+        'query=@-',
+      ],
+      query,
+    );
+
+    const group = payload.data?.repository?.pullRequests;
+    if (!group) break;
+    prs.push(...group.nodes);
+    if (!group.pageInfo?.hasNextPage) break;
+    after = group.pageInfo.endCursor;
+  }
+
+  return prs.slice(0, limit);
+}
+
+function fetchReviewThreads(repo, prNumber) {
+  const query = buildThreadQuery();
+  const threads = [];
+  let after = null;
+
+  while (true) {
+    const payload = ghJson(
+      [
+        'api',
+        'graphql',
+        '-F',
+        `owner=${repo.owner}`,
+        '-F',
+        `repo=${repo.name}`,
+        '-F',
+        `number=${prNumber}`,
+        '-F',
+        `first=${DEFAULT_THREAD_BATCH}`,
+        '-F',
+        `after=${after ?? ''}`,
+        '-F',
+        'query=@-',
+      ],
+      query,
+    );
+
+    const group = payload.data?.repository?.pullRequest?.reviewThreads;
+    if (!group) break;
+    threads.push(...group.nodes);
+    if (!group.pageInfo?.hasNextPage) break;
+    after = group.pageInfo.endCursor;
+  }
+
+  return threads;
+}
+
+function classifyThread(pr, thread) {
+  const comments = thread.comments.nodes.map((comment) => ({
+    id: comment.id,
+    author: comment.author?.login ?? '(unknown)',
+    body: comment.body,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+    url: comment.url,
+  }));
+  const codexComments = comments.filter((comment) => isCodexLogin(comment.author));
+  if (codexComments.length === 0) return null;
+
+  const firstCodex = codexComments[0];
+  const lastComment = comments.at(-1) ?? null;
+  const hasHumanReplyAfterCodex = comments.some(
+    (comment) => comment.createdAt > firstCodex.createdAt && !isCodexLogin(comment.author),
+  );
+  const classes = [];
+  if (!thread.isResolved) classes.push('unresolved');
+  if (!hasHumanReplyAfterCodex) classes.push('no-reply');
+  if (!thread.isResolved && !hasHumanReplyAfterCodex) classes.push('unresolved-no-reply');
+  if (thread.isResolved && !hasHumanReplyAfterCodex) classes.push('resolved-no-reply');
+
+  return {
+    prNumber: pr.number,
+    prTitle: pr.title,
+    prState: pr.state,
+    prUrl: pr.url,
+    prUpdatedAt: pr.updatedAt,
+    threadId: thread.id,
+    path: thread.path,
+    line: thread.line ?? thread.originalLine ?? null,
+    diffSide: thread.diffSide ?? null,
+    isResolved: thread.isResolved,
+    isOutdated: thread.isOutdated,
+    hasHumanReplyAfterCodex,
+    firstCodexAt: firstCodex.createdAt,
+    lastCommentAuthor: lastComment?.author ?? null,
+    lastCommentAt: lastComment?.createdAt ?? null,
+    lastCommentUrl: lastComment?.url ?? null,
+    codexCommentCount: codexComments.length,
+    latestCodexComment: {
+      author: codexComments.at(-1)?.author ?? null,
+      createdAt: codexComments.at(-1)?.createdAt ?? null,
+      url: codexComments.at(-1)?.url ?? null,
+      body: codexComments.at(-1)?.body ?? '',
+    },
+    classes,
+  };
+}
+
+function filterItems(items, filter) {
+  if (filter === 'all') return items;
+  return items.filter((item) => item.classes.includes(filter));
+}
+
+function summarize(items) {
+  const counts = {
+    total: items.length,
+    unresolved: 0,
+    noReply: 0,
+    unresolvedNoReply: 0,
+    resolvedNoReply: 0,
+  };
+
+  for (const item of items) {
+    if (item.classes.includes('unresolved')) counts.unresolved += 1;
+    if (item.classes.includes('no-reply')) counts.noReply += 1;
+    if (item.classes.includes('unresolved-no-reply')) counts.unresolvedNoReply += 1;
+    if (item.classes.includes('resolved-no-reply')) counts.resolvedNoReply += 1;
+  }
+
+  return counts;
+}
+
+function renderText(repo, prsScanned, items, counts, filter) {
+  const lines = [];
+  lines.push(`Codex review thread 稽核：${repo.nameWithOwner}`);
+  lines.push(`掃描 PR 數：${prsScanned}`);
+  lines.push(`篩選：${filter}`);
+  lines.push(`符合條件：${items.length}`);
+  lines.push(
+    `統計（全量 Codex threads）：total=${counts.total}, unresolved=${counts.unresolved}, no-reply=${counts.noReply}, unresolved-no-reply=${counts.unresolvedNoReply}, resolved-no-reply=${counts.resolvedNoReply}`,
+  );
+  lines.push('');
+
+  if (items.length === 0) {
+    lines.push('沒有符合條件的 Codex review threads。');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const item of items) {
+    lines.push(`#${item.prNumber} ${item.prTitle}`);
+    lines.push(`  state=${item.prState} resolved=${item.isResolved} outdated=${item.isOutdated}`);
+    lines.push(`  class=${item.classes.join(', ')}`);
+    lines.push(`  file=${item.path ?? '(global)'} line=${item.line ?? '-'}`);
+    lines.push(`  latest=${item.lastCommentAuthor ?? '-'} ${item.lastCommentAt ?? '-'}`);
+    lines.push(`  url=${item.latestCodexComment.url ?? item.lastCommentUrl ?? item.prUrl}`);
+    lines.push(`  note=${item.latestCodexComment.body.replace(/\s+/g, ' ').slice(0, 220)}`);
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  const allowedFilters = new Set([
+    'all',
+    'unresolved',
+    'no-reply',
+    'unresolved-no-reply',
+    'resolved-no-reply',
+  ]);
+  if (!allowedFilters.has(opts.filter)) {
+    throw new Error(`--filter 僅支援 ${Array.from(allowedFilters).join(', ')}`);
+  }
+
+  const repo = resolveRepo(opts.repo);
+  const prs = fetchPullRequests(repo, opts.states, opts.prLimit);
+  const items = [];
+
+  for (const pr of prs) {
+    const threads = fetchReviewThreads(repo, pr.number);
+    for (const thread of threads) {
+      const item = classifyThread(pr, thread);
+      if (item) items.push(item);
+    }
+  }
+
+  items.sort((a, b) => Date.parse(b.firstCodexAt) - Date.parse(a.firstCodexAt));
+  const filtered = filterItems(items, opts.filter);
+  const counts = summarize(items);
+  const result = {
+    repo: repo.nameWithOwner,
+    scannedAt: new Date().toISOString(),
+    filters: {
+      states: opts.states,
+      prLimit: opts.prLimit,
+      filter: opts.filter,
+    },
+    scannedPrCount: prs.length,
+    matchedCount: filtered.length,
+    counts,
+    items: filtered,
+  };
+
+  const output = opts.json
+    ? `${JSON.stringify(result, null, 2)}\n`
+    : renderText(repo, prs.length, filtered, counts, opts.filter);
+  if (opts.output) {
+    fs.mkdirSync(path.dirname(opts.output), { recursive: true });
+    fs.writeFileSync(opts.output, output, 'utf8');
+  }
+  process.stdout.write(output);
+}
+
+main();


### PR DESCRIPTION
## 摘要
- 新增全 repo 的 Codex review thread 稽核腳本
- 補上 `pnpm review:codex:audit` 入口，支援 CLI / JSON 雙輸出
- 腳本自動用 `gh repo view` 解析 repo，並用 GraphQL 分頁掃描 PR 與 review threads，避免硬編碼 repo 與單 PR 限制

## 設計重點
- 不硬編碼 owner/repo：預設從目前 `gh` repo 自動解析，也支援 `--repo owner/name`
- 不硬編碼單一 PR：支援 `--states`、`--pr-limit`、`--filter`
- 以 thread 為 SSOT：分類 `unresolved`、`no-reply`、`unresolved-no-reply`、`resolved-no-reply`
- 同時支援人讀文字輸出與機器可消費 JSON，便於後續自動回覆 / weekly audit / dashboard 整合

## 本地驗證
- `node scripts/audit-codex-review-threads.mjs --pr-limit 80 --filter unresolved`
- `node scripts/audit-codex-review-threads.mjs --pr-limit 80 --filter no-reply --json`
- `pnpm review:codex:audit -- --pr-limit 20 --filter unresolved`
- `git push` 前 repo `pre-push` 全綠（typecheck / test / build:ratewise）

## 全 repo 掃描快照
以 `--pr-limit 200 --filter unresolved` 掃描目前 repo：
- `total Codex threads = 128`
- `unresolved = 69`
- `no-reply = 33`
- `unresolved-no-reply = 31`
- `resolved-no-reply = 2`

目前前三個高訊號 unresolved threads：
1. `PR #270` `.github/workflows/update-latest-rates.yml:210`
   `continue-on-error` 下用 `conclusion` 判斷失敗，可能吃掉 warning
2. `PR #263` `apps/ratewise/index.html:24`
   manifest href 硬編 `/ratewise/manifest.webmanifest`，不利 base path 可配置部署
3. `PR #263` `apps/ratewise/vite.config.ts:329`
   `manifest: false` 可能影響 PWA manifest link generation
