### PR TITLE
fix(pwa): watchdog 保留 SSG 預渲染內容避免冷啟動降級白屏

### DIFF
--- a/.changeset/ratewise-watchdog-preserve-ssg.md
+++ b/.changeset/ratewise-watchdog-preserve-ssg.md
@@ -2,4 +2,4 @@
 '@app/ratewise': patch
 ---
 
-修正冷啟動 watchdog 抹除 SSG 預渲染內容的反模式。當 JS chunk 載入失敗時，若 `#root` 已含 vite-react-ssg 預渲染樹，watchdog 改採 floating banner 模式並附加在 `<body>`，使用者仍可閱讀靜態頁；無 SSG 內容時沿用原本全屏 fallback。
+修正冷啟動 watchdog 抹除 SSG 預渲染內容的反模式。當 JS chunk 載入失敗時，若 `#root` 已含 vite-react-ssg 預渲染樹，watchdog 改採 floating banner 模式並附加在 `<body>`，使用者仍可閱讀靜態頁；診斷視窗改用 design token 色彩與純文字標籤，並明確提示「Service Worker 未註冊但舊快取仍存在」的修復路徑。

--- a/.changeset/ratewise-watchdog-preserve-ssg.md
+++ b/.changeset/ratewise-watchdog-preserve-ssg.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修正冷啟動 watchdog 抹除 SSG 預渲染內容的反模式。當 JS chunk 載入失敗時，若 `#root` 已含 vite-react-ssg 預渲染樹，watchdog 改採 floating banner 模式並附加在 `<body>`，使用者仍可閱讀靜態頁；無 SSG 內容時沿用原本全屏 fallback。

--- a/.changeset/watchdog-banner-ready-cleanup.md
+++ b/.changeset/watchdog-banner-ready-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+啟動完成後自動清除冷啟動 watchdog banner，避免慢速 hydration 成功後仍顯示過時的載入失敗提示。

--- a/.changeset/watchdog-overlay-dedupe.md
+++ b/.changeset/watchdog-overlay-dedupe.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+避免 cold-start watchdog 在 SSG banner 模式下重複附加錯誤提示；新 overlay 顯示前會先清除既有 cold-start overlay。

--- a/.changeset/watchdog-ssg-marker-only.md
+++ b/.changeset/watchdog-ssg-marker-only.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+收斂 cold-start watchdog 的 SSG 判斷：banner 模式只信任 `data-server-rendered="true"`，避免破碎 root 或 placeholder 子節點被誤判為可閱讀的預渲染內容。

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -446,6 +446,11 @@
           var root = document.getElementById('root');
           return Boolean(root && root.querySelector(WATCHDOG_READY_SELECTOR));
         }
+        function removeColdStartOverlay() {
+          document.querySelectorAll('[data-cold-start-overlay]').forEach(function (el) {
+            el.remove();
+          });
+        }
         // SSG 預渲染內容偵測：vite-react-ssg 會在 #root 標 data-server-rendered="true"
         // 並填入完整 hydration tree。JS 載入失敗時應保留此可見內容，
         // 不可整片清除換成診斷面板，否則使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」。
@@ -768,6 +773,7 @@
           recordDiagnostic('cold-start-watchdog-cleared', reason);
           clearTimeout(coldStartTimer);
           clearRetry();
+          removeColdStartOverlay();
         }
         window.addEventListener(APP_READY_EVENT, function () {
           clearWatchdog('ready-event');

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -461,16 +461,20 @@
           return root.children.length > 0;
         }
         function collectDiagnostics() {
-          var lines = ['\u23f0 ' + new Date().toLocaleTimeString('zh-TW')];
-          lines.push(
-            '\ud83c\udf10 \u7db2\u8def:' + (navigator.onLine ? '\u5728\u7dda' : '\u96e2\u7dda'),
-          );
+          var state = {
+            hasServiceWorkerSupport: 'serviceWorker' in navigator,
+            hasRegistration: false,
+            cacheTotal: 0,
+          };
+          var lines = ['\u6642\u9593\uff1a' + new Date().toLocaleTimeString('zh-TW')];
+          lines.push('\u7db2\u8def\uff1a' + (navigator.onLine ? '\u5728\u7dda' : '\u96e2\u7dda'));
           var swP =
             'serviceWorker' in navigator
               ? navigator.serviceWorker
                   .getRegistration()
                   .then(function (reg) {
                     if (reg) {
+                      state.hasRegistration = true;
                       var st = reg.active
                         ? 'active'
                         : reg.waiting
@@ -478,21 +482,21 @@
                           : reg.installing
                             ? 'installing'
                             : '\u7121 worker';
-                      lines.push('\u2699\ufe0f SW:' + st);
+                      lines.push('Service Worker\uff1a' + st);
                       lines.push(
-                        '\ud83c\udfae \u63a7\u5236:' +
+                        '\u63a7\u5236\u72c0\u614b\uff1a' +
                           (navigator.serviceWorker.controller
                             ? '\u6709'
                             : '\u7121\uff08\u9801\u9762\u9700\u91cd\u8f09\uff09'),
                       );
                     } else {
-                      lines.push('\u2699\ufe0f SW:\u672a\u8a3b\u518a');
+                      lines.push('Service Worker\uff1a\u672a\u8a3b\u518a');
                     }
                   })
                   .catch(function (e) {
-                    lines.push('\u2699\ufe0f SW:' + String(e));
+                    lines.push('Service Worker\uff1a' + String(e));
                   })
-              : (lines.push('\u2699\ufe0f SW:\u4e0d\u652f\u63f4'), Promise.resolve());
+              : (lines.push('Service Worker\uff1a\u4e0d\u652f\u63f4'), Promise.resolve());
           var cacheP =
             'caches' in window
               ? caches
@@ -512,8 +516,9 @@
                     var total = list.reduce(function (s, c) {
                       return s + c.count;
                     }, 0);
+                    state.cacheTotal = total;
                     lines.push(
-                      '\ud83d\udce6 \u5feb\u53d6:' + list.length + ' \u500b / ' + total + ' \u9805',
+                      '\u5feb\u53d6\uff1a' + list.length + ' \u500b / ' + total + ' \u9805',
                     );
                     list.forEach(function (c) {
                       lines.push(
@@ -525,14 +530,23 @@
                     });
                   })
                   .catch(function (e) {
-                    lines.push('\ud83d\udce6 \u5feb\u53d6:' + String(e));
+                    lines.push('\u5feb\u53d6\uff1a' + String(e));
                   })
-              : (lines.push('\ud83d\udce6 \u5feb\u53d6:\u4e0d\u652f\u63f4'), Promise.resolve());
+              : (lines.push('\u5feb\u53d6\uff1a\u4e0d\u652f\u63f4'), Promise.resolve());
           return Promise.all([swP, cacheP]).then(function () {
+            if (state.hasServiceWorkerSupport && !state.hasRegistration && state.cacheTotal > 0) {
+              lines.push('');
+              lines.push(
+                '\u72c0\u614b\uff1aService Worker \u672a\u8a3b\u518a\uff0c\u4f46\u700f\u89bd\u5668\u4ecd\u4fdd\u7559\u820a\u5feb\u53d6\u3002',
+              );
+              lines.push(
+                '\u5efa\u8b70\uff1a\u4f7f\u7528\u300c\u6e05\u9664\u5feb\u53d6\u4e26\u91cd\u8f09\u300d\u91cd\u5efa PWA \u72c0\u614b\u3002',
+              );
+            }
             var recentEvents = readDiagnostics().slice(-8);
             if (recentEvents.length > 0) {
               lines.push('');
-              lines.push('\ud83e\udde0 \u6700\u8fd1\u4e8b\u4ef6');
+              lines.push('\u6700\u8fd1\u4e8b\u4ef6');
               recentEvents.forEach(function (event) {
                 lines.push(
                   ' ' +
@@ -613,8 +627,9 @@
               'position:fixed;left:50%;transform:translateX(-50%);' +
               'bottom:calc(env(safe-area-inset-bottom,0px) + 16px);' +
               'width:min(420px,calc(100% - 32px));max-height:60vh;overflow-y:auto;' +
-              'background:var(--sk-surface,#ffffff);color:var(--sk-text,#1e293b);' +
-              'border:1px solid var(--sk-border,#e2e8f0);border-radius:1rem;' +
+              'background:rgb(var(--color-surface,255 255 255));' +
+              'color:rgb(var(--color-text,30 41 59));' +
+              'border:1px solid rgb(var(--color-border,226 232 240));border-radius:1rem;' +
               'box-shadow:0 12px 32px rgba(15,23,42,0.18);' +
               'padding:1rem 1.25rem;display:flex;flex-direction:column;align-items:center;' +
               'gap:0.5rem;text-align:center;z-index:9999;' +
@@ -623,19 +638,29 @@
             // \u7121 SSG \u5167\u5bb9\uff1a\u6cbf\u7528\u539f\u672c\u5168\u5c4f\u932f\u8aa4\u9762\u677f\uff08\u4fdd\u96aa\u5c64\uff09\u3002
             wrap.style.cssText =
               'position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;' +
-              'justify-content:center;overflow-y:auto;background:var(--sk-bg,#f8fafc);' +
+              'justify-content:center;overflow-y:auto;background:rgb(var(--color-background,248 250 252));' +
+              'color:rgb(var(--color-text,30 41 59));' +
               'font-family:system-ui,-apple-system,sans-serif;' +
               'padding:2rem 1.5rem;text-align:center;gap:0.625rem;z-index:9999;';
           }
-          var icon = document.createElement('div');
-          icon.style.cssText = hasPrerendered
-            ? 'font-size:1.5rem;line-height:1'
-            : 'font-size:2.5rem;line-height:1';
-          icon.textContent = isOnline ? '\u26a0\ufe0f' : '\ud83d\udce1';
+          var statusBadge = document.createElement('div');
+          statusBadge.setAttribute('aria-hidden', 'true');
+          statusBadge.style.cssText =
+            'display:flex;align-items:center;justify-content:center;border-radius:9999px;' +
+            'width:' +
+            (hasPrerendered ? '2rem' : '3rem') +
+            ';height:' +
+            (hasPrerendered ? '2rem' : '3rem') +
+            ';font-weight:700;font-size:' +
+            (hasPrerendered ? '1rem' : '1.25rem') +
+            ';background:rgb(var(--color-warning-light,254 243 199));' +
+            'color:rgb(var(--color-warning-text,146 64 14));' +
+            'border:1px solid rgb(var(--color-warning,245 158 11) / 0.35);';
+          statusBadge.textContent = isOnline ? '!' : 'i';
           var title = document.createElement('div');
           title.style.cssText = hasPrerendered
-            ? 'font-size:1rem;font-weight:600;color:var(--sk-text,#1e293b)'
-            : 'font-size:1.125rem;font-weight:700;color:var(--sk-text,#1e293b)';
+            ? 'font-size:1rem;font-weight:600;color:rgb(var(--color-text,30 41 59))'
+            : 'font-size:1.125rem;font-weight:700;color:rgb(var(--color-text,30 41 59))';
           title.textContent = isOnline
             ? hasPrerendered
               ? '\u4e92\u52d5\u529f\u80fd\u8f09\u5165\u5931\u6557'
@@ -643,21 +668,24 @@
             : '\u76ee\u524d\u8655\u65bc\u96e2\u7dda\u6a21\u5f0f';
           var desc = document.createElement('div');
           desc.style.cssText =
-            'font-size:0.875rem;color:var(--sk-text-muted,#64748b);max-width:320px;line-height:1.6';
+            'font-size:0.875rem;color:rgb(var(--color-text-muted,100 116 139));max-width:320px;line-height:1.6';
           desc.textContent = hasPrerendered
             ? '\u9801\u9762\u5167\u5bb9\u4ecd\u53ef\u95b1\u8b80\uff0c\u4f46\u52d5\u614b\u63db\u7b97\u8207 PWA \u4e92\u52d5\u66ab\u6642\u5931\u6548\u3002\u8acb\u91cd\u65b0\u8f09\u5165\u4ee5\u6062\u5fa9\u5b8c\u6574\u529f\u80fd\u3002'
             : isOnline
               ? 'PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u53ef\u80fd\u5df2\u640d\u58de\u6216\u4e0d\u5b8c\u6574\u3002\u5efa\u8b70\u6e05\u9664\u5feb\u53d6\u5f8c\u91cd\u8a66\u3002'
               : '\u96e2\u7dda\u6a21\u5f0f\u4e0b PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u8acb\u9023\u7dda\u5f8c\u91cd\u65b0\u958b\u555f\u3002';
-          wrap.appendChild(icon);
+          wrap.appendChild(statusBadge);
           wrap.appendChild(title);
           wrap.appendChild(desc);
           var CTA =
-            'padding:.625rem 1.75rem;background:#8B5CF6;color:#fff;border:none;' +
-            'border-radius:9999px;font-size:.875rem;font-weight:600;cursor:pointer;';
+            'padding:.625rem 1.75rem;background:rgb(var(--color-primary,124 58 237));' +
+            'color:#fff;border:none;border-radius:.75rem;font-size:.875rem;font-weight:600;' +
+            'cursor:pointer;box-shadow:0 8px 20px rgb(var(--color-primary,124 58 237) / 0.22);';
           var SEC =
-            'padding:.5rem 1.25rem;background:transparent;color:var(--sk-text-muted,#64748b);' +
-            'border:1px solid var(--sk-border,#cbd5e1);border-radius:9999px;font-size:.8rem;cursor:pointer;';
+            'padding:.5rem 1.25rem;background:rgb(var(--color-surface-elevated,248 250 252));' +
+            'color:rgb(var(--color-text-muted,100 116 139));' +
+            'border:1px solid rgb(var(--color-border,226 232 240));border-radius:.75rem;' +
+            'font-size:.8rem;cursor:pointer;';
           var btnRow = document.createElement('div');
           btnRow.style.cssText =
             'display:flex;flex-wrap:wrap;gap:0.5rem;justify-content:center;margin-top:0.25rem';
@@ -684,7 +712,8 @@
           }
           if (!isOnline) {
             var hintOffline = document.createElement('div');
-            hintOffline.style.cssText = 'font-size:0.75rem;color:var(--sk-text-muted,#94a3b8)';
+            hintOffline.style.cssText =
+              'font-size:0.75rem;color:rgb(var(--color-text-muted,100 116 139))';
             hintOffline.textContent =
               '\u9023\u7dda\u5f8c\u8acb\u91cd\u65b0\u958b\u555f\u61c9\u7528\u7a0b\u5f0f';
             btnRow.appendChild(hintOffline);
@@ -692,7 +721,7 @@
           if (!canRetry && isOnline) {
             var hintFailed = document.createElement('div');
             hintFailed.style.cssText =
-              'font-size:0.75rem;color:var(--sk-text-muted,#94a3b8);max-width:260px';
+              'font-size:0.75rem;color:rgb(var(--color-text-muted,100 116 139));max-width:260px';
             hintFailed.textContent =
               '\u82e5\u554f\u984c\u6301\u7e8c\uff0c\u8acb\u81f3\u700f\u89bd\u5668\u8a2d\u5b9a\u6e05\u9664\u7db2\u7ad9\u5feb\u53d6\u5f8c\u91cd\u8a66\u3002';
             btnRow.appendChild(hintFailed);
@@ -701,19 +730,21 @@
           var diagId = 'cs-diag';
           var details = document.createElement('details');
           details.style.cssText =
-            'margin-top:0.5rem;text-align:left;font-size:.75rem;max-width:320px;width:100%;';
+            'margin-top:0.5rem;text-align:left;font-size:.75rem;max-width:360px;width:100%;' +
+            'border:1px solid rgb(var(--color-border,226 232 240));border-radius:.75rem;' +
+            'background:rgb(var(--color-surface-elevated,248 250 252));overflow:hidden;';
           var summary = document.createElement('summary');
           summary.style.cssText =
-            'cursor:pointer;text-align:center;padding:.25rem;' +
-            'color:var(--sk-text-muted,#94a3b8);-webkit-user-select:none;user-select:none';
-          summary.textContent = '\ud83d\udcca \u8a3a\u65b7\u8a73\u60c5';
+            'cursor:pointer;text-align:center;padding:.5rem .75rem;font-weight:600;' +
+            'color:rgb(var(--color-text-muted,100 116 139));-webkit-user-select:none;user-select:none';
+          summary.textContent = '\u8a3a\u65b7\u8a73\u60c5';
           var diagPre = document.createElement('pre');
           diagPre.id = diagId;
           diagPre.style.cssText =
-            'white-space:pre-wrap;word-break:break-all;margin:.5rem 0;' +
-            'background:var(--sk-surface,#fff);border:1px solid var(--sk-border,#e2e8f0);' +
-            'padding:.75rem;border-radius:.5rem;font-size:.7rem;' +
-            'color:var(--sk-text,#475569);text-align:left;line-height:1.6;';
+            'white-space:pre-wrap;word-break:break-all;margin:0;border-top:1px solid rgb(var(--color-border,226 232 240));' +
+            'background:rgb(var(--color-surface,255 255 255));padding:.75rem;font-size:.7rem;' +
+            'font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;' +
+            'color:rgb(var(--color-text,51 65 85));text-align:left;line-height:1.6;';
           diagPre.textContent = '\u6536\u96c6\u4e2d\u2026';
           details.appendChild(summary);
           details.appendChild(diagPre);

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -613,6 +613,7 @@
             { timeoutMs: TIMEOUT_MS, hasPrerendered: hasPrerendered },
             'error',
           );
+          removeColdStartOverlay();
           var isOnline = navigator.onLine !== false;
           var canRetry = isOnline && getRetryCount() < MAX_RETRIES;
           var wrap = document.createElement('div');

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -446,6 +446,15 @@
           var root = document.getElementById('root');
           return Boolean(root && root.querySelector(WATCHDOG_READY_SELECTOR));
         }
+        // SSG 預渲染內容偵測：vite-react-ssg 會在 #root 標 data-server-rendered="true"
+        // 並填入完整 hydration tree。JS 載入失敗時應保留此可見內容，
+        // 不可整片清除換成診斷面板，否則使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」。
+        function hasPrerenderedRootContent() {
+          var root = document.getElementById('root');
+          if (!root) return false;
+          if (root.getAttribute('data-server-rendered') === 'true') return true;
+          return root.children.length > 0;
+        }
         function collectDiagnostics() {
           var lines = ['\u23f0 ' + new Date().toLocaleTimeString('zh-TW')];
           lines.push(
@@ -581,31 +590,60 @@
         function showColdStartError() {
           var root = document.getElementById('root');
           if (!root || isAppReady() || hasReactFallbackReady()) return;
-          recordDiagnostic('cold-start-overlay-shown', { timeoutMs: TIMEOUT_MS }, 'error');
+          var hasPrerendered = hasPrerenderedRootContent();
+          recordDiagnostic(
+            'cold-start-overlay-shown',
+            { timeoutMs: TIMEOUT_MS, hasPrerendered: hasPrerendered },
+            'error',
+          );
           var isOnline = navigator.onLine !== false;
           var canRetry = isOnline && getRetryCount() < MAX_RETRIES;
           var wrap = document.createElement('div');
           wrap.setAttribute('role', 'alert');
           wrap.setAttribute('aria-live', 'assertive');
-          wrap.style.cssText =
-            'position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;' +
-            'justify-content:center;overflow-y:auto;background:var(--sk-bg,#f8fafc);' +
-            'font-family:system-ui,-apple-system,sans-serif;' +
-            'padding:2rem 1.5rem;text-align:center;gap:0.625rem;z-index:9999;';
+          wrap.setAttribute('data-cold-start-overlay', hasPrerendered ? 'banner' : 'fullscreen');
+          if (hasPrerendered) {
+            // SSG \u5df2\u6e32\u67d3\u53ef\u898b\u5167\u5bb9\uff1a\u63a1\u7528\u5e95\u90e8 floating banner \u6a21\u5f0f\uff0c\u4e0d\u7834\u58de\u4f7f\u7528\u8005\u5df2\u770b\u5230\u7684\u975c\u614b\u9801\u3002
+            wrap.style.cssText =
+              'position:fixed;left:50%;transform:translateX(-50%);' +
+              'bottom:calc(env(safe-area-inset-bottom,0px) + 16px);' +
+              'width:min(420px,calc(100% - 32px));max-height:60vh;overflow-y:auto;' +
+              'background:var(--sk-surface,#ffffff);color:var(--sk-text,#1e293b);' +
+              'border:1px solid var(--sk-border,#e2e8f0);border-radius:1rem;' +
+              'box-shadow:0 12px 32px rgba(15,23,42,0.18);' +
+              'padding:1rem 1.25rem;display:flex;flex-direction:column;align-items:center;' +
+              'gap:0.5rem;text-align:center;z-index:9999;' +
+              'font-family:system-ui,-apple-system,sans-serif;';
+          } else {
+            // \u7121 SSG \u5167\u5bb9\uff1a\u6cbf\u7528\u539f\u672c\u5168\u5c4f\u932f\u8aa4\u9762\u677f\uff08\u4fdd\u96aa\u5c64\uff09\u3002
+            wrap.style.cssText =
+              'position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;' +
+              'justify-content:center;overflow-y:auto;background:var(--sk-bg,#f8fafc);' +
+              'font-family:system-ui,-apple-system,sans-serif;' +
+              'padding:2rem 1.5rem;text-align:center;gap:0.625rem;z-index:9999;';
+          }
           var icon = document.createElement('div');
-          icon.style.cssText = 'font-size:2.5rem;line-height:1';
+          icon.style.cssText = hasPrerendered
+            ? 'font-size:1.5rem;line-height:1'
+            : 'font-size:2.5rem;line-height:1';
           icon.textContent = isOnline ? '\u26a0\ufe0f' : '\ud83d\udce1';
           var title = document.createElement('div');
-          title.style.cssText = 'font-size:1.125rem;font-weight:700;color:var(--sk-text,#1e293b)';
+          title.style.cssText = hasPrerendered
+            ? 'font-size:1rem;font-weight:600;color:var(--sk-text,#1e293b)'
+            : 'font-size:1.125rem;font-weight:700;color:var(--sk-text,#1e293b)';
           title.textContent = isOnline
-            ? '\u61c9\u7528\u7a0b\u5f0f\u8f09\u5165\u5931\u6557'
+            ? hasPrerendered
+              ? '\u4e92\u52d5\u529f\u80fd\u8f09\u5165\u5931\u6557'
+              : '\u61c9\u7528\u7a0b\u5f0f\u8f09\u5165\u5931\u6557'
             : '\u76ee\u524d\u8655\u65bc\u96e2\u7dda\u6a21\u5f0f';
           var desc = document.createElement('div');
           desc.style.cssText =
-            'font-size:0.875rem;color:var(--sk-text-muted,#64748b);max-width:280px;line-height:1.6';
-          desc.textContent = isOnline
-            ? 'PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u53ef\u80fd\u5df2\u640d\u58de\u6216\u4e0d\u5b8c\u6574\u3002\u5efa\u8b70\u6e05\u9664\u5feb\u53d6\u5f8c\u91cd\u8a66\u3002'
-            : '\u96e2\u7dda\u6a21\u5f0f\u4e0b PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u8acb\u9023\u7dda\u5f8c\u91cd\u65b0\u958b\u555f\u3002';
+            'font-size:0.875rem;color:var(--sk-text-muted,#64748b);max-width:320px;line-height:1.6';
+          desc.textContent = hasPrerendered
+            ? '\u9801\u9762\u5167\u5bb9\u4ecd\u53ef\u95b1\u8b80\uff0c\u4f46\u52d5\u614b\u63db\u7b97\u8207 PWA \u4e92\u52d5\u66ab\u6642\u5931\u6548\u3002\u8acb\u91cd\u65b0\u8f09\u5165\u4ee5\u6062\u5fa9\u5b8c\u6574\u529f\u80fd\u3002'
+            : isOnline
+              ? 'PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u53ef\u80fd\u5df2\u640d\u58de\u6216\u4e0d\u5b8c\u6574\u3002\u5efa\u8b70\u6e05\u9664\u5feb\u53d6\u5f8c\u91cd\u8a66\u3002'
+              : '\u96e2\u7dda\u6a21\u5f0f\u4e0b PWA \u5feb\u53d6\u8cc7\u6e90\u7121\u6cd5\u8f09\u5165\uff0c\u8acb\u9023\u7dda\u5f8c\u91cd\u65b0\u958b\u555f\u3002';
           wrap.appendChild(icon);
           wrap.appendChild(title);
           wrap.appendChild(desc);
@@ -675,8 +713,14 @@
           details.appendChild(summary);
           details.appendChild(diagPre);
           wrap.appendChild(details);
-          root.innerHTML = '';
-          root.appendChild(wrap);
+          if (hasPrerendered) {
+            // 已有 SSG 內容：banner 附加到 body，不動 #root，使用者仍可看靜態頁。
+            document.body.appendChild(wrap);
+          } else {
+            // 無 SSG：原本全屏 fallback，沿用既有行為。
+            root.innerHTML = '';
+            root.appendChild(wrap);
+          }
           collectDiagnostics().then(function (lines) {
             var el = document.getElementById(diagId);
             if (el) el.textContent = lines.join('\n');

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -456,9 +456,7 @@
         // 不可整片清除換成診斷面板，否則使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」。
         function hasPrerenderedRootContent() {
           var root = document.getElementById('root');
-          if (!root) return false;
-          if (root.getAttribute('data-server-rendered') === 'true') return true;
-          return root.children.length > 0;
+          return Boolean(root && root.getAttribute('data-server-rendered') === 'true');
         }
         function collectDiagnostics() {
           var state = {

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -225,6 +225,22 @@ describe('PWA 離線功能測試', () => {
       expect(html).toContain('hasPrerendered: hasPrerendered');
     });
 
+    it('should render cold-start diagnostics without emoji and with design token colors', () => {
+      const html = readFileSync(resolve(ROOT_PATH, 'index.html'), 'utf-8');
+
+      expect(html).toContain('Service Worker\\uff1a\\u672a\\u8a3b\\u518a');
+      expect(html).toContain('\\u72c0\\u614b\\uff1aService Worker \\u672a\\u8a3b\\u518a');
+      expect(html).toContain('rgb(var(--color-primary,124 58 237))');
+      expect(html).toContain('rgb(var(--color-surface,255 255 255))');
+      expect(html).toContain('rgb(var(--color-border,226 232 240))');
+      expect(html).toContain("summary.textContent = '\\u8a3a\\u65b7\\u8a73\\u60c5'");
+      expect(html).not.toContain('\\u23f0');
+      expect(html).not.toContain('\\ud83c');
+      expect(html).not.toContain('\\ud83d');
+      expect(html).not.toContain('\\ud83e');
+      expect(html).not.toContain('\\u26a0');
+    });
+
     it('should reload on controllerchange after activating a waiting worker', () => {
       const swUtils = readFileSync(resolve(ROOT_PATH, 'src/utils/swUtils.ts'), 'utf-8');
       expect(swUtils).toContain('controllerchange');

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -208,7 +208,7 @@ describe('PWA 離線功能測試', () => {
       // SSG 內容偵測函式必須存在，watchdog 才能判斷是否走 banner 模式。
       expect(html).toContain('hasPrerenderedRootContent');
       expect(html).toContain('data-server-rendered');
-      expect(html).toContain('root.children.length > 0');
+      expect(html).not.toContain('root.children.length > 0');
 
       // 雙模式分支：banner（保留 SSG）vs fullscreen（沿用原行為）。
       expect(html).toContain('data-cold-start-overlay');

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -198,6 +198,7 @@ describe('PWA 離線功能測試', () => {
       expect(html).toContain('react-fallback-ready');
       expect(html).toContain('cold-start-watchdog-cleared');
       expect(html).toContain('removeColdStartOverlay');
+      expect(html).toContain('removeColdStartOverlay();');
       expect(html).not.toContain('root.children.length === 0');
       expect(fallbackComponent).toContain('data-ratewise-watchdog-ready="true"');
     });
@@ -223,6 +224,7 @@ describe('PWA 離線功能測試', () => {
 
       // 診斷事件需帶 hasPrerendered 標記，供後續觀察性追蹤。
       expect(html).toContain('hasPrerendered: hasPrerendered');
+      expect(html).toContain('removeColdStartOverlay();');
     });
 
     it('should render cold-start diagnostics without emoji and with design token colors', () => {

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -201,6 +201,29 @@ describe('PWA 離線功能測試', () => {
       expect(fallbackComponent).toContain('data-ratewise-watchdog-ready="true"');
     });
 
+    it('should preserve SSG-rendered #root content when watchdog falls back to error UI', () => {
+      const html = readFileSync(resolve(ROOT_PATH, 'index.html'), 'utf-8');
+
+      // SSG 內容偵測函式必須存在，watchdog 才能判斷是否走 banner 模式。
+      expect(html).toContain('hasPrerenderedRootContent');
+      expect(html).toContain('data-server-rendered');
+      expect(html).toContain('root.children.length > 0');
+
+      // 雙模式分支：banner（保留 SSG）vs fullscreen（沿用原行為）。
+      expect(html).toContain('data-cold-start-overlay');
+      expect(html).toContain("'banner'");
+      expect(html).toContain("'fullscreen'");
+
+      // 已渲染狀態下：watchdog 必須附加 wrap 到 body，禁止清除 #root。
+      expect(html).toContain('document.body.appendChild(wrap)');
+
+      // 無 SSG 時保留原本 fallback 行為。
+      expect(html).toContain("root.innerHTML = ''");
+
+      // 診斷事件需帶 hasPrerendered 標記，供後續觀察性追蹤。
+      expect(html).toContain('hasPrerendered: hasPrerendered');
+    });
+
     it('should reload on controllerchange after activating a waiting worker', () => {
       const swUtils = readFileSync(resolve(ROOT_PATH, 'src/utils/swUtils.ts'), 'utf-8');
       expect(swUtils).toContain('controllerchange');

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -197,6 +197,7 @@ describe('PWA 離線功能測試', () => {
       expect(html).toContain('hasReactFallbackReady');
       expect(html).toContain('react-fallback-ready');
       expect(html).toContain('cold-start-watchdog-cleared');
+      expect(html).toContain('removeColdStartOverlay');
       expect(html).not.toContain('root.children.length === 0');
       expect(fallbackComponent).toContain('data-ratewise-watchdog-ready="true"');
     });

--- a/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
+++ b/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
@@ -529,9 +529,7 @@ test.describe('飛航模式冷啟動診斷', () => {
     expect(cssCacheCount, '快取中應有 CSS files').toBeGreaterThanOrEqual(1);
   });
 
-  test('即使 root 提前出現假節點，冷啟動 watchdog 仍應顯示診斷 UI（banner 模式）', async ({
-    browser,
-  }) => {
+  test('即使 root 提前出現假節點，冷啟動 watchdog 仍應顯示全屏診斷 UI', async ({ browser }) => {
     const context = await browser.newContext({
       serviceWorkers: 'allow',
     });
@@ -539,39 +537,32 @@ test.describe('飛航模式冷啟動診斷', () => {
 
     await page.addInitScript(() => {
       window.__RATEWISE_COLD_START_TIMEOUT_MS__ = 900;
+    });
 
-      const timer = window.setInterval(() => {
-        const root = document.getElementById('root');
-        const isReady = document.documentElement.getAttribute('data-ratewise-app-ready') === 'true';
-
-        if (isReady) {
-          window.clearInterval(timer);
-          return;
-        }
-
-        if (root && root.children.length === 0) {
-          const phantom = document.createElement('div');
-          phantom.setAttribute('data-test-phantom-root-child', 'true');
-          root.appendChild(phantom);
-          window.clearInterval(timer);
-        }
-      }, 50);
+    await page.route('**/ratewise/', async (route) => {
+      const response = await route.fetch();
+      let body = await response.text();
+      body = body.replace(
+        "recordDiagnostic('cold-start-watchdog-start'",
+        "var __testRoot=document.getElementById('root');if(__testRoot){__testRoot.removeAttribute('data-server-rendered');__testRoot.innerHTML='<div data-test-phantom-root-child=\"true\"></div>';}recordDiagnostic('cold-start-watchdog-start'",
+      );
+      await route.fulfill({ response, body });
     });
 
     await page.route('**/assets/*.js*', (route) => route.abort());
     await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
-    // root 有 phantom child → hasPrerenderedRootContent=true → 走 banner 模式
+    // root 有 phantom child 但沒有 SSG 標記 → 不可誤判成可閱讀預渲染內容。
     const alert = page.getByRole('alert');
     await expect(alert).toBeVisible({ timeout: 10_000 });
-    await expect(alert).toHaveAttribute('data-cold-start-overlay', 'banner');
-    await expect(alert).toContainText('互動功能載入失敗');
+    await expect(alert).toHaveAttribute('data-cold-start-overlay', 'fullscreen');
+    await expect(alert).toContainText('應用程式載入失敗');
 
-    // 關鍵保護：phantom 節點不可被 watchdog 清除（不 root.innerHTML=''）
+    // 關鍵保護：phantom 節點不能讓 watchdog 降級成小 banner；全屏 fallback 會清空破碎 root。
     const phantomStillPresent = await page.evaluate(() =>
       Boolean(document.querySelector('[data-test-phantom-root-child="true"]')),
     );
-    expect(phantomStillPresent).toBe(true);
+    expect(phantomStillPresent).toBe(false);
 
     await page.getByText('診斷詳情').click();
     const diagnosticPanel = page.locator('#cs-diag');

--- a/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
+++ b/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
@@ -529,7 +529,9 @@ test.describe('飛航模式冷啟動診斷', () => {
     expect(cssCacheCount, '快取中應有 CSS files').toBeGreaterThanOrEqual(1);
   });
 
-  test('即使 root 提前出現假節點，冷啟動 watchdog 仍應顯示診斷 UI', async ({ browser }) => {
+  test('即使 root 提前出現假節點，冷啟動 watchdog 仍應顯示診斷 UI（banner 模式）', async ({
+    browser,
+  }) => {
     const context = await browser.newContext({
       serviceWorkers: 'allow',
     });
@@ -559,14 +561,63 @@ test.describe('飛航模式冷啟動診斷', () => {
     await page.route('**/assets/*.js*', (route) => route.abort());
     await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
+    // root 有 phantom child → hasPrerenderedRootContent=true → 走 banner 模式
     const alert = page.getByRole('alert');
     await expect(alert).toBeVisible({ timeout: 10_000 });
-    await expect(alert).toContainText('應用程式載入失敗');
+    await expect(alert).toHaveAttribute('data-cold-start-overlay', 'banner');
+    await expect(alert).toContainText('互動功能載入失敗');
+
+    // 關鍵保護：phantom 節點不可被 watchdog 清除（不 root.innerHTML=''）
+    const phantomStillPresent = await page.evaluate(() =>
+      Boolean(document.querySelector('[data-test-phantom-root-child="true"]')),
+    );
+    expect(phantomStillPresent).toBe(true);
 
     await page.getByText('診斷詳情').click();
     const diagnosticPanel = page.locator('#cs-diag');
     await expect(diagnosticPanel).toContainText('最近事件');
     await expect(diagnosticPanel).toContainText('cold-start-overlay-shown');
+
+    await context.close();
+  });
+
+  test('SSG 預渲染內容被保留：JS 全失時 banner 模式不抹除 #root', async ({ browser }) => {
+    const context = await browser.newContext({
+      serviceWorkers: 'allow',
+    });
+    const page = await context.newPage();
+
+    await page.addInitScript(() => {
+      window.__RATEWISE_COLD_START_TIMEOUT_MS__ = 900;
+    });
+
+    // 阻斷所有 chunk → React 永遠無法 hydrate → watchdog 必觸發
+    await page.route('**/assets/*.js*', (route) => route.abort());
+    await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+    const alert = page.getByRole('alert');
+    await expect(alert).toBeVisible({ timeout: 10_000 });
+    await expect(alert).toHaveAttribute('data-cold-start-overlay', 'banner');
+
+    // SSG 預渲染樹必須仍可見：#root 不為空、attribute 仍在。
+    const rootSnapshot = await page.evaluate(() => {
+      const root = document.getElementById('root');
+      return {
+        hasRoot: Boolean(root),
+        childCount: root?.children.length ?? 0,
+        serverRendered: root?.getAttribute('data-server-rendered'),
+      };
+    });
+    expect(rootSnapshot.hasRoot).toBe(true);
+    expect(rootSnapshot.childCount).toBeGreaterThan(0);
+    expect(rootSnapshot.serverRendered).toBe('true');
+
+    // banner 必須附加在 body 直接子層而非 #root 內。
+    const bannerParent = await page.evaluate(() => {
+      const banner = document.querySelector('[data-cold-start-overlay="banner"]');
+      return banner?.parentElement?.tagName.toLowerCase() ?? null;
+    });
+    expect(bannerParent).toBe('body');
 
     await context.close();
   });

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr371-cold-start-diagnostics-token-ui
+- 原因：實際 cold-start 診斷出現「Service Worker 未註冊但舊快取仍存在」的矛盾狀態，舊視窗只用 emoji log 與硬編紫色，未清楚指向可執行修復。
+- 解法：將診斷輸出改為純文字標籤，新增 SW 未註冊但 cache 存在的狀態/建議行，並把視窗樣式改用 `--color-*` design token fallback。
+
+- 日期：2026-05-07
 - ID：pr371-watchdog-banner-ready-cleanup
 - 原因：PR #371 的 watchdog banner 模式將冷啟動警示掛到 `body`，但 app ready 後只清除 timer/retry，會留下已過時的「載入失敗」提示。
 - 解法：在 `clearWatchdog` ready 共用路徑同步移除 `[data-cold-start-overlay]`，並補靜態測試鎖住 ready cleanup 契約。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -828,3 +828,8 @@
 - ID：ratewise-lhci-homepage-runtime-refresh-guard
 - 原因：PR #350 的 Lighthouse CI 在首頁 `/` 掉到 `0.87~0.88`，根因為 LHCI 離線模式下首頁仍執行 runtime 匯率 refresh，失敗後插入 stale warning 與額外背景工作，拉低首屏效能。
 - 解法：在 `exchangeRateService` 與 `useExchangeRates` 增加 `VITE_LHCI_OFFLINE` 穩定分支，LHCI 直接使用 build-time 匯率並跳過 runtime refresh / polling，另補 service 與 hook 回歸測試鎖住行為。
+
+- 日期：2026-05-07
+- ID：ratewise-watchdog-preserve-ssg-content
+- 原因：60 天內 PWA 冷啟動白屏修復累積 11+ 次仍復發，根本反模式為 `index.html` watchdog 5 秒 timeout 後執行 `root.innerHTML=''` 直接抹除 vite-react-ssg 預渲染的 144KB 內容，使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」。
+- 解法：watchdog 加 `hasPrerenderedRootContent()` 偵測（`data-server-rendered` 或 `#root.children.length > 0`），有 SSG 內容時改採 floating banner 並附加到 `<body>`，保留 `#root`；無 SSG 時沿用原全屏 fallback。新增 vitest 靜態回歸與 E2E 鎖住雙模式分支；同步關閉 PR #367 emergency HTML（與本修正重複）。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr371-watchdog-banner-ready-cleanup
+- 原因：PR #371 的 watchdog banner 模式將冷啟動警示掛到 `body`，但 app ready 後只清除 timer/retry，會留下已過時的「載入失敗」提示。
+- 解法：在 `clearWatchdog` ready 共用路徑同步移除 `[data-cold-start-overlay]`，並補靜態測試鎖住 ready cleanup 契約。
+
+- 日期：2026-05-07
 - ID：ratewise-pwa-offline-fallback-runtime-contract
 - 原因：emergency fallback 初版主要依賴 `sw.ts` 字串斷言，未直接驗證 `index.html`、`offline.html` 與任意 cache 全失效時仍會回可見 HTML。
 - 解法：抽出 `resolveOfflineDocumentFallback` 純函式並補 runtime-style 單元測試，鎖住 fallback 優先序、200 HTML 回應與 `X-RateWise-Offline-Fallback` header。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr371-watchdog-overlay-dedupe
+- 原因：Codex review 指出 SSG banner 模式下 timeout 與後續 script error 可能連續觸發 `showColdStartError()`，造成多個 cold-start banner 重疊。
+- 解法：在建立新 watchdog overlay 前先呼叫 `removeColdStartOverlay()`，讓 banner/fullscreen fallback 都維持單一可見診斷視窗。
+
+- 日期：2026-05-07
 - ID：pr371-ssg-marker-only-watchdog-banner
 - 原因：Codex review 指出 cold-start watchdog 只要看到 `#root` 子節點就走 banner，可能把 phantom/破碎 root 誤判為可閱讀 SSG。
 - 解法：將 banner 模式收斂為只信任 `data-server-rendered="true"`，並更新 phantom E2E 斷言為全屏診斷 fallback。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr371-ssg-marker-only-watchdog-banner
+- 原因：Codex review 指出 cold-start watchdog 只要看到 `#root` 子節點就走 banner，可能把 phantom/破碎 root 誤判為可閱讀 SSG。
+- 解法：將 banner 模式收斂為只信任 `data-server-rendered="true"`，並更新 phantom E2E 斷言為全屏診斷 fallback。
+
+- 日期：2026-05-07
 - ID：pr371-cold-start-diagnostics-token-ui
 - 原因：實際 cold-start 診斷出現「Service Worker 未註冊但舊快取仍存在」的矛盾狀態，舊視窗只用 emoji log 與硬編紫色，未清楚指向可執行修復。
 - 解法：將診斷輸出改為純文字標籤，新增 SW 未註冊但 cache 存在的狀態/建議行，並把視窗樣式改用 `--color-*` design token fallback。


### PR DESCRIPTION
## 摘要

- 修正 `index.html` 冷啟動 watchdog 抹除 SSG 預渲染內容的反模式
- 有 SSG 內容時改用底部 floating banner 並附加到 `<body>`，保留 `#root` 可見
- 無 SSG 內容時沿用原全屏 fallback（保險層）
- 鎖住 vitest 靜態回歸 + E2E 雙模式分支

## 背景與根因

過去 60 天 PWA 冷啟動白屏修復累積 11+ 次（PR #199-#202、#351、#355、#358、#359、#360、#364、#367），仍持續復發。經盤點所有防線後，定位到根本反模式：

`apps/ratewise/index.html` watchdog 5 秒 timeout 後執行：

```js
root.innerHTML = '';        // ← 抹除 SSG 預渲染的 144KB 內容
root.appendChild(wrap);     // ← 換成診斷面板
```

vite-react-ssg 預渲染了 50 條路徑（17 幣別正向 + 17 反向 + 8 內容頁 + 8 其他），每條 HTML 都帶 `<div id="root" data-server-rendered="true">…完整 hydration tree…</div>`。但 watchdog 觸發時直接清掉，**使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」**。

業界 App Shell 模式核心原則：JS 失敗時不破壞已渲染 DOM，讓使用者至少能看到靜態內容。本 PR 修復這點。

## 變更內容

### `apps/ratewise/index.html`

1. 加 `hasPrerenderedRootContent()` helper：偵測 `data-server-rendered="true"` 或 `#root.children.length > 0`
2. `showColdStartError()` 雙模式分支：
   - **banner 模式**（有 SSG）：底部 floating banner，附加到 `<body>`，保留 `#root`
   - **fullscreen 模式**（無 SSG）：沿用原全屏 fallback
3. `data-cold-start-overlay` 屬性區分兩種模式
4. 診斷事件 `cold-start-overlay-shown` 帶 `hasPrerendered` 標記

### 測試

- `apps/ratewise/src/pwa-offline.test.ts`：靜態回歸鎖住雙模式分支
- `apps/ratewise/tests/e2e/offline-cold-start.spec.ts`：
  - phantom child 場景改測 banner 模式 + DOM 保留斷言
  - 新增「真 SSG 內容 + 阻斷所有 chunk」場景，驗證 `#root` `data-server-rendered` + children 仍在 + banner 附加在 body

## 影響

- 50 條 SSG 預渲染路徑（首頁、17 幣別、17 反向、8 內容頁等）冷啟動 JS 全失時，使用者仍可看到靜態內容
- watchdog 從「強制覆蓋畫面」改為「不打擾既有可見內容，僅提示互動失效」
- 同步取消 PR #367（emergency inline HTML 與本 PR 重複，banner 已涵蓋同樣場景）

## 範圍

- `apps/ratewise/index.html`
- `apps/ratewise/src/pwa-offline.test.ts`
- `apps/ratewise/tests/e2e/offline-cold-start.spec.ts`
- `docs/dev/002_development_reward_penalty_log.md`
- `.changeset/ratewise-watchdog-preserve-ssg.md`

## 已執行驗證

- `pnpm --filter @app/ratewise typecheck` ✅
- `pnpm --filter @app/ratewise exec vitest run src/pwa-offline.test.ts src/__tests__/sw.test.ts` ✅ 61/61
- `pnpm --filter @app/ratewise exec vitest run src/config/__tests__/build-scripts.test.ts` ✅ 38/38
- `VITE_RATEWISE_BASE_PATH='/' pnpm build:ratewise` ✅
- `git push` 前 pre-push: typecheck + 全 repo test + build:ratewise 全綠

## 相關

- 取代 #367（emergency inline HTML）
- 對應根因分析詳見 commit message 與 002 紀錄

🤖 Generated with [Claude Code](https://claude.ai/code)