### PR TITLE
fix(ratewise): 修正離線 fallback 不可達

### DIFF
--- a/.changeset/ratewise-offline-fallback-reachability.md
+++ b/.changeset/ratewise-offline-fallback-reachability.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 PWA 離線導覽在 precache `index.html` / `offline.html` 缺失時的最後 fallback reachability，讓 `NavigationRoute` 也能直接命中任意快取中的 `offline.html`，避免冷啟動白屏。

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -237,6 +237,21 @@ describe('Service Worker Cache Strategies', () => {
     // 確保有 fallback 到 precache index.html
     expect(sourceCode).toContain("matchPrecache('index.html')");
   });
+
+  it('should let NavigationRoute fallback reach cached offline.html before returning Response.error', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const swPath = path.resolve(__dirname, '../sw.ts');
+    const sourceCode = await fs.readFile(swPath, 'utf-8');
+
+    const handlerBlockMatch =
+      /handlerDidError:\s*async\s*\(\)\s*=>\s*\{[\s\S]*?return\s+\(await\s+caches\.match\('offline\.html'\)\)\s*\?\?\s*Response\.error\(\);[\s\S]*?\}/.exec(
+        sourceCode,
+      );
+
+    expect(handlerBlockMatch).not.toBeNull();
+  });
 });
 
 describe('Service Worker URL Matching', () => {

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -120,6 +120,9 @@ describe('PWA 離線功能測試', () => {
       expect(swContent).toContain('離線回退');
       // document 請求回退到 precache index.html，確保冷啟動離線可用。
       expect(swContent).toContain("matchPrecache('index.html')");
+      // NavigationRoute 的 handlerDidError 也必須能直接命中任意快取中的 offline.html，
+      // 避免 Workbox 視為已處理後不再進入全域 setCatchHandler。
+      expect(swContent).toContain("caches.match('offline.html')");
     });
 
     it('should not write launch-recache assets into workbox precache', () => {

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -272,8 +272,11 @@ const navigationStrategy = new NetworkFirst({
       handlerDidError: async () => {
         const precached = await matchPrecache('index.html');
         if (precached) return precached;
-        // 最後防線：嘗試 offline.html
-        return (await matchPrecache('offline.html')) ?? Response.error();
+        const precachedOffline = await matchPrecache('offline.html');
+        if (precachedOffline) return precachedOffline;
+        // 最後防線：搜尋任何快取中的 offline.html，避免 Workbox 在 plugin 已回傳
+        // Response.error() 時不再進入全域 setCatchHandler，導致冷啟動離線 fallback 失效。
+        return (await caches.match('offline.html')) ?? Response.error();
       },
     },
   ],

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -23,6 +23,11 @@
 - 解法：新增 SW activate 階段 `ensureOfflineHtmlCached` 補救機制，在 precache 失敗或 iOS cache eviction 後主動抓取並快取 `offline.html`；增強 `setCatchHandler` 三層回退策略（index → offline precache → 任何快取）。
 
 - 日期：2026-05-05
+- ID：ratewise-navigationroute-offline-fallback-reachability
+- 原因：`NavigationRoute` 的 `handlerDidError` 在找不到 precache `index.html` / `offline.html` 時直接回 `Response.error()`，導致 Workbox 不再進入全域 `setCatchHandler`，讓任意快取中的 `offline.html` fallback 變成不可達。
+- 解法：在 `handlerDidError` 內補上 `caches.match('offline.html')` 最後防線，並新增回歸測試鎖住離線 fallback reachability。
+
+- 日期：2026-05-05
 - ID：ratewise-trend-chart-perf-pr1234-convergence
 - 原因：趨勢圖載入極慢（~10.9s）— 10s 硬延遲 + 30 筆 JSON 並行 fetch + requestIdleCallback 等待，PWA 導覽缺 timeout fallback 與 cache 預算控制。
 - 解法：PR1 aggregate fetch（30 fetch → 1 fetch）+ PR2 移除 10s defer 改 requestIdleCallback only + PR3 NavigationRoute 3s timeout + cache 40MB budget guard + PR4 performance.mark 觀測（趨勢圖可見時間 10937ms → 820ms，達業界 <2500ms 標準）。


### PR DESCRIPTION
## 摘要
- 修正 NavigationRoute 的 handlerDidError 在 precache miss 時過早回傳 `Response.error()` 的問題
- 補上 `caches.match('offline.html')` 最後防線，讓冷啟動離線 fallback 可達
- 新增回歸測試、changeset 與 002 紀錄

## 背景與證據
- 已合併的 #358 收到 Codex review，指出 `NavigationRoute` 的 plugin fallback 不會再進入全域 `setCatchHandler`
- 主支 `apps/ratewise/src/sw.ts` 確實只有 `matchPrecache('offline.html') ?? Response.error()`，未覆蓋任意快取中的 `offline.html`

## 驗證
- `pnpm --filter @app/ratewise exec vitest run src/__tests__/sw.test.ts src/pwa-offline.test.ts`
- `pnpm --filter @app/ratewise typecheck`
- `VITE_RATEWISE_BASE_PATH='/' pnpm build:ratewise`
- `git push` 前 `pre-push` 全綠（typecheck / 全 repo test / build:ratewise）
