### PR TITLE
perf(ratewise): 建立 production baseline 自動化監控

### DIFF
--- a/.github/workflows/lighthouse-production.yml
+++ b/.github/workflows/lighthouse-production.yml
@@ -1,0 +1,187 @@
+name: Lighthouse Production Baseline
+
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Target production URL (with trailing slash)'
+        required: false
+        default: 'https://app.haotool.org/ratewise/'
+        type: string
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/ratewise/**'
+      - 'scripts/lighthouse-production.mjs'
+      - 'scripts/lighthouse-baseline.production.json'
+      - '.github/workflows/lighthouse-production.yml'
+
+jobs:
+  lighthouse-production:
+    name: Production Lighthouse Baseline Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run production lighthouse baseline check
+        id: lighthouse-production
+        run: node scripts/lighthouse-production.mjs
+        env:
+          LH_PRODUCTION_URL: ${{ github.event.inputs.target_url || 'https://app.haotool.org/ratewise/' }}
+          LH_RUNS: '3'
+          LH_OUTPUT_DIR: lighthouse-reports/production
+          LH_BASELINE_PATH: scripts/lighthouse-baseline.production.json
+          LH_BASELINE_DRIFT_PCT: '5'
+
+      - name: Upload lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-production-reports
+          path: lighthouse-reports/production
+          retention-days: 21
+
+      - name: Comment production baseline summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const repo = context.repo;
+            const issue_number = context.issue.number;
+            const summaryPath = path.join(process.cwd(), 'lighthouse-reports/production', 'summary.json');
+
+            let summary;
+            try {
+              summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+            } catch (error) {
+              summary = { status: 'error', reason: error?.message || 'summary parse failed' };
+            }
+
+            const baselinePath = path.join(process.cwd(), 'scripts/lighthouse-baseline.production.json');
+            let baselineMeta = {};
+            try {
+              baselineMeta = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+            } catch {
+              baselineMeta = {};
+            }
+
+            const header = `### Lighthouse Production Baseline ${summary.status === 'pass' ? '✅' : '❌'}\n`;
+            const body =
+              `${header}` +
+              `- 狀態：\`${summary.status || 'unknown'}\`\n` +
+              `- 目標網址：\`${summary.targetUrl || 'N/A'}\`\n` +
+              `- 實際執行：${summary.runs || 0} 次\n` +
+              `- 退化容忍：${summary.driftTolerancePercent || 5}%\n` +
+              `- Baseline 更新時間：${baselineMeta.updatedAt || 'N/A'}\n\n` +
+              `**檢查細節**\n`;
+
+            const lines = [];
+            for (const [name, check] of Object.entries(summary.checks || {})) {
+              if (check?.type === 'hard_fail') {
+                lines.push(`- ❌ ${name}: expected \`${check.expected}\` \u2264 actual \`${check.actual}\``);
+              } else if (check?.type === 'regression') {
+                lines.push(`- ⚠️ ${name}: baseline drift +${check.drift}%`);
+              }
+            }
+            const content = `${body}${lines.length ? lines.join('\\n') : '- 無異常，指標符合要求'}\n`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: repo.owner,
+              repo: repo.repo,
+              issue_number,
+            });
+            const marker = '<!-- lighthouse-production-baseline -->';
+            const previous = comments.find((item) => item.body?.includes(marker));
+            const message = `${marker}\n${content}`;
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                comment_id: previous.id,
+                body: message,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                issue_number,
+                body: message,
+              });
+            }
+
+      - name: Add summary to GitHub summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f lighthouse-reports/production/summary.json ]; then
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              node --input-type=module -e '
+                import { readFileSync, appendFileSync } from "node:fs";
+                const summary = JSON.parse(
+                  readFileSync("lighthouse-reports/production/summary.json", "utf8"),
+                );
+                const checks = summary.checks || {};
+                const drift = summary.drift || {};
+                const baselineEntries = Object.entries(checks).filter(([, check]) => check?.type === "regression");
+                const hardFailEntries = Object.entries(checks).filter(([, check]) => check?.type === "hard_fail");
+                const details = [
+                  `- 狀態：${summary.status || "unknown"}`,
+                  `- 目標網址：${summary.targetUrl || "N/A"}`,
+                  `- 每頁執行：${summary.runs || "N/A"}`,
+                  `- 路徑數：${summary.paths ? Object.keys(summary.paths).length : 0}`,
+                  `- 退化告警：${baselineEntries.length}`,
+                  `- 硬性失敗：${hardFailEntries.length}`,
+                ];
+                const lines = [
+                  "## Lighthouse Production Baseline",
+                  ...details,
+                  "",
+                  "### 檢查明細",
+                ];
+
+                for (const [name, check] of Object.entries(checks)) {
+                  if (check?.type === "hard_fail") {
+                    lines.push(`- ❌ ${name}: expected ${check.expected}${check.unit ?? ""}, actual ${check.actual}${check.unit ?? ""}`);
+                    continue;
+                  }
+                  if (check?.type === "regression") {
+                    const driftValue = check.drift ?? drift[name];
+                    const baselineValue = check.baseline ?? "N/A";
+                    lines.push(`- ⚠️ ${name}: baseline ${baselineValue} -> ${check.actual} (${driftValue}%)`);
+                  }
+                }
+                if (lines.length === details.length + 2) {
+                  lines.push("- ✅ 無異常");
+                }
+                appendFileSync(process.env.GITHUB_STEP_SUMMARY || "", `${lines.join("\n")}\n`);
+              '
+            fi
+          else
+            echo "summary missing";
+            exit 1;
+          fi

--- a/apps/ratewise/docs/dev/PERFORMANCE_BASELINE.md
+++ b/apps/ratewise/docs/dev/PERFORMANCE_BASELINE.md
@@ -1,0 +1,112 @@
+# Performance Baseline（效能基準）
+
+本文件記錄 RateWise 的效能基準與監控 SOP。
+
+## 版本資訊
+
+- **基準版本**：v2.22.15
+- **建立日期**：2026-05-05
+- **最後更新**：2026-05-05
+
+## 效能指標基準（Local Development）
+
+| 指標                   | 目標          | 當前實測                                | 狀態 |
+| ---------------------- | ------------- | --------------------------------------- | ---- |
+| **趨勢圖首次可見時間** | ≤ 2,500ms     | 828ms                                   | ✅   |
+| **LCP**                | ≤ 2,500ms     | 待實測（首個 production baseline 回填） | -    |
+| **INP**                | ≤ 200ms       | 待實測（首個 production baseline 回填） | -    |
+| **CLS**                | ≤ 0.1         | 待實測（首個 production baseline 回填） | -    |
+| **歷史 API 請求數**    | 1 (aggregate) | 1                                       | ✅   |
+| **fetch 總耗時**       | ≤ 500ms       | ~10ms                                   | ✅   |
+
+## 效能指標基準（Production）
+
+| 指標                       | 目標      | 當前實測                                | 狀態 |
+| -------------------------- | --------- | --------------------------------------- | ---- |
+| **LCP (4G median)**        | ≤ 2,500ms | 待實測（首個 production baseline 回填） | -    |
+| **INP**                    | ≤ 200ms   | 待實測（首個 production baseline 回填） | -    |
+| **CLS**                    | ≤ 0.1     | 待實測（首個 production baseline 回填） | -    |
+| **Lighthouse Performance** | ≥ 90      | 待實測（首個 production baseline 回填） | -    |
+
+## 優化歷史
+
+### PR1: Aggregate Trend History Fetch（2026-05-05）
+
+- **問題**：30 個 JSON 並行 fetch（N+1 問題）
+- **解法**：新增 `history-30d.json` 聚合 endpoint，30 fetch → 1 fetch
+- **效果**：fetch 耗時從 ~3,000ms 降至 ~10ms（-99%）
+
+### PR2: Drop 10s Defer（2026-05-05）
+
+- **問題**：`TREND_CHART_DEFER_MS` 硬延遲 10 秒
+- **解法**：改為 `requestIdleCallback` 直接載入（無硬延遲）
+- **效果**：趨勢圖可見時間從 10,937ms 降至 828ms（-92%）
+
+### PR3: PWA Navigation Timeout（2026-05-05）
+
+- **問題**：iOS Safari 冷啟動離線白屏
+- **解法**：NavigationRoute 改用 `NetworkFirst` + 3 秒 timeout + fallback
+- **效果**：網路超時自動 fallback 到 precache，避免無限等待
+
+### PR4: Cache Budget Guard（2026-05-05）
+
+- **問題**：iOS Safari 50MB cache 上限可能觸發 eviction
+- **解法**：install 時檢查使用量，超過 40MB 清理非關鍵快取
+- **效果**：預防 cache eviction 導致的白屏
+
+## 退化偵測 SOP
+
+### 自動偵測
+
+1. **趨勢圖 E2E 測試**：`tests/e2e/trend-chart-latency.spec.ts`
+   - CI 每次 PR 執行
+   - 門檻：趨勢圖可見時間 ≤ 2,500ms
+   - 失敗自動阻擋合併
+
+2. **Lighthouse Production Baseline**
+   - 每日 cron 執行 production URL
+   - 腳本：`scripts/lighthouse-production.mjs`
+   - 每頁 3 次取中位數，持續更新 `scripts/lighthouse-baseline.production.json`
+   - 硬性門檻：LCP ≤ 2,500ms、INP ≤ 200ms、CLS ≤ 0.1、Performance ≥ 90
+   - 退化 > 5%（較上次 baseline）自動 fail 並在 PR 留言
+
+3. **RUM（Real User Monitoring）**（待啟用）
+   - `web-vitals` → `VITE_VITALS_ENDPOINT`
+   - 可選：GA4 Measurement Protocol 或 Cloudflare Worker collector
+
+4. **RUM + Lighthouse 綜合查核**
+   - PR 每次合併前：本地執行 `pnpm lighthouse:production`，確認 `.json` 摘要可讀
+   - Production：每日固定 `workflow_dispatch/schedule` 上傳 `lighthouse-reports/production/summary.json`
+
+### 手動驗證
+
+```bash
+# 運行趨勢圖效能測試
+pnpm --filter @app/ratewise exec playwright test trend-chart-latency --grep "baseline"
+pnpm lighthouse:production
+cat scripts/lighthouse-baseline.production.json
+
+# 預期輸出：
+# 總載入時間：<1000ms
+# 歷史 API 請求數：1
+# 使用 aggregate endpoint：✅ 是
+```
+
+### 退化處理流程
+
+1. **CI 失敗**
+   - 檢查 E2E 測試輸出
+   - 比對與基準的差異
+   - 回退或修復後重新提交
+
+2. **Production 退化**
+   - 檢查 Lighthouse CI 報告
+   - 比對 RUM 數據
+   - 建立緊急修復 PR
+
+## 相關文件
+
+- [AGENTS.md](../../../AGENTS.md) - Agent SOP
+- [CLAUDE.md](../../../CLAUDE.md) - Claude 開發指南
+- [sw.ts](../../src/sw.ts) - Service Worker 實作
+- [performance.ts](../../src/config/performance.ts) - 效能配置

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -12,6 +12,11 @@
 
 ## 條目（新→舊）
 
+- 日期：2026-05-05
+- ID：ratewise-production-lighthouse-baseline-pr4
+- 原因：缺少 production LCP/INP/CLS/Lighthouse baseline 觀測，無法第一時間偵測 trend 與 PWA 回歸。
+- 解法：建立 `scripts/lighthouse-production.mjs`、baseline workflow、summary 回報文件與 baseline JSON，並把 PR4 指標門檻收斂為可自動回報機制。
+
 - 日期：2026-05-04
 - ID：ratewise-authority-guide-mirror-production-verification
 - 原因：3 篇 Authority Guide Markdown mirrors 已存在於 public 與 `llms.txt`，但未被納入 `SEO_FILES` 與正式 production verification，且 Worker / `_headers` 的 alternate Link 治理也未完全覆蓋，形成真實監測缺口。

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "seo:health-check": "node scripts/seo-health-check.mjs",
     "seo:audit": "node scripts/seo-full-audit.mjs",
     "purge:cdn": "bash scripts/purge-cdn-cache.sh",
+    "lighthouse:production": "node scripts/lighthouse-production.mjs",
     "clean": "pnpm -r clean && rm -rf node_modules",
     "prepare": "husky || true",
     "update:release-metadata": "node scripts/update-release-metadata.js",

--- a/scripts/lighthouse-baseline.production.json
+++ b/scripts/lighthouse-baseline.production.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "updatedAt": "2026-05-05T00:00:00.000Z",
+  "generatedBy": "scripts/lighthouse-production.mjs",
+  "status": "placeholder",
+  "runs": 3,
+  "targetUrl": "https://app.haotool.org/ratewise/",
+  "driftTolerancePercent": 5,
+  "paths": {}
+}

--- a/scripts/lighthouse-production.mjs
+++ b/scripts/lighthouse-production.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+/**
+ * Production Lighthouse baseline checker
+ *
+ * 目的：
+ * 1. 每日/PR 自動跑 production 慢速路徑（Lighthouse Smoke Paths）
+ * 2. 建立並持續比較 baseline（失敗條件：性能退化 >5%）
+ * 3. 輸出可被 CI/Pipeline 解析的 JSON summary
+ *
+ * 可用環境變數：
+ * - LH_PRODUCTION_URL: 目標 production base URL（預設：https://app.haotool.org/ratewise/）
+ * - LH_RUNS: 每頁重跑次數（預設：3）
+ * - LH_OUTPUT_DIR: 報告輸出目錄（預設：lighthouse-reports/production）
+ * - LH_BASELINE_PATH: baseline 檔案路徑（預設：scripts/lighthouse-baseline.production.json）
+ * - LH_BASELINE_DRIFT_PCT: 可接受退化百分比（預設：5）
+ * - LH_OUTPUT_ONLY: 僅輸出 baseline summary（預設：0）
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { APP_CONFIG } from '../apps/ratewise/app.config.mjs';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = resolve(SCRIPT_DIR, '..');
+
+const PRODUCTION_URL = (
+  process.env.LH_PRODUCTION_URL || 'https://app.haotool.org/ratewise/'
+).replace(/\/?$/, '/');
+const RUNS = Number.parseInt(process.env.LH_RUNS || '3', 10);
+const BASELINE_PATH = resolve(
+  process.env.LH_BASELINE_PATH || join(ROOT_DIR, 'scripts/lighthouse-baseline.production.json'),
+);
+const REPORT_DIR = resolve(
+  process.env.LH_OUTPUT_DIR || join(ROOT_DIR, 'lighthouse-reports/production'),
+);
+const DRIFT_PERCENT = Number.parseFloat(process.env.LH_BASELINE_DRIFT_PCT || '5');
+const LIGHTHOUSE_BIN = resolve(ROOT_DIR, 'node_modules', '.bin', 'lighthouse');
+const OUTPUT_ONLY = process.env.LH_OUTPUT_ONLY === '1';
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT;
+
+const PATHS = Array.isArray(APP_CONFIG.lighthouseSmokePaths)
+  ? APP_CONFIG.lighthouseSmokePaths
+  : ['/'];
+
+const BASELINE_ASSERT = {
+  performanceScore: 0.9,
+  lcpMs: 2500,
+  inpMs: 200,
+  cls: 0.1,
+};
+
+const METRIC_AUDIT_IDS = {
+  lcp: 'largest-contentful-paint',
+  inp: ['interaction-to-next-paint', 'experimental-interaction-to-next-paint', 'max-potential-fid'],
+  cls: 'cumulative-layout-shift',
+};
+
+const CATEGORY_KEYS = {
+  performance: 'performance',
+  accessibility: 'accessibility',
+  bestPractices: 'best-practices',
+  seo: 'seo',
+};
+
+const THRESHOLD_CHECKS = [
+  {
+    title: 'Performance',
+    path: 'performanceScore',
+    compareDirection: 'higherBetter',
+    threshold: BASELINE_ASSERT.performanceScore * 100,
+    unit: '%',
+  },
+  {
+    title: 'LCP',
+    path: 'lcpMs',
+    compareDirection: 'lowerBetter',
+    threshold: BASELINE_ASSERT.lcpMs,
+    unit: 'ms',
+  },
+  {
+    title: 'INP',
+    path: 'inpMs',
+    compareDirection: 'lowerBetter',
+    threshold: BASELINE_ASSERT.inpMs,
+    unit: 'ms',
+  },
+  {
+    title: 'CLS',
+    path: 'cls',
+    compareDirection: 'lowerBetter',
+    threshold: BASELINE_ASSERT.cls,
+    unit: '',
+  },
+];
+
+/**
+ * 統計：取中位數
+ */
+function median(values) {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+/**
+ * 讀 baseline。檔不存在或 JSON 失效則回傳 null，讓流程進入初始化模式。
+ */
+function readBaseline() {
+  if (!existsSync(BASELINE_PATH)) {
+    return null;
+  }
+  try {
+    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+    if (typeof baseline !== 'object' || baseline === null) {
+      return null;
+    }
+    return baseline;
+  } catch {
+    return null;
+  }
+}
+
+function isUsableBaseline(baseline) {
+  if (!baseline || typeof baseline !== 'object') {
+    return false;
+  }
+  if (baseline.status === 'placeholder') {
+    return false;
+  }
+  if (!baseline.paths || typeof baseline.paths !== 'object') {
+    return false;
+  }
+  return Object.keys(baseline.paths).length > 0;
+}
+
+function safeRound(value, digits = 2) {
+  return Number.isFinite(value) ? Number(value.toFixed(digits)) : null;
+}
+
+function normalizePath(path = '/') {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return normalized.replace(/\/{2,}/g, '/');
+}
+
+function buildTargetUrl(path) {
+  return `${PRODUCTION_URL.replace(/\/$/, '')}${normalizePath(path)}`;
+}
+
+function pickReportNumber(report, key) {
+  if (key === 'performanceScore') {
+    const score = report?.categories?.[CATEGORY_KEYS.performance]?.score;
+    return Number.isFinite(score) ? score * 100 : null;
+  }
+
+  if (key === 'lcpMs') {
+    const value = report?.audits?.[METRIC_AUDIT_IDS.lcp]?.numericValue;
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (key === 'inpMs') {
+    for (const auditId of METRIC_AUDIT_IDS.inp) {
+      const value = report?.audits?.[auditId]?.numericValue;
+      if (Number.isFinite(value)) return value;
+    }
+    return null;
+  }
+
+  if (key === 'cls') {
+    const value = report?.audits?.[METRIC_AUDIT_IDS.cls]?.numericValue;
+    return Number.isFinite(value) ? value : null;
+  }
+
+  return null;
+}
+
+function runLighthouse(url, outputPath) {
+  const args = [
+    url,
+    '--preset=desktop',
+    '--only-categories=performance,accessibility,best-practices,seo',
+    '--output=json',
+    `--output-path=${outputPath}`,
+    '--chrome-flags=--headless=new --no-sandbox --disable-dev-shm-usage --disable-gpu',
+    '--quiet',
+  ];
+
+  const result = spawnSync(LIGHTHOUSE_BIN, args, {
+    encoding: 'utf8',
+    env: { ...process.env, NODE_ENV: 'production' },
+    timeout: 180000,
+    maxBuffer: 1024 * 1024 * 6,
+  });
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(`Lighthouse run failed: ${stderr || result.error?.message || 'unknown error'}`);
+  }
+
+  const report = JSON.parse(readFileSync(outputPath, 'utf8'));
+  return report;
+}
+
+function compareDirection(current, baseline, compareDirection) {
+  if (
+    baseline === null ||
+    baseline === 0 ||
+    !Number.isFinite(current) ||
+    !Number.isFinite(baseline)
+  ) {
+    return { changed: 0, exceed: false };
+  }
+
+  if (compareDirection === 'higherBetter') {
+    const degradePercent = ((baseline - current) / baseline) * 100;
+    return {
+      changed: safeRound(degradePercent, 2),
+      exceed: degradePercent > DRIFT_PERCENT,
+    };
+  }
+
+  const worsenPercent = ((current - baseline) / baseline) * 100;
+  return {
+    changed: safeRound(worsenPercent, 2),
+    exceed: worsenPercent > DRIFT_PERCENT,
+  };
+}
+
+function main() {
+  if (!existsSync(LIGHTHOUSE_BIN)) {
+    throw new Error('Lighthouse CLI not found. Run pnpm install --frozen-lockfile first.');
+  }
+
+  if (
+    !Array.isArray(APP_CONFIG.lighthouseSmokePaths) ||
+    APP_CONFIG.lighthouseSmokePaths.length === 0
+  ) {
+    throw new Error('APP_CONFIG.lighthouseSmokePaths is empty or invalid.');
+  }
+
+  if (!Number.isFinite(RUNS) || RUNS <= 0) {
+    throw new Error(`Invalid LH_RUNS: ${process.env.LH_RUNS}`);
+  }
+
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const timestamp = new Date().toISOString();
+  const summary = {
+    generatedAt: timestamp,
+    targetUrl: PRODUCTION_URL,
+    runs: RUNS,
+    driftTolerancePercent: DRIFT_PERCENT,
+    paths: {},
+    overall: {
+      drift: {},
+      checks: {},
+      passed: true,
+    },
+  };
+  const baseline = readBaseline();
+  const hasUsableBaseline = isUsableBaseline(baseline);
+  const enforceHardThreshold = !!hasUsableBaseline;
+
+  console.log('🚀 啟動 Production Lighthouse baseline 檢核');
+  console.log(`🔗 Base URL: ${PRODUCTION_URL}`);
+  console.log(`📊 路徑：${PATHS.length} 個`);
+  console.log(`🎯 每頁執行：${RUNS} 次`);
+
+  const errors = [];
+
+  for (const path of PATHS) {
+    const normalizedPath = normalizePath(path);
+    const pathKey =
+      normalizedPath === '/' ? 'home' : normalizedPath.replace(/\//g, '-').replace(/^-/, '');
+    const url = buildTargetUrl(normalizedPath);
+    console.log(`\n📍 掃描：${url}`);
+
+    const stats = {
+      path: normalizedPath,
+      url,
+      runs: [],
+    };
+    const collected = {
+      performanceScore: [],
+      lcpMs: [],
+      inpMs: [],
+      cls: [],
+    };
+
+    for (let index = 0; index < RUNS; index++) {
+      const reportPath = join(REPORT_DIR, `${pathKey}-run-${index + 1}.report.json`);
+      const lhr = runLighthouse(url, reportPath);
+      const runResult = {
+        run: index + 1,
+        performanceScore: safeRound(pickReportNumber(lhr, 'performanceScore'), 2),
+        lcpMs: safeRound(pickReportNumber(lhr, 'lcpMs'), 2),
+        inpMs: safeRound(pickReportNumber(lhr, 'inpMs'), 2),
+        cls: safeRound(pickReportNumber(lhr, 'cls'), 3),
+        lighthouseScore: {
+          performance: lhr?.categories?.[CATEGORY_KEYS.performance]?.score ?? null,
+          accessibility: lhr?.categories?.[CATEGORY_KEYS.accessibility]?.score ?? null,
+          bestPractices: lhr?.categories?.[CATEGORY_KEYS.bestPractices]?.score ?? null,
+          seo: lhr?.categories?.[CATEGORY_KEYS.seo]?.score ?? null,
+        },
+      };
+
+      for (const check of THRESHOLD_CHECKS) {
+        const value = runResult[check.path];
+        if (Number.isFinite(value)) {
+          collected[check.path].push(value);
+        }
+      }
+      stats.runs.push(runResult);
+    }
+
+    const pathSummary = {
+      path: normalizedPath,
+      median: {
+        performanceScore: median(collected.performanceScore),
+        lcpMs: median(collected.lcpMs),
+        inpMs: median(collected.inpMs),
+        cls: median(collected.cls),
+      },
+      runs: stats.runs,
+    };
+    summary.paths[pathKey] = pathSummary;
+
+    for (const check of THRESHOLD_CHECKS) {
+      const value = pathSummary.median[check.path];
+      if (value === null) {
+        continue;
+      }
+      if (!enforceHardThreshold) {
+        continue;
+      }
+      if (check.compareDirection === 'higherBetter' && value < check.threshold) {
+        summary.overall.passed = false;
+        summary.overall.checks[`${normalizedPath}-${check.path}`] = {
+          type: 'hard_fail',
+          expected: check.threshold,
+          actual: value,
+          unit: check.unit,
+        };
+      }
+
+      if (check.compareDirection === 'lowerBetter' && value > check.threshold) {
+        summary.overall.passed = false;
+        summary.overall.checks[`${normalizedPath}-${check.path}`] = {
+          type: 'hard_fail',
+          expected: check.threshold,
+          actual: value,
+          unit: check.unit,
+        };
+      }
+    }
+  }
+
+  if (hasUsableBaseline) {
+    for (const [pathKey, item] of Object.entries(summary.paths)) {
+      const baselineItem = baseline.paths[pathKey];
+      if (!baselineItem?.median) {
+        continue;
+      }
+
+      for (const check of THRESHOLD_CHECKS) {
+        const current = item.median?.[check.path];
+        const previous = baselineItem.median?.[check.path];
+        if (current === null || previous === null || previous === undefined) {
+          continue;
+        }
+
+        const drift = compareDirection(current, previous, check.compareDirection);
+        summary.overall.drift[`${pathKey}:${check.path}`] = drift;
+        if (drift.exceed) {
+          summary.overall.passed = false;
+          errors.push(
+            `${check.title} 退化超過 ${DRIFT_PERCENT}%：${pathKey} ${previous} -> ${current} (${drift.changed}%)`,
+          );
+          summary.overall.checks[`${pathKey}-${check.path}`] = {
+            ...summary.overall.checks[`${pathKey}-${check.path}`],
+            type: summary.overall.checks[`${pathKey}-${check.path}`] ? 'hard_fail' : 'regression',
+            baseline: previous,
+            drift: drift.changed,
+          };
+        }
+      }
+    }
+  }
+
+  const output = {
+    generatedAt: timestamp,
+    status: summary.overall.passed ? 'pass' : 'fail',
+    targetUrl: PRODUCTION_URL,
+    runs: RUNS,
+    driftTolerancePercent: DRIFT_PERCENT,
+    checks: summary.overall.checks,
+    drift: summary.overall.drift,
+    errors,
+    paths: summary.paths,
+  };
+
+  if (!baseline) {
+    console.log('📌 Baseline 不存在，將以本次結果初始化。');
+    writeFileSync(
+      BASELINE_PATH,
+      JSON.stringify(
+        {
+          version: 1,
+          updatedAt: timestamp,
+          generatedBy: 'scripts/lighthouse-production.mjs',
+          status: 'active',
+          runs: RUNS,
+          targetUrl: PRODUCTION_URL,
+          driftTolerancePercent: DRIFT_PERCENT,
+          paths: summary.paths,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    writeFileSync(
+      BASELINE_PATH,
+      JSON.stringify(
+        {
+          ...baseline,
+          updatedAt: timestamp,
+          generatedBy: 'scripts/lighthouse-production.mjs',
+          status: summary.overall.passed ? 'active' : 'degraded',
+          runs: RUNS,
+          targetUrl: PRODUCTION_URL,
+          driftTolerancePercent: DRIFT_PERCENT,
+          paths: summary.paths,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  const summaryPath = join(REPORT_DIR, 'summary.json');
+  writeFileSync(summaryPath, JSON.stringify(output, null, 2));
+
+  console.log('\n=== Lighthouse Production Baseline Summary ===');
+  for (const [name, check] of Object.entries(summary.overall.checks)) {
+    if (check.type === 'hard_fail') {
+      const relation = `expected ${check.expected}${check.unit} / actual ${check.actual}${check.unit}`;
+      console.log(`❌ ${name}: ${relation}`);
+    } else if (check.type === 'regression') {
+      console.log(
+        `⚠️ ${name}: baseline drift +${check.drift}% (${check.baseline} -> ${check.actual})`,
+      );
+    }
+  }
+
+  if (GITHUB_OUTPUT) {
+    appendFileSync(
+      GITHUB_OUTPUT,
+      `status=${summary.overall.passed ? 'pass' : 'fail'}\n` +
+        `summary_path=${summaryPath}\n` +
+        `baseline_path=${BASELINE_PATH}\n` +
+        `errors=${JSON.stringify(errors)}\n`,
+    );
+  }
+
+  if (OUTPUT_ONLY) {
+    return;
+  }
+
+  if (!summary.overall.passed) {
+    throw new Error(`Lighthouse baseline 檢核失敗：${errors.join('；') || '存在硬性門檻下降'}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## 變更摘要
- 新增 production Lighthouse baseline 自動化腳本（scripts/lighthouse-production.mjs）
- 新增每日日誌 workflow 與 PR 自動摘要回報（.github/workflows/lighthouse-production.yml）
- 新增 baseline 儲存檔與效能指標文件
- 更新 root scripts 與 002 稽核紀錄

## 驗證
- 提交前通過 pre-push 檢查（typecheck/test/build:ratewise）
- 本機未另跑 standalone 的 production baseline / e2e 腳本
