### PR TITLE
fix(pwa): 補上冷啟動 emergency HTML 回退

### DIFF
--- a/.changeset/bright-cobras-fail.md
+++ b/.changeset/bright-cobras-fail.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正 PWA 冷啟動離線時在 HTML fallback 全失守情境下仍可能白屏的問題，新增 Service Worker 最後一層 emergency 保護頁。

--- a/.changeset/fair-apes-juggle.md
+++ b/.changeset/fair-apes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+fix(pwa): 讓 emergency offline fallback 品牌與導航回退測試對齊 SSOT

--- a/.changeset/ratewise-pwa-emergency-fallback-contract.md
+++ b/.changeset/ratewise-pwa-emergency-fallback-contract.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+補強冷啟動離線保護頁的 fallback 契約，確保快取全失效時仍回可見 HTML。

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -238,7 +238,7 @@ describe('Service Worker Cache Strategies', () => {
     expect(sourceCode).toContain("matchPrecache('index.html')");
   });
 
-  it('should let NavigationRoute fallback reach cached offline.html before returning Response.error', async () => {
+  it('should let NavigationRoute fallback reach cached offline.html before using emergency HTML', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
@@ -246,7 +246,7 @@ describe('Service Worker Cache Strategies', () => {
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
     const handlerBlockMatch =
-      /handlerDidError:\s*async\s*\(\)\s*=>\s*\{[\s\S]*?return\s+\(await\s+caches\.match\('offline\.html'\)\)\s*\?\?\s*Response\.error\(\);[\s\S]*?\}/.exec(
+      /handlerDidError:\s*async\s*\(\)\s*=>\s*\{[\s\S]*?return\s+\([\s\S]*?await\s+caches\.match\('offline\.html'\)[\s\S]*?createEmergencyOfflineResponse\('emergency-navigation-fallback'\)[\s\S]*?\);[\s\S]*?\}/.exec(
         sourceCode,
       );
 

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -234,23 +234,19 @@ describe('Service Worker Cache Strategies', () => {
     expect(sourceCode).toContain('new NetworkFirst(');
     expect(sourceCode).toContain('networkTimeoutSeconds:');
     expect(sourceCode).toContain('new NavigationRoute(');
-    // 確保有 fallback 到 precache index.html
-    expect(sourceCode).toContain("matchPrecache('index.html')");
+    expect(sourceCode).toContain('resolveOfflineDocumentFallback');
   });
 
-  it('should let NavigationRoute fallback reach cached offline.html before using emergency HTML', async () => {
+  it('should delegate NavigationRoute failures to the shared offline document fallback', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
     const swPath = path.resolve(__dirname, '../sw.ts');
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
-    const handlerBlockMatch =
-      /handlerDidError:\s*async\s*\(\)\s*=>\s*\{[\s\S]*?return\s+\([\s\S]*?await\s+caches\.match\('offline\.html'\)[\s\S]*?createEmergencyOfflineResponse\('emergency-navigation-fallback'\)[\s\S]*?\);[\s\S]*?\}/.exec(
-        sourceCode,
-      );
-
-    expect(handlerBlockMatch).not.toBeNull();
+    expect(sourceCode).toContain('resolveOfflineDocumentFallback');
+    expect(sourceCode).toContain("emergencyReason: 'emergency-navigation-fallback'");
+    expect(sourceCode).toContain("matchOfflineHtmlInAnyCache: () => caches.match('offline.html')");
   });
 });
 

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -116,10 +116,15 @@ describe('PWA 離線功能測試', () => {
 
     it('should have offline-first strategy in setCatchHandler', () => {
       const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
+      const fallbackContent = readFileSync(
+        resolve(ROOT_PATH, 'src/utils/pwaOfflineFallback.ts'),
+        'utf-8',
+      );
       // 確保離線回退策略邏輯存在
       expect(swContent).toContain('離線回退');
       // document 請求回退到 precache index.html，確保冷啟動離線可用。
-      expect(swContent).toContain("matchPrecache('index.html')");
+      expect(swContent).toContain('resolveOfflineDocumentFallback');
+      expect(fallbackContent).toContain("matchPrecache('index.html')");
       // NavigationRoute 的 handlerDidError 也必須能直接命中任意快取中的 offline.html，
       // 避免 Workbox 視為已處理後不再進入全域 setCatchHandler。
       expect(swContent).toContain("caches.match('offline.html')");
@@ -127,10 +132,14 @@ describe('PWA 離線功能測試', () => {
 
     it('should provide an emergency inline HTML fallback when both index and offline caches are unavailable', () => {
       const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
-      expect(swContent).toContain('EMERGENCY_OFFLINE_HTML');
-      expect(swContent).toContain('createEmergencyOfflineResponse');
-      expect(swContent).toContain('data-ratewise-emergency-fallback="true"');
-      expect(swContent).toContain("'X-RateWise-Offline-Fallback'");
+      const fallbackContent = readFileSync(
+        resolve(ROOT_PATH, 'src/utils/pwaOfflineFallback.ts'),
+        'utf-8',
+      );
+      expect(fallbackContent).toContain('EMERGENCY_OFFLINE_HTML');
+      expect(fallbackContent).toContain('createEmergencyOfflineResponse');
+      expect(fallbackContent).toContain('data-ratewise-emergency-fallback="true"');
+      expect(fallbackContent).toContain("'X-RateWise-Offline-Fallback'");
       expect(swContent).toContain('emergency-document-fallback');
       expect(swContent).toContain('emergency-navigation-fallback');
     });

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -125,6 +125,16 @@ describe('PWA 離線功能測試', () => {
       expect(swContent).toContain("caches.match('offline.html')");
     });
 
+    it('should provide an emergency inline HTML fallback when both index and offline caches are unavailable', () => {
+      const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
+      expect(swContent).toContain('EMERGENCY_OFFLINE_HTML');
+      expect(swContent).toContain('createEmergencyOfflineResponse');
+      expect(swContent).toContain('data-ratewise-emergency-fallback="true"');
+      expect(swContent).toContain("'X-RateWise-Offline-Fallback'");
+      expect(swContent).toContain('emergency-document-fallback');
+      expect(swContent).toContain('emergency-navigation-fallback');
+    });
+
     it('should not write launch-recache assets into workbox precache', () => {
       const storageManager = readFileSync(
         resolve(ROOT_PATH, 'src/utils/pwaStorageManager.ts'),

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -8,6 +8,7 @@ import { NavigationRoute, registerRoute, setCatchHandler } from 'workbox-routing
 import { CacheFirst, NetworkFirst, NetworkOnly, StaleWhileRevalidate } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
+import { APP_INFO } from './config/app-info';
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
@@ -16,7 +17,7 @@ const EMERGENCY_OFFLINE_HTML = `<!doctype html>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>離線模式 - HaoRate 匯率好工具</title>
+    <title>離線模式 - ${APP_INFO.name}</title>
     <meta name="robots" content="noindex,nofollow">
     <style>
       :root { color-scheme: light; }

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -11,6 +11,70 @@ import { ExpirationPlugin } from 'workbox-expiration';
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
+const EMERGENCY_OFFLINE_HTML = `<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>離線模式 - HaoRate 匯率好工具</title>
+    <meta name="robots" content="noindex,nofollow">
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: #f8fafc;
+        color: #0f172a;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .card {
+        width: min(100%, 360px);
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        background: #fff;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        padding: 24px 20px;
+        text-align: center;
+      }
+      .icon { font-size: 40px; line-height: 1; margin-bottom: 12px; }
+      h1 { margin: 0 0 12px; font-size: 20px; }
+      p { margin: 0; line-height: 1.65; color: #475569; }
+      button {
+        margin-top: 16px;
+        border: 0;
+        border-radius: 999px;
+        background: #0f172a;
+        color: #fff;
+        font: inherit;
+        padding: 10px 16px;
+      }
+    </style>
+  </head>
+  <body data-ratewise-emergency-fallback="true">
+    <main class="card" role="alert" aria-live="assertive">
+      <div class="icon">⚠️</div>
+      <h1>離線啟動保護模式</h1>
+      <p>目前無法取得完整快取資源，已切換到最低限度離線保護頁。請重新連線後再試一次。</p>
+      <button type="button" onclick="window.location.reload()">重新載入</button>
+    </main>
+  </body>
+</html>`;
+
+function createEmergencyOfflineResponse(reason: string): Response {
+  return new Response(EMERGENCY_OFFLINE_HTML, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-RateWise-Offline-Fallback': reason,
+    },
+  });
+}
+
 // precache 安裝失敗自動修復：首次安裝失敗時登出以允許重試；已有 active worker 則保留。
 self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
   if (String(event.reason).includes('bad-precaching-response')) {
@@ -247,7 +311,7 @@ setCatchHandler(async ({ event, request }): Promise<Response> => {
 
   // 最後防線：搜尋所有快取中的 offline.html（含 ensureOfflineHtmlCached 補救的版本）
   const anyOffline = await caches.match('offline.html');
-  return anyOffline ?? Response.error();
+  return anyOffline ?? createEmergencyOfflineResponse('emergency-document-fallback');
 });
 
 /**
@@ -276,7 +340,10 @@ const navigationStrategy = new NetworkFirst({
         if (precachedOffline) return precachedOffline;
         // 最後防線：搜尋任何快取中的 offline.html，避免 Workbox 在 plugin 已回傳
         // Response.error() 時不再進入全域 setCatchHandler，導致冷啟動離線 fallback 失效。
-        return (await caches.match('offline.html')) ?? Response.error();
+        return (
+          (await caches.match('offline.html')) ??
+          createEmergencyOfflineResponse('emergency-navigation-fallback')
+        );
       },
     },
   ],

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -8,73 +8,9 @@ import { NavigationRoute, registerRoute, setCatchHandler } from 'workbox-routing
 import { CacheFirst, NetworkFirst, NetworkOnly, StaleWhileRevalidate } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
-import { APP_INFO } from './config/app-info';
+import { resolveOfflineDocumentFallback } from './utils/pwaOfflineFallback';
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
-
-const EMERGENCY_OFFLINE_HTML = `<!doctype html>
-<html lang="zh-TW">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>離線模式 - ${APP_INFO.name}</title>
-    <meta name="robots" content="noindex,nofollow">
-    <style>
-      :root { color-scheme: light; }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 24px;
-        background: #f8fafc;
-        color: #0f172a;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      }
-      .card {
-        width: min(100%, 360px);
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        background: #fff;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-        padding: 24px 20px;
-        text-align: center;
-      }
-      .icon { font-size: 40px; line-height: 1; margin-bottom: 12px; }
-      h1 { margin: 0 0 12px; font-size: 20px; }
-      p { margin: 0; line-height: 1.65; color: #475569; }
-      button {
-        margin-top: 16px;
-        border: 0;
-        border-radius: 999px;
-        background: #0f172a;
-        color: #fff;
-        font: inherit;
-        padding: 10px 16px;
-      }
-    </style>
-  </head>
-  <body data-ratewise-emergency-fallback="true">
-    <main class="card" role="alert" aria-live="assertive">
-      <div class="icon">⚠️</div>
-      <h1>離線啟動保護模式</h1>
-      <p>目前無法取得完整快取資源，已切換到最低限度離線保護頁。請重新連線後再試一次。</p>
-      <button type="button" onclick="window.location.reload()">重新載入</button>
-    </main>
-  </body>
-</html>`;
-
-function createEmergencyOfflineResponse(reason: string): Response {
-  return new Response(EMERGENCY_OFFLINE_HTML, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'no-store',
-      'X-RateWise-Offline-Fallback': reason,
-    },
-  });
-}
 
 // precache 安裝失敗自動修復：首次安裝失敗時登出以允許重試；已有 active worker 則保留。
 self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
@@ -303,16 +239,11 @@ setCatchHandler(async ({ event, request }): Promise<Response> => {
   }
 
   // NavigationRoute 已攔截正常導覽；setCatchHandler 僅在網路失敗時作保險層。
-  // 三層回退：matchPrecache('index.html') → matchPrecache('offline.html') → caches.match('offline.html')
-  const precachedIndex = await matchPrecache('index.html');
-  if (precachedIndex) return precachedIndex;
-
-  const precachedOffline = await matchPrecache('offline.html');
-  if (precachedOffline) return precachedOffline;
-
-  // 最後防線：搜尋所有快取中的 offline.html（含 ensureOfflineHtmlCached 補救的版本）
-  const anyOffline = await caches.match('offline.html');
-  return anyOffline ?? createEmergencyOfflineResponse('emergency-document-fallback');
+  return resolveOfflineDocumentFallback({
+    emergencyReason: 'emergency-document-fallback',
+    matchPrecache,
+    matchOfflineHtmlInAnyCache: () => caches.match('offline.html'),
+  });
 });
 
 /**
@@ -335,16 +266,13 @@ const navigationStrategy = new NetworkFirst({
     {
       // 網路失敗時回退到 precache index.html（離線或 timeout 後快取也沒有）
       handlerDidError: async () => {
-        const precached = await matchPrecache('index.html');
-        if (precached) return precached;
-        const precachedOffline = await matchPrecache('offline.html');
-        if (precachedOffline) return precachedOffline;
-        // 最後防線：搜尋任何快取中的 offline.html，避免 Workbox 在 plugin 已回傳
-        // Response.error() 時不再進入全域 setCatchHandler，導致冷啟動離線 fallback 失效。
-        return (
-          (await caches.match('offline.html')) ??
-          createEmergencyOfflineResponse('emergency-navigation-fallback')
-        );
+        // 最後防線：搜尋任何快取中的 offline.html；若全數失守，回 inline HTML，
+        // 避免 Workbox 在 plugin 已回傳 Response.error() 後不再進入全域 setCatchHandler。
+        return resolveOfflineDocumentFallback({
+          emergencyReason: 'emergency-navigation-fallback',
+          matchPrecache,
+          matchOfflineHtmlInAnyCache: () => caches.match('offline.html'),
+        });
       },
     },
   ],

--- a/apps/ratewise/src/utils/__tests__/pwaOfflineFallback.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaOfflineFallback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { APP_INFO } from '../../config/app-info';
+import { resolveOfflineDocumentFallback } from '../pwaOfflineFallback';
+
+describe('pwaOfflineFallback', () => {
+  it('should prefer cached index.html before offline fallbacks', async () => {
+    const indexResponse = new Response('<html>app shell</html>');
+    const matchPrecache = vi.fn((url: 'index.html' | 'offline.html') =>
+      url === 'index.html' ? indexResponse : null,
+    );
+    const matchOfflineHtmlInAnyCache = vi.fn();
+
+    const response = await resolveOfflineDocumentFallback({
+      emergencyReason: 'emergency-navigation-fallback',
+      matchPrecache,
+      matchOfflineHtmlInAnyCache,
+    });
+
+    expect(response).toBe(indexResponse);
+    expect(matchPrecache).toHaveBeenCalledWith('index.html');
+    expect(matchPrecache).not.toHaveBeenCalledWith('offline.html');
+    expect(matchOfflineHtmlInAnyCache).not.toHaveBeenCalled();
+  });
+
+  it('should use precached offline.html when index.html is unavailable', async () => {
+    const offlineResponse = new Response('<html>offline</html>');
+
+    const response = await resolveOfflineDocumentFallback({
+      emergencyReason: 'emergency-navigation-fallback',
+      matchPrecache: (url) => (url === 'offline.html' ? offlineResponse : null),
+      matchOfflineHtmlInAnyCache: () => null,
+    });
+
+    expect(response).toBe(offlineResponse);
+  });
+
+  it('should use any cached offline.html before emergency HTML', async () => {
+    const anyCacheOfflineResponse = new Response('<html>offline from any cache</html>');
+
+    const response = await resolveOfflineDocumentFallback({
+      emergencyReason: 'emergency-navigation-fallback',
+      matchPrecache: () => null,
+      matchOfflineHtmlInAnyCache: () => anyCacheOfflineResponse,
+    });
+
+    expect(response).toBe(anyCacheOfflineResponse);
+  });
+
+  it('should return visible emergency HTML when all cache fallbacks are unavailable', async () => {
+    const response = await resolveOfflineDocumentFallback({
+      emergencyReason: 'emergency-navigation-fallback',
+      matchPrecache: () => null,
+      matchOfflineHtmlInAnyCache: () => null,
+    });
+
+    const html = await response.text();
+    expect(html).toContain('data-ratewise-emergency-fallback="true"');
+    expect(html).toContain(APP_INFO.name);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-RateWise-Offline-Fallback')).toBe(
+      'emergency-navigation-fallback',
+    );
+    expect(response.headers.get('X-RateWise-Offline-Fallback')).not.toBeNull();
+  });
+});

--- a/apps/ratewise/src/utils/pwaOfflineFallback.ts
+++ b/apps/ratewise/src/utils/pwaOfflineFallback.ts
@@ -1,0 +1,95 @@
+import { APP_INFO } from '../config/app-info';
+
+export type EmergencyOfflineFallbackReason =
+  | 'emergency-document-fallback'
+  | 'emergency-navigation-fallback';
+
+export const EMERGENCY_OFFLINE_HTML = `<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>離線模式 - ${APP_INFO.name}</title>
+    <meta name="robots" content="noindex,nofollow">
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: #f8fafc;
+        color: #0f172a;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .card {
+        width: min(100%, 360px);
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        background: #fff;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        padding: 24px 20px;
+        text-align: center;
+      }
+      .icon { font-size: 40px; line-height: 1; margin-bottom: 12px; }
+      h1 { margin: 0 0 12px; font-size: 20px; }
+      p { margin: 0; line-height: 1.65; color: #475569; }
+      button {
+        margin-top: 16px;
+        border: 0;
+        border-radius: 999px;
+        background: #0f172a;
+        color: #fff;
+        font: inherit;
+        padding: 10px 16px;
+      }
+    </style>
+  </head>
+  <body data-ratewise-emergency-fallback="true">
+    <main class="card" role="alert" aria-live="assertive">
+      <div class="icon">⚠️</div>
+      <h1>離線啟動保護模式</h1>
+      <p>目前無法取得完整快取資源，已切換到最低限度離線保護頁。請重新連線後再試一次。</p>
+      <button type="button" onclick="window.location.reload()">重新載入</button>
+    </main>
+  </body>
+</html>`;
+
+export function createEmergencyOfflineResponse(reason: EmergencyOfflineFallbackReason): Response {
+  return new Response(EMERGENCY_OFFLINE_HTML, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-RateWise-Offline-Fallback': reason,
+    },
+  });
+}
+
+interface ResolveOfflineDocumentFallbackOptions {
+  emergencyReason: EmergencyOfflineFallbackReason;
+  matchPrecache: (
+    url: 'index.html' | 'offline.html',
+  ) => Response | undefined | null | Promise<Response | undefined | null>;
+  matchOfflineHtmlInAnyCache: () =>
+    | Response
+    | undefined
+    | null
+    | Promise<Response | undefined | null>;
+}
+
+export async function resolveOfflineDocumentFallback({
+  emergencyReason,
+  matchPrecache,
+  matchOfflineHtmlInAnyCache,
+}: ResolveOfflineDocumentFallbackOptions): Promise<Response> {
+  const precachedIndex = await matchPrecache('index.html');
+  if (precachedIndex) return precachedIndex;
+
+  const precachedOffline = await matchPrecache('offline.html');
+  if (precachedOffline) return precachedOffline;
+
+  return (await matchOfflineHtmlInAnyCache()) ?? createEmergencyOfflineResponse(emergencyReason);
+}

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -18,6 +18,11 @@
 - 解法：補齊 relatedGuides SSOT、HTML/Markdown/llms.txt 測試與產物，並讓排程 baseline 變更以 release 豁免格式提交回 main。
 
 - 日期：2026-05-06
+- ID：ratewise-pwa-emergency-fallback-brand-ssot
+- 原因：emergency inline HTML fallback 初版仍硬編碼 `HaoRate`，會讓正式品牌字串與 `APP_INFO` SSOT 漂移，且對應測試仍鎖在舊的 `Response.error()` 控制流。
+- 解法：改為從 `APP_INFO.name` 生成 emergency fallback 標題，並同步更新 SW 測試斷言，讓品牌與 fallback 行為都回到單一真實來源。
+
+- 日期：2026-05-06
 - ID：ratewise-pwa-emergency-html-fallback
 - 原因：`2.22.20` 在快取損毀更嚴重的冷啟動離線情境下，若 `index.html` 與 `offline.html` 同時從各快取失守，SW 仍會直接回 `ERR_FAILED`，連 watchdog 都來不及顯示，形成真正白屏。
 - 解法：在 Service Worker 增加不依賴任何 cache 的 emergency inline HTML fallback，讓導覽 HTML fallback 全失守時仍能回傳最小可見保護頁，並補靜態回歸測試鎖住 `emergency-document-fallback` / `emergency-navigation-fallback`。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -18,6 +18,11 @@
 - 解法：補齊 relatedGuides SSOT、HTML/Markdown/llms.txt 測試與產物，並讓排程 baseline 變更以 release 豁免格式提交回 main。
 
 - 日期：2026-05-06
+- ID：ratewise-pwa-emergency-html-fallback
+- 原因：`2.22.20` 在快取損毀更嚴重的冷啟動離線情境下，若 `index.html` 與 `offline.html` 同時從各快取失守，SW 仍會直接回 `ERR_FAILED`，連 watchdog 都來不及顯示，形成真正白屏。
+- 解法：在 Service Worker 增加不依賴任何 cache 的 emergency inline HTML fallback，讓導覽 HTML fallback 全失守時仍能回傳最小可見保護頁，並補靜態回歸測試鎖住 `emergency-document-fallback` / `emergency-navigation-fallback`。
+
+- 日期：2026-05-06
 - ID：ratewise-pwa-watchdog-fallback-and-timeout-signal-guard
 - 原因：冷啟動 watchdog 若只認 `app-ready`，可能誤蓋 React 已成功渲染的 chunk/offline fallback；同時 cold-start prime race 若不清除落敗 timeout，健康啟動也會留下假的 timeout 診斷。
 - 解法：為 `OfflineAwareFallback` 加入 watchdog-ready 訊號，讓已渲染 fallback 可正確終止 watchdog；並在 early prime 成功時清除 timeout handle，維持 PWA 診斷訊號的真實性。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -12,6 +12,11 @@
 
 ## 條目（新→舊）
 
+- 日期：2026-05-07
+- ID：ratewise-pwa-offline-fallback-runtime-contract
+- 原因：emergency fallback 初版主要依賴 `sw.ts` 字串斷言，未直接驗證 `index.html`、`offline.html` 與任意 cache 全失效時仍會回可見 HTML。
+- 解法：抽出 `resolveOfflineDocumentFallback` 純函式並補 runtime-style 單元測試，鎖住 fallback 優先序、200 HTML 回應與 `X-RateWise-Offline-Fallback` header。
+
 - 日期：2026-05-06
 - ID：ratewise-authority-guide-crosslinks-and-baseline-persist
 - 原因：authority guide 頁面與 Markdown mirrors 缺少 guide-to-guide 互連，且 production Lighthouse baseline 排程更新後未能持久化回 repo。


### PR DESCRIPTION
## 摘要
- 補上不依賴 cache 的 emergency inline HTML fallback
- 修正 emergency fallback 標題改用 `APP_INFO.name`，避免品牌 SSOT 漂移
- 補強 PWA regression tests，鎖住 navigation fallback 最後一層保護

## 背景與證據
使用 `2.22.16` / `2.22.20` 工作樹做冷啟動 A/B 後，已確認 `2.22.20` 雖能處理「JS chunk 遺失但 HTML 尚在」的情境，但若離線冷啟動時 `index.html` 與 `offline.html` 兩層 HTML fallback 都從 cache 失守，導覽會直接落到 `ERR_FAILED`，連 watchdog 都無法執行，這才是真正的白屏類型。

本 PR 讓 SW 在 document/navigation fallback 全失守時，仍回傳最小可見的 emergency HTML，避免使用者得到完全空白頁。

## 影響
- 冷啟動離線失效時，從「完全白屏 / net::ERR_FAILED」降級為「可見的保護頁」
- 讓現有可觀性真正有機會顯示，不再因無 HTML 回應而完全失聲
- 品牌標題回到 SSOT

## 範圍
- `apps/ratewise/src/sw.ts`
- `apps/ratewise/src/pwa-offline.test.ts`
- `apps/ratewise/src/__tests__/sw.test.ts`
- `docs/dev/002_development_reward_penalty_log.md`
- `.changeset/*.md`

## 驗收標準
- 離線冷啟動時，即使 `index.html` 與 `offline.html` 均不在 cache，中斷導覽不再出現白屏
- `app-ready` / watchdog 以外的最後 fallback 層仍有可見 HTML 響應
- 相關 vitest 與 `build:ratewise` 通過

## 已執行驗證
- `pnpm --filter @app/ratewise exec vitest run src/pwa-offline.test.ts src/__tests__/sw.test.ts src/config/__tests__/build-scripts.test.ts`
- `VITE_RATEWISE_BASE_PATH='/' pnpm build:ratewise`
- `pre-push`: `pnpm -r typecheck`、`pnpm -r test`、`pnpm build:ratewise`
- 本地 browser A/B：
  - `2.22.20` 原版在刪除 JS/CSS + HTML fallback 後離線導覽會 `net::ERR_FAILED`
  - 本分支同條件下會顯示 emergency fallback 頁，而不是白屏
