### PR TITLE
fix(ratewise): 收斂離線冷啟動驗證

### DIFF
--- a/.changeset/ratewise-offline-cold-start-e2e.md
+++ b/.changeset/ratewise-offline-cold-start-e2e.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+穩定離線冷啟動 E2E 診斷，避免 PWA precache readiness 的假陽性失敗。

--- a/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
+++ b/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
@@ -18,17 +18,102 @@
  * @created 2026-03-12
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] || 'http://localhost:4173';
 const BASE_PATH =
   process.env['E2E_BASE_PATH'] || process.env['VITE_RATEWISE_BASE_PATH'] || '/ratewise';
 const BASE = `${BASE_URL}${BASE_PATH}/`.replace(/\/+$/, '/');
 
-// precache 暖機等待時間（ms）
-const PRECACHE_SETTLE_MS = 5000;
+interface PrecacheAuditSummary {
+  precacheName: string | null;
+  totalEntries: number;
+  jsCount: number;
+  cssCount: number;
+  hasIndexHtml: boolean;
+  hasOfflineHtml: boolean;
+}
+
+async function getPrecacheAudit(page: Page, baseUrl: string): Promise<PrecacheAuditSummary> {
+  return page.evaluate(async (resolvedBaseUrl: string) => {
+    const names = await caches.keys();
+    const precacheName = names.find((name) => name.startsWith('workbox-precache-v2')) ?? null;
+
+    if (!precacheName) {
+      return {
+        precacheName: null,
+        totalEntries: 0,
+        jsCount: 0,
+        cssCount: 0,
+        hasIndexHtml: false,
+        hasOfflineHtml: false,
+      };
+    }
+
+    const cache = await caches.open(precacheName);
+    const keys = await cache.keys();
+    const normalizedBaseUrl = resolvedBaseUrl.replace(/\/$/, '');
+
+    const summary: PrecacheAuditSummary = {
+      precacheName,
+      totalEntries: keys.length,
+      jsCount: 0,
+      cssCount: 0,
+      hasIndexHtml: false,
+      hasOfflineHtml: false,
+    };
+
+    for (const req of keys) {
+      const url = req.url;
+      if (url.includes('.js') && url.includes('assets/')) summary.jsCount++;
+      if (url.includes('.css')) summary.cssCount++;
+      if (
+        url.endsWith('/') ||
+        url.includes('index.html') ||
+        url.replace(/\/$/, '') === normalizedBaseUrl
+      ) {
+        summary.hasIndexHtml = true;
+      }
+      if (url.includes('offline.html')) {
+        summary.hasOfflineHtml = true;
+      }
+    }
+
+    return summary;
+  }, baseUrl);
+}
+
+async function waitForOfflineReadiness(page: Page, baseUrl: string): Promise<PrecacheAuditSummary> {
+  const deadline = Date.now() + 30_000;
+  let lastAudit: PrecacheAuditSummary = {
+    precacheName: null,
+    totalEntries: 0,
+    jsCount: 0,
+    cssCount: 0,
+    hasIndexHtml: false,
+    hasOfflineHtml: false,
+  };
+
+  while (Date.now() < deadline) {
+    lastAudit = await getPrecacheAudit(page, baseUrl);
+    if (
+      lastAudit.precacheName &&
+      lastAudit.jsCount >= 5 &&
+      lastAudit.cssCount >= 1 &&
+      lastAudit.hasIndexHtml &&
+      lastAudit.hasOfflineHtml
+    ) {
+      return lastAudit;
+    }
+
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error(`Offline readiness audit timeout: ${JSON.stringify(lastAudit)}`);
+}
 
 test.describe('飛航模式冷啟動診斷', () => {
+  test.describe.configure({ mode: 'serial' });
   test.use({ serviceWorkers: 'allow' });
   // 冷啟動測試包含：SW 安裝 + precache 暖機（5s）+ 離線導覽，需要較長超時。
   test.setTimeout(120_000);
@@ -61,8 +146,9 @@ test.describe('飛航模式冷啟動診斷', () => {
       undefined,
       { timeout: 60000 },
     );
-    console.log('[Phase 1] SW activated，等待 precache settle...');
-    await warmPage.waitForTimeout(PRECACHE_SETTLE_MS);
+    console.log('[Phase 1] SW activated，等待 offline readiness 診斷達標...');
+    const warmAudit = await waitForOfflineReadiness(warmPage, BASE);
+    console.log(`[Phase 1] precache ready: ${JSON.stringify(warmAudit)}`);
 
     // ======================================================================
     // Phase 2：快取審計 - 列出所有 cache storage 條目
@@ -238,7 +324,7 @@ test.describe('飛航模式冷啟動診斷', () => {
       undefined,
       { timeout: 60_000 },
     );
-    await page.waitForTimeout(PRECACHE_SETTLE_MS);
+    await waitForOfflineReadiness(page, BASE);
 
     // Phase 2：清除所有非 precache 快取（模擬新安裝 — 只有 SW install 填充的 precache）。
     const clearedCaches = await page.evaluate(async () => {
@@ -346,7 +432,7 @@ test.describe('飛航模式冷啟動診斷', () => {
       undefined,
       { timeout: 60_000 },
     );
-    await page.waitForTimeout(PRECACHE_SETTLE_MS);
+    await waitForOfflineReadiness(page, BASE);
 
     // 驗證 precache 中的每個 JS chunk 都能被 ignoreSearch 和 matchPrecache 策略命中。
     interface CacheHitReport {
@@ -412,7 +498,7 @@ test.describe('飛航模式冷啟動診斷', () => {
       undefined,
       { timeout: 60000 },
     );
-    await page.waitForTimeout(PRECACHE_SETTLE_MS);
+    await waitForOfflineReadiness(page, BASE);
 
     const { jsCacheCount, cssCacheCount, cacheNames } = await page.evaluate(async () => {
       const names = await caches.keys();

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-04
+- ID：ratewise-offline-cold-start-e2e-serial-audit
+- 原因：`offline-cold-start.spec.ts` 在 `fullyParallel` 下會讓多個 stateful PWA 測試同時操作同一個 origin 的 precache 與 runtime caches，首輪間歇誤判「冷啟動離線失敗 / 無 CSS」，造成真 bug 與測試競態無法區分。
+- 解法：將 `offline-cold-start` 測試明確改為 serial，並把固定 5 秒硬等待改成直接輪詢 Cache Storage 的 precache audit，要求 JS/CSS/index/offline.html 四項 readiness 全達標後才進入斷言，讓未來離線回歸有可觀測證據且不再靠 retry 撐過。
+
+- 日期：2026-05-04
 - ID：ratewise-authority-guide-mirror-production-verification
 - 原因：3 篇 Authority Guide Markdown mirrors 已存在於 public 與 `llms.txt`，但未被納入 `SEO_FILES` 與正式 production verification，且 Worker / `_headers` 的 alternate Link 治理也未完全覆蓋，形成真實監測缺口。
 - 解法：將 3 篇 Authority Guide mirrors 納入 `SEO_FILES` SSOT，補齊 Worker 與 `_headers` 的 Markdown alternate Link 覆蓋，並以 seo-paths / securityHeaders / markdown mirror 測試與 SSOT 驗證收斂為正式閉環。


### PR DESCRIPTION
## 摘要
- 將 `offline-cold-start.spec.ts` 改為 serial，避免 stateful PWA 測試在 `fullyParallel` 下互相清除同一個 origin 的 precache / runtime caches
- 以 Cache Storage readiness audit 取代固定 5 秒等待，要求 precache 的 JS / CSS / `index.html` / `offline.html` 全數就緒後才進入斷言
- 更新 `002` 與 changeset，保留最小必要變更

## 根因
- 主線現況在 parallel 執行 `offline-cold-start.spec.ts` 時，首輪會間歇出現 `CSS files = 0`，retry 才恢復
- 同一份 spec 改成 `--workers=1` 後穩定全綠，證明不是正式站 SW 策略壞掉，而是測試並行模型與固定等待造成假陽性
- 回退點落在 `59d38e2f`：該 commit 把 `offline-cold-start.spec.ts` 納入 `offline-pwa-chromium` 專案，但沒有同時為這組會操作共享快取的測試加上 serial 隔離；而 `fullyParallel: true` 早已存在於 `playwright.config.ts`

## 驗證
- `pnpm --filter @app/ratewise exec vitest run src/__tests__/sw.test.ts src/pwa-offline.test.ts`
- `pnpm --filter @app/ratewise typecheck`
- `CI=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4177 E2E_BASE_PATH=/ratewise pnpm --filter @app/ratewise exec playwright test tests/e2e/offline-cold-start.spec.ts --project=offline-pwa-chromium`
- `CI=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4177 E2E_BASE_PATH=/ratewise pnpm --filter @app/ratewise exec playwright test tests/e2e/offline-pwa.spec.ts tests/e2e/offline-cold-start.spec.ts --project=offline-pwa-chromium`
- `git push` 前 `pre-push`：`pnpm -r typecheck`、`pnpm -r test`、`pnpm build:ratewise` 全通過