### PR TITLE
fix(seo): 納入 authority guide 正式驗證

### DIFF
--- a/.changeset/ratewise-authority-guide-verification.md
+++ b/.changeset/ratewise-authority-guide-verification.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+將 3 篇 Authority Guide Markdown mirrors 納入正式 SEO 驗證清單，並補齊對應的 Markdown alternate Link 治理。

--- a/apps/ratewise/public/_headers
+++ b/apps/ratewise/public/_headers
@@ -97,6 +97,12 @@
   Link: </ratewise/guide.md>; rel="alternate"; type="text/markdown"
 /ratewise/open-data/
   Link: </ratewise/open-data.md>; rel="alternate"; type="text/markdown"
+/ratewise/sell-rate-vs-mid-rate/
+  Link: </ratewise/sell-rate-vs-mid-rate.md>; rel="alternate"; type="text/markdown"
+/ratewise/cash-vs-spot-rate/
+  Link: </ratewise/cash-vs-spot-rate.md>; rel="alternate"; type="text/markdown"
+/ratewise/card-rate-guide/
+  Link: </ratewise/card-rate-guide.md>; rel="alternate"; type="text/markdown"
 /*.css
   Cache-Control: public, max-age=86400
 /*.js

--- a/apps/ratewise/seo-paths.config.mjs
+++ b/apps/ratewise/seo-paths.config.mjs
@@ -248,6 +248,9 @@ export const SEO_FILES = [
   '/about.md',
   '/privacy.md',
   '/open-data.md',
+  '/sell-rate-vs-mid-rate.md',
+  '/cash-vs-spot-rate.md',
+  '/card-rate-guide.md',
 ];
 
 /**

--- a/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
+++ b/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
@@ -288,6 +288,23 @@ describe('security-headers worker', () => {
     expect(response.headers.get('vary')).toMatch(/(?:^|,\s*)accept(?:\s*,|$)/i);
   });
 
+  it('authority guide HTML 頁應輸出對應的 Markdown alternate Link header', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        createHtmlResponse('<!doctype html><html><head></head><body>authority guide</body></html>'),
+      );
+
+    const response = await worker.fetch(
+      new Request('https://app.haotool.org/ratewise/sell-rate-vs-mid-rate/'),
+    );
+    const link = response.headers.get('link') ?? '';
+
+    expect(link).toContain(
+      '<https://app.haotool.org/ratewise/sell-rate-vs-mid-rate.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
   it('既有 Vary 標頭存在時，Markdown negotiable 路徑只會 append Accept、不重複', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(

--- a/apps/ratewise/src/config/__tests__/seo-paths.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-paths.test.ts
@@ -163,6 +163,9 @@ describe('SEO Paths Configuration', () => {
         '/about.md',
         '/privacy.md',
         '/open-data.md',
+        '/sell-rate-vs-mid-rate.md',
+        '/cash-vs-spot-rate.md',
+        '/card-rate-guide.md',
       ]);
     });
 

--- a/apps/ratewise/src/config/seo-paths.ts
+++ b/apps/ratewise/src/config/seo-paths.ts
@@ -190,6 +190,9 @@ export const SEO_FILES = [
   '/about.md',
   '/privacy.md',
   '/open-data.md',
+  '/sell-rate-vs-mid-rate.md',
+  '/cash-vs-spot-rate.md',
+  '/card-rate-guide.md',
 ] as const;
 
 export const SHARE_IMAGE = '/og-image.jpg' as const;

--- a/docs/SEO_MASTER_SSOT.md
+++ b/docs/SEO_MASTER_SSOT.md
@@ -233,7 +233,7 @@ public/
 - 內容與對應 HTML 頁語義一致（同 FAQ、同作者、同資料來源），符合 Google cloaking 紅線。
 - Authority Guide mirrors（`sell-rate-vs-mid-rate.md`、`cash-vs-spot-rate.md`、`card-rate-guide.md`）已納入 `llms.txt`，讓 AI crawler 可直接發現長篇主題頁的純文字版本。
 - drift-guard 測試：`apps/ratewise/src/__tests__/markdown-mirror.test.ts`（含 Authority Guide mirrors 與 `llms.txt` 收錄斷言）。
-- 注意：`SEO_FILES` SSOT 已擴充為 12 個公開 SEO / AI 資源：`sitemap.xml`、`robots.txt`、`llms.txt`、`llms-full.txt`、`openapi.json`、`api/latest.json` 與 6 個核心 Markdown mirrors（`index.md`、`faq.md`、`guide.md`、`about.md`、`privacy.md`、`open-data.md`）。3 篇 Authority Guide mirrors 目前仍由 prebuild、`_headers`、`llms.txt` 與手動 smoke probe 管理，尚未納入 `resources.seoFiles` 驗證清單。
+- 注意：`SEO_FILES` SSOT 已擴充為 15 個公開 SEO / AI 資源：`sitemap.xml`、`robots.txt`、`llms.txt`、`llms-full.txt`、`openapi.json`、`api/latest.json`，以及 9 個 Markdown mirrors（`index.md`、`faq.md`、`guide.md`、`about.md`、`privacy.md`、`open-data.md`、`sell-rate-vs-mid-rate.md`、`cash-vs-spot-rate.md`、`card-rate-guide.md`）。Authority Guide mirrors 現已納入 `resources.seoFiles` 正式驗證清單，與 `_headers`、Worker alternate Link、`llms.txt` 共同構成單一治理閉環。
 
 ### 2.4 驗證層（Verification Layer）
 
@@ -1501,13 +1501,13 @@ curl -s --compressed https://app.haotool.org/.well-known/agent-skills/index.json
 
 ```bash
 # 1. 生產 SEO 健康檢查（覆蓋 SEO_PATHS 公開路徑 200、APP_ONLY_PATHS app-shell 路由、
-#    SEO_FILES = sitemap/robots/llms/llms-full/openapi/api/latest + 6 個核心 Markdown mirrors、
+#    SEO_FILES = sitemap/robots/llms/llms-full/openapi/api/latest + 9 個 Markdown mirrors、
 #    sitemap 與 hreflang 內容、404 真實性、舊資產 301）
 #    --base-url 可指向 staging
 node scripts/verify-production-seo.mjs ratewise --base-url=https://app.haotool.org/ratewise
 
 # 2. 生產資源可用性（OG/Twitter 圖片 + favicon + apple-touch-icon + 3 個 PWA icon + SEO_FILES）
-#    實際覆蓋為 IMAGE_RESOURCES（7 個檔）+ SEO_FILES（12 個檔）；不含 manifest.webmanifest、screenshots
+#    實際覆蓋為 IMAGE_RESOURCES（7 個檔）+ SEO_FILES（15 個檔）；不含 manifest.webmanifest、screenshots
 node scripts/verify-production-resources.mjs ratewise
 
 # 3. 結構化資料驗證（schema 種類 / Speakable / aggregateRating gate）
@@ -1516,9 +1516,9 @@ node scripts/verify-structured-data.mjs
 # 4. 公開 SEO 真相 surface 檢查（H1 順序、SeoTech、sitemap 舊標籤）
 pnpm --filter @app/ratewise vitest run src/__tests__/seo-public-surface.test.ts
 
-# 5. §12.7.2 表格剩餘端點補充探針（命令 #1/#2 不涵蓋的 PWA/noindex 頁與 3 篇 Authority Guide Markdown mirrors）
+# 5. §12.7.2 表格剩餘端點補充探針（命令 #1/#2 不涵蓋的 PWA/noindex 頁）
 #    這些端點故意不在 SEO_PATHS / SEO_FILES：/manifest.webmanifest 屬 PWA、/privacy/ 屬 noindex；
-#    3 篇 Authority Guide mirrors 目前尚未納入 `resources.seoFiles`，故額外列出做 smoke probe
+#    其餘 9 個 Markdown mirrors 已由 `resources.seoFiles` 正式覆蓋
 #    Markdown 鏡像 path 對齊 _headers 與 generate-markdown-mirrors.mjs SSOT：
 #      /ratewise/index.md      ↔ /ratewise/
 #      /ratewise/{slug}.md     ↔ /ratewise/{slug}/    （faq、about、guide、open-data、privacy、sell-rate-vs-mid-rate、cash-vs-spot-rate、card-rate-guide）
@@ -1549,9 +1549,9 @@ curl -X POST https://isitagentready.com/api/scan -H 'Content-Type: application/j
 
 > **覆蓋說明**：
 >
-> - 命令 #1 (`verify-production-seo.mjs`) 覆蓋 `apps/ratewise/seo-paths.config.mjs` 的 `seoPaths`（249 URL）+ `appShellPaths` + `resources.seoFiles`（目前為 12 檔：`/sitemap.xml`、`/robots.txt`、`/llms.txt`、`/llms-full.txt`、`/openapi.json`、`/api/latest.json` 與 6 個核心 Markdown mirrors），對齊 §12.6.5 與 CI 實作。
-> - 命令 #2 (`verify-production-resources.mjs`) 實際覆蓋 `IMAGE_RESOURCES`（`/og-image.jpg`、`/twitter-image.jpg`、`/favicon.ico`、`/apple-touch-icon.png`、3 個 PWA icon — 共 7 檔）+ `SEO_FILES`（12 檔）；**不含** `/manifest.webmanifest` 與 `screenshots/*`。
-> - **§12.7.2 表格中**：`/manifest.webmanifest` 不在 `SEO_FILES`（屬 PWA 類），`/privacy/` 不在 `seoPaths`（noindex），3 篇 Authority Guide Markdown mirrors 目前也不在 `resources.seoFiles` 驗證集合，**因此命令 #5 對這些端點獨立做 smoke probe**，避免「命令 #1/#2 通過但實際漏檢」。
+> - 命令 #1 (`verify-production-seo.mjs`) 覆蓋 `apps/ratewise/seo-paths.config.mjs` 的 `seoPaths`（249 URL）+ `appShellPaths` + `resources.seoFiles`（目前為 15 檔：`/sitemap.xml`、`/robots.txt`、`/llms.txt`、`/llms-full.txt`、`/openapi.json`、`/api/latest.json` 與 9 個 Markdown mirrors），對齊 §12.6.5 與 CI 實作。
+> - 命令 #2 (`verify-production-resources.mjs`) 實際覆蓋 `IMAGE_RESOURCES`（`/og-image.jpg`、`/twitter-image.jpg`、`/favicon.ico`、`/apple-touch-icon.png`、3 個 PWA icon — 共 7 檔）+ `SEO_FILES`（15 檔）；**不含** `/manifest.webmanifest` 與 `screenshots/*`。
+> - **§12.7.2 表格中**：`/manifest.webmanifest` 不在 `SEO_FILES`（屬 PWA 類），`/privacy/` 不在 `seoPaths`（noindex）；其餘 9 個 Markdown mirrors 已由 `resources.seoFiles` 與 production verification 正式覆蓋，避免「命令 #1/#2 通過但實際漏檢」。
 > - v2.7.0 初版誤把命令 #1 寫成 `verify-production-resources.mjs --base-url=...`，但該腳本只讀 `resources.seoFiles/images` 且不接受 `--base-url`；已於本次修正為 `verify-production-seo.mjs` 並補上 #5 探針。
 
 #### 12.7.8 2026-04-30 例行重跑狀態

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-04
+- ID：ratewise-authority-guide-mirror-production-verification
+- 原因：3 篇 Authority Guide Markdown mirrors 已存在於 public 與 `llms.txt`，但未被納入 `SEO_FILES` 與正式 production verification，且 Worker / `_headers` 的 alternate Link 治理也未完全覆蓋，形成真實監測缺口。
+- 解法：將 3 篇 Authority Guide mirrors 納入 `SEO_FILES` SSOT，補齊 Worker 與 `_headers` 的 Markdown alternate Link 覆蓋，並以 seo-paths / securityHeaders / markdown mirror 測試與 SSOT 驗證收斂為正式閉環。
+
+- 日期：2026-05-04
 - ID：issue-backlog-contract-rule-sync
 - 原因：repo 先前雖要求 review thread 收斂，但對 issue / backlog 的格式、嚴重度標籤與刪除條件仍缺乏正式契約條款，容易導致未來 agent 使用不一致格式。
 - 解法：在 `AGENTS.md` 與 `CLAUDE.md` 補入 issue / backlog 契約規則，強制使用正式 issue 結構、`severity:*` 標籤與 `gh` 刪除前置條件。

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -56,6 +56,17 @@ const ROOT_SITE_HTML_HOSTS = new Set(['haotool.org', 'www.haotool.org']);
 const HAOTOOL_ROOT_HTML_PATHS = new Set(['/', '/projects/', '/about/', '/contact/']);
 const HAOTOOL_ROOT_MARKDOWN_MIRROR = '/index.md';
 const RATEWISE_MARKDOWN_MIRROR = '/ratewise/index.md';
+const RATEWISE_PAGE_MARKDOWN_MIRRORS = new Map([
+	['/ratewise/', '/ratewise/index.md'],
+	['/ratewise/faq/', '/ratewise/faq.md'],
+	['/ratewise/about/', '/ratewise/about.md'],
+	['/ratewise/privacy/', '/ratewise/privacy.md'],
+	['/ratewise/guide/', '/ratewise/guide.md'],
+	['/ratewise/open-data/', '/ratewise/open-data.md'],
+	['/ratewise/sell-rate-vs-mid-rate/', '/ratewise/sell-rate-vs-mid-rate.md'],
+	['/ratewise/cash-vs-spot-rate/', '/ratewise/cash-vs-spot-rate.md'],
+	['/ratewise/card-rate-guide/', '/ratewise/card-rate-guide.md'],
+]);
 const AGENT_SKILLS_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 const API_CATALOG_PATH = '/.well-known/api-catalog';
 const AGENT_SKILLS_INDEX_PATH = '/.well-known/agent-skills/index.json';
@@ -254,6 +265,15 @@ function buildRatewiseAgentDiscoveryLinks(url) {
 		`<${buildAbsoluteUrl(url, '/ratewise/openapi.json')}>; rel="service-desc"; type="application/vnd.oai.openapi+json"`,
 		`<${buildAbsoluteUrl(url, '/ratewise/open-data/')}>; rel="service-doc"; type="text/html"`,
 	];
+}
+
+function resolveRatewiseMarkdownAlternate(url) {
+	const normalizedPath = normalizeHtmlPath(url.pathname);
+	const mirrorPath = RATEWISE_PAGE_MARKDOWN_MIRRORS.get(normalizedPath);
+	if (!mirrorPath) {
+		return null;
+	}
+	return `<${buildAbsoluteUrl(url, mirrorPath)}>; rel="alternate"; type="text/markdown"`;
 }
 
 function resolveAgentDiscoveryLinks(url) {
@@ -864,6 +884,10 @@ export default {
 
 		if (isHTML) {
 			addLinkHeaders(response, resolveAgentDiscoveryLinks(url));
+			const markdownAlternate = resolveRatewiseMarkdownAlternate(url);
+			if (markdownAlternate !== null) {
+				addLinkHeader(response, markdownAlternate);
+			}
 		}
 
 		stripOriginLeakHeaders(response);


### PR DESCRIPTION
Closes #343

## 摘要
- 將 3 篇 Authority Guide Markdown mirrors 納入 `SEO_FILES` SSOT
- 補齊 `security-headers` worker 與 `apps/ratewise/public/_headers` 的 Markdown alternate Link 覆蓋
- 更新回歸測試、changeset、`SEO_MASTER_SSOT` 與 `002` 紀錄

## 背景與根因
目前正式 SEO 驗證腳本是依 `resources.seoFiles` / `SEO_FILES` 展開檢查，因此真正的缺口不是腳本本身，而是 SSOT 尚未納入：
- `/sell-rate-vs-mid-rate.md`
- `/cash-vs-spot-rate.md`
- `/card-rate-guide.md`

另外 Authority Guide HTML 頁原先也沒有完整輸出對應的 Markdown `Link: rel=alternate; type=text/markdown` header，造成治理與驗證邊界不一致。

## 變更範圍
- `apps/ratewise/seo-paths.config.mjs`
- `apps/ratewise/src/config/seo-paths.ts`
- `apps/ratewise/public/_headers`
- `security-headers/src/worker.js`
- `apps/ratewise/src/config/__tests__/seo-paths.test.ts`
- `apps/ratewise/src/__tests__/securityHeadersWorker.test.ts`
- `docs/SEO_MASTER_SSOT.md`
- `docs/dev/002_development_reward_penalty_log.md`
- `.changeset/ratewise-authority-guide-verification.md`

## 驗證
- `node scripts/verify-ssot-sync.mjs`
- `pnpm --filter @app/ratewise exec vitest run src/config/__tests__/seo-paths.test.ts src/__tests__/securityHeadersWorker.test.ts src/__tests__/markdown-mirror.test.ts`
- `pnpm --filter @app/ratewise typecheck`
- `pre-push`: `pnpm -r typecheck`、`pnpm -r test`、`pnpm build:ratewise`
