### PR TITLE
fix(pwa): SPA navigation 改用 SWR 將冷啟動感知白屏降為 0

### DIFF
--- a/.changeset/navigation-cache-miss-waituntil.md
+++ b/.changeset/navigation-cache-miss-waituntil.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+補強 bounded SWR 導覽 cache miss 路徑：超時回退到 precache 後仍保活慢網路 HTML fetch，讓 `html-cache` 能在背景完成暖機。

--- a/.changeset/ratewise-sw-navigation-swr.md
+++ b/.changeset/ratewise-sw-navigation-swr.md
@@ -2,4 +2,4 @@
 '@app/ratewise': patch
 ---
 
-冷啟動白屏 P1：SPA navigation 由 NetworkFirst + 3s timeout 改為 StaleWhileRevalidate。已 install 過的 PWA 與已 visited 的瀏覽器 cache hit 立即返回，背景 revalidate 抓最新 HTML，把感知白屏降為 0。版本切換仍由 controllerchange + UpdatePrompt 雙重檢查；handlerDidError fallback 三層保留。
+冷啟動白屏 P1：SPA navigation 改為 bounded SWR-style handler。已暖機 cache hit 立即返回並背景更新，cache miss 最多等待網路 3 秒後回 precache fallback；新版 SW 啟用時清除舊 HTML runtime cache，避免更新後先回舊版 HTML。

--- a/.changeset/ratewise-sw-navigation-swr.md
+++ b/.changeset/ratewise-sw-navigation-swr.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+冷啟動白屏 P1：SPA navigation 由 NetworkFirst + 3s timeout 改為 StaleWhileRevalidate。已 install 過的 PWA 與已 visited 的瀏覽器 cache hit 立即返回，背景 revalidate 抓最新 HTML，把感知白屏降為 0。版本切換仍由 controllerchange + UpdatePrompt 雙重檢查；handlerDidError fallback 三層保留。

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -151,7 +151,7 @@ describe('Service Worker Cache Strategies', () => {
     'static-resources': { strategy: 'CacheFirst', maxAge: 30 * 24 * 60 * 60 },
   };
 
-  it('should use NavigationRoute + StaleWhileRevalidate for zero-white-screen navigation', async () => {
+  it('should use NavigationRoute + bounded SWR-style handler for zero-white-screen navigation', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
@@ -159,12 +159,13 @@ describe('Service Worker Cache Strategies', () => {
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
     // 已 install 過的 PWA 與已 visited 的瀏覽器：cache hit 立即返回，背景 revalidate。
-    // 取代 NetworkFirst + 3s timeout 在慢網路下的感知白屏。
-    expect(sourceCode).toContain('const navigationStrategy = new StaleWhileRevalidate(');
-    expect(sourceCode).toContain('new NavigationRoute(navigationStrategy)');
+    // cache miss 則保留 3 秒 bounded fallback，避免慢網路下白屏。
+    expect(sourceCode).toContain('handleNavigationRequest');
+    expect(sourceCode).toContain('new NavigationRoute(handleNavigationRequest)');
+    expect(sourceCode).toContain('event.waitUntil(');
+    expect(sourceCode).toContain('fetchAndCacheNavigation(request, cache)');
     // 防回歸：禁止重新引入 NetworkFirst navigation（cold-start 白屏根因之一）。
     expect(sourceCode).not.toContain('new NetworkFirst(');
-    expect(sourceCode).not.toContain('networkTimeoutSeconds:');
   });
 
   it('should have correct historical rates cache configuration', () => {
@@ -233,13 +234,29 @@ describe('Service Worker Cache Strategies', () => {
     const swPath = path.resolve(__dirname, '../sw.ts');
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
-    // SWR + handlerDidError → resolveOfflineDocumentFallback helper（含三層 fallback + emergency HTML）。
+    // bounded SWR-style navigation → resolveOfflineDocumentFallback helper（含三層 fallback + emergency HTML）。
     expect(sourceCode).toContain('new NavigationRoute(');
     expect(sourceCode).toContain('resolveOfflineDocumentFallback');
     expect(sourceCode).toContain("emergencyReason: 'emergency-navigation-fallback'");
+    expect(sourceCode).toContain('const NAVIGATION_NETWORK_TIMEOUT_MS = 3000');
+    expect(sourceCode).toContain('Promise.race([networkResponse, timeoutFallback])');
     // 防回歸：navigation 不可重新引入 NetworkFirst（cold-start 白屏根因之一）。
     expect(sourceCode).not.toContain('new NetworkFirst(');
-    expect(sourceCode).not.toContain('networkTimeoutSeconds:');
+  });
+
+  it('should clear stale navigation HTML runtime cache when a new worker activates', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const swPath = path.resolve(__dirname, '../sw.ts');
+    const sourceCode = await fs.readFile(swPath, 'utf-8');
+
+    expect(sourceCode).toContain("const HTML_CACHE_NAME = 'html-cache'");
+    expect(sourceCode).toContain('clearNavigationHtmlCacheOnActivate');
+    expect(sourceCode).toContain('caches.delete(HTML_CACHE_NAME)');
+    expect(sourceCode).toContain(
+      'clearNavigationHtmlCacheOnActivate().then(() => ensureOfflineHtmlCached())',
+    );
   });
 
   it('should delegate NavigationRoute failures to the shared offline document fallback', async () => {

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -151,17 +151,20 @@ describe('Service Worker Cache Strategies', () => {
     'static-resources': { strategy: 'CacheFirst', maxAge: 30 * 24 * 60 * 60 },
   };
 
-  it('should use NavigationRoute + NetworkFirst with timeout for document navigation', async () => {
+  it('should use NavigationRoute + StaleWhileRevalidate for zero-white-screen navigation', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
     const swPath = path.resolve(__dirname, '../sw.ts');
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
-    // PR3: 使用 NetworkFirst + timeout 取代 createHandlerBoundToURL
-    expect(sourceCode).toContain('new NetworkFirst(');
-    expect(sourceCode).toContain('networkTimeoutSeconds:');
-    expect(sourceCode).toContain('new NavigationRoute(');
+    // 已 install 過的 PWA 與已 visited 的瀏覽器：cache hit 立即返回，背景 revalidate。
+    // 取代 NetworkFirst + 3s timeout 在慢網路下的感知白屏。
+    expect(sourceCode).toContain('const navigationStrategy = new StaleWhileRevalidate(');
+    expect(sourceCode).toContain('new NavigationRoute(navigationStrategy)');
+    // 防回歸：禁止重新引入 NetworkFirst navigation（cold-start 白屏根因之一）。
+    expect(sourceCode).not.toContain('new NetworkFirst(');
+    expect(sourceCode).not.toContain('networkTimeoutSeconds:');
   });
 
   it('should have correct historical rates cache configuration', () => {
@@ -223,18 +226,20 @@ describe('Service Worker Cache Strategies', () => {
     expect(sourceCode).not.toContain("cacheName: 'offline-fallback'");
   });
 
-  it('should use NetworkFirst strategy for navigation with timeout fallback', async () => {
+  it('should delegate handlerDidError to the shared offline document fallback helper', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
 
     const swPath = path.resolve(__dirname, '../sw.ts');
     const sourceCode = await fs.readFile(swPath, 'utf-8');
 
-    // PR3: 使用 NetworkFirst + timeout 取代 createHandlerBoundToURL
-    expect(sourceCode).toContain('new NetworkFirst(');
-    expect(sourceCode).toContain('networkTimeoutSeconds:');
+    // SWR + handlerDidError → resolveOfflineDocumentFallback helper（含三層 fallback + emergency HTML）。
     expect(sourceCode).toContain('new NavigationRoute(');
     expect(sourceCode).toContain('resolveOfflineDocumentFallback');
+    expect(sourceCode).toContain("emergencyReason: 'emergency-navigation-fallback'");
+    // 防回歸：navigation 不可重新引入 NetworkFirst（cold-start 白屏根因之一）。
+    expect(sourceCode).not.toContain('new NetworkFirst(');
+    expect(sourceCode).not.toContain('networkTimeoutSeconds:');
   });
 
   it('should delegate NavigationRoute failures to the shared offline document fallback', async () => {

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -164,6 +164,9 @@ describe('Service Worker Cache Strategies', () => {
     expect(sourceCode).toContain('new NavigationRoute(handleNavigationRequest)');
     expect(sourceCode).toContain('event.waitUntil(');
     expect(sourceCode).toContain('fetchAndCacheNavigation(request, cache)');
+    expect(sourceCode).toContain(
+      'event.waitUntil(networkResponse.then(() => undefined).catch(() => undefined))',
+    );
     // 防回歸：禁止重新引入 NetworkFirst navigation（cold-start 白屏根因之一）。
     expect(sourceCode).not.toContain('new NetworkFirst(');
   });

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -106,12 +106,16 @@ describe('PWA 離線功能測試', () => {
       expect(swContent).toContain("destination !== 'document'");
     });
 
-    it('should use NavigationRoute + NetworkFirst with timeout for SPA offline navigation', () => {
+    it('should use NavigationRoute + StaleWhileRevalidate for zero-white-screen navigation', () => {
       const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
-      // PR3: 使用 NetworkFirst + timeout 取代 createHandlerBoundToURL，網路超時自動 fallback 到 precache
-      expect(swContent).toContain('new NetworkFirst(');
-      expect(swContent).toContain('networkTimeoutSeconds:');
-      expect(swContent).toContain('new NavigationRoute(');
+      // 取代 NetworkFirst + 3s timeout：installed PWA 已暖機後 cache hit 立即返回，
+      // 背景 revalidate 抓最新 HTML；版本切換由 controllerchange + UpdatePrompt 處理。
+      expect(swContent).toContain('const navigationStrategy = new StaleWhileRevalidate(');
+      expect(swContent).toContain("cacheName: 'html-cache'");
+      expect(swContent).toContain('new NavigationRoute(navigationStrategy)');
+      // 防回歸：禁止把 NetworkFirst 重新引入 navigation 路徑（cold-start 白屏根因之一）。
+      expect(swContent).not.toContain('new NetworkFirst(');
+      expect(swContent).not.toContain('networkTimeoutSeconds:');
     });
 
     it('should have offline-first strategy in setCatchHandler', () => {

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -106,16 +106,25 @@ describe('PWA 離線功能測試', () => {
       expect(swContent).toContain("destination !== 'document'");
     });
 
-    it('should use NavigationRoute + StaleWhileRevalidate for zero-white-screen navigation', () => {
+    it('should use NavigationRoute + bounded SWR-style handler for zero-white-screen navigation', () => {
       const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
-      // 取代 NetworkFirst + 3s timeout：installed PWA 已暖機後 cache hit 立即返回，
-      // 背景 revalidate 抓最新 HTML；版本切換由 controllerchange + UpdatePrompt 處理。
-      expect(swContent).toContain('const navigationStrategy = new StaleWhileRevalidate(');
-      expect(swContent).toContain("cacheName: 'html-cache'");
-      expect(swContent).toContain('new NavigationRoute(navigationStrategy)');
+      // 取代 NetworkFirst：installed PWA 已暖機後 cache hit 立即返回，背景 revalidate 抓最新 HTML。
+      expect(swContent).toContain('handleNavigationRequest');
+      expect(swContent).toContain('new NavigationRoute(handleNavigationRequest)');
+      expect(swContent).toContain("const HTML_CACHE_NAME = 'html-cache'");
+      expect(swContent).toContain('event.waitUntil(');
+      expect(swContent).toContain('fetchAndCacheNavigation(request, cache)');
       // 防回歸：禁止把 NetworkFirst 重新引入 navigation 路徑（cold-start 白屏根因之一）。
       expect(swContent).not.toContain('new NetworkFirst(');
-      expect(swContent).not.toContain('networkTimeoutSeconds:');
+    });
+
+    it('should clear old navigation HTML cache on activate and keep a bounded cache-miss fallback', () => {
+      const swContent = readFileSync(resolve(ROOT_PATH, 'src/sw.ts'), 'utf-8');
+      expect(swContent).toContain('clearNavigationHtmlCacheOnActivate');
+      expect(swContent).toContain('caches.delete(HTML_CACHE_NAME)');
+      expect(swContent).toContain('const NAVIGATION_NETWORK_TIMEOUT_MS = 3000');
+      expect(swContent).toContain('Promise.race([networkResponse, timeoutFallback])');
+      expect(swContent).toContain('resolveNavigationFallback');
     });
 
     it('should have offline-first strategy in setCatchHandler', () => {

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -114,6 +114,9 @@ describe('PWA 離線功能測試', () => {
       expect(swContent).toContain("const HTML_CACHE_NAME = 'html-cache'");
       expect(swContent).toContain('event.waitUntil(');
       expect(swContent).toContain('fetchAndCacheNavigation(request, cache)');
+      expect(swContent).toContain(
+        'event.waitUntil(networkResponse.then(() => undefined).catch(() => undefined))',
+      );
       // 防回歸：禁止把 NetworkFirst 重新引入 navigation 路徑（cold-start 白屏根因之一）。
       expect(swContent).not.toContain('new NetworkFirst(');
     });

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -5,7 +5,7 @@
 import { clientsClaim } from 'workbox-core';
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from 'workbox-precaching';
 import { NavigationRoute, registerRoute, setCatchHandler } from 'workbox-routing';
-import { CacheFirst, NetworkFirst, NetworkOnly, StaleWhileRevalidate } from 'workbox-strategies';
+import { CacheFirst, NetworkOnly, StaleWhileRevalidate } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { resolveOfflineDocumentFallback } from './utils/pwaOfflineFallback';
@@ -247,26 +247,30 @@ setCatchHandler(async ({ event, request }): Promise<Response> => {
 });
 
 /**
- * SPA 導覽策略（PR3: Navigation Timeout）
+ * SPA 導覽策略：StaleWhileRevalidate（installed PWA 與瀏覽器共用）
  *
  * 業界最佳實踐（web.dev / Workbox docs）：
- * - NetworkFirst + timeout：優先嘗試網路，超時後 fallback 到快取
- * - 3 秒 timeout：平衡使用者體驗與網路等待
- * - handlerDidError：網路完全失敗時回退到 precache index.html
+ * - 已 install 過的 PWA / 已 visited 的瀏覽器：cache hit 立即返回（零白屏冷啟動）
+ * - 背景 revalidate 抓取最新 HTML 寫回 cache，下一次 navigation 自動拿到新版
+ * - 新版本切換由既有 SW controllerchange + reload 機制處理（main.tsx）
+ * - handlerDidError：第一次訪問的離線或 fetch 失敗時，仍走 precache 三層 fallback
  *
- * 解決問題：
- * - iOS Safari 冷啟動離線白屏（precache 未完成時無 fallback）
- * - 慢網路卡住導覽（無限等待網路回應）
+ * 取代 NetworkFirst + 3s timeout 的理由：
+ * - NetworkFirst 在慢網路下要等到 3s timeout 才 fallback → 感知白屏
+ * - SWR 對「已有 cache」的場景立即回應，把感知白屏降為 0
+ * - 對版本撕裂的防護：UpdatePrompt + handleVersionUpdate 雙重檢查
+ *
+ * @see https://developer.chrome.com/docs/workbox/modules/workbox-strategies#stale-while-revalidate
  */
-const navigationStrategy = new NetworkFirst({
+const navigationStrategy = new StaleWhileRevalidate({
   cacheName: 'html-cache',
-  networkTimeoutSeconds: 3,
   plugins: [
     new CacheableResponsePlugin({ statuses: [0, 200] }),
     {
-      // 網路失敗時回退到 precache index.html（離線或 timeout 後快取也沒有）
+      // 第一次訪問且網路失敗時的 fallback chain：precache index → precache offline → any cache offline。
+      // SWR 在 cache miss 時必須等 fetch；fetch 失敗才會進入 handlerDidError。
       handlerDidError: async () => {
-        // 最後防線：搜尋任何快取中的 offline.html；若全數失守，回 inline HTML，
+        // 最後防線：搜尋任何快取中的 offline.html；若全數失守，回 inline emergency HTML，
         // 避免 Workbox 在 plugin 已回傳 Response.error() 後不再進入全域 setCatchHandler。
         return resolveOfflineDocumentFallback({
           emergencyReason: 'emergency-navigation-fallback',

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -313,6 +313,7 @@ async function handleNavigationRequest({
   const networkResponse = fetchAndCacheNavigation(request, cache).catch(() =>
     resolveNavigationFallback(),
   );
+  event.waitUntil(networkResponse.then(() => undefined).catch(() => undefined));
   const timeoutFallback = new Promise<Response>((resolve) => {
     setTimeout(() => {
       resolve(resolveNavigationFallback());

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -27,6 +27,8 @@ self.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
 
 // 保存 manifest 供 VERIFY_AND_REPAIR_PRECACHE 使用。
 const WB_MANIFEST = self.__WB_MANIFEST;
+const HTML_CACHE_NAME = 'html-cache';
+const NAVIGATION_NETWORK_TIMEOUT_MS = 3000;
 
 // 預快取 Vite 產出的靜態資源。
 precacheAndRoute(WB_MANIFEST);
@@ -56,7 +58,7 @@ async function ensureOfflineHtmlCached(): Promise<void> {
 
     const response = await fetch(offlineUrl, { cache: 'no-cache' });
     if (response.ok) {
-      const cache = await caches.open('html-cache');
+      const cache = await caches.open(HTML_CACHE_NAME);
       await cache.put(offlineUrl, response.clone());
       // 同時用相對路徑快取，讓 matchPrecache('offline.html') 也能命中
       await cache.put('offline.html', response);
@@ -117,6 +119,14 @@ async function verifyAndRepairPrecache(): Promise<void> {
 // 清除舊版快取。
 cleanupOutdatedCaches();
 
+async function clearNavigationHtmlCacheOnActivate(): Promise<void> {
+  try {
+    await caches.delete(HTML_CACHE_NAME);
+  } catch {
+    // 快取清理失敗不可阻斷新版 SW 啟用。
+  }
+}
+
 /**
  * Cache Budget Guard（PR3: iOS 50MB cache 限制保護）
  *
@@ -168,9 +178,9 @@ self.addEventListener('install', (event: ExtendableEvent) => {
   event.waitUntil(checkAndCleanupCacheBudget());
 });
 
-// activate 時確保 offline.html 已快取（install 失敗時的補救）
+// activate 時清掉舊 navigation HTML，再確保 offline.html 已快取（install 失敗時的補救）。
 self.addEventListener('activate', (event: ExtendableEvent) => {
-  event.waitUntil(ensureOfflineHtmlCached());
+  event.waitUntil(clearNavigationHtmlCacheOnActivate().then(() => ensureOfflineHtmlCached()));
 });
 
 // prompt 模式：僅在 waiting SW 收到 SKIP_WAITING 訊息後才接管。
@@ -247,42 +257,72 @@ setCatchHandler(async ({ event, request }): Promise<Response> => {
 });
 
 /**
- * SPA 導覽策略：StaleWhileRevalidate（installed PWA 與瀏覽器共用）
+ * SPA 導覽策略：bounded SWR-style navigation（installed PWA 與瀏覽器共用）
  *
  * 業界最佳實踐（web.dev / Workbox docs）：
  * - 已 install 過的 PWA / 已 visited 的瀏覽器：cache hit 立即返回（零白屏冷啟動）
  * - 背景 revalidate 抓取最新 HTML 寫回 cache，下一次 navigation 自動拿到新版
  * - 新版本切換由既有 SW controllerchange + reload 機制處理（main.tsx）
- * - handlerDidError：第一次訪問的離線或 fetch 失敗時，仍走 precache 三層 fallback
+ * - cache miss 導覽：網路最多等待 3s，再回 precache 三層 fallback
  *
  * 取代 NetworkFirst + 3s timeout 的理由：
  * - NetworkFirst 在慢網路下要等到 3s timeout 才 fallback → 感知白屏
- * - SWR 對「已有 cache」的場景立即回應，把感知白屏降為 0
- * - 對版本撕裂的防護：UpdatePrompt + handleVersionUpdate 雙重檢查
+ * - SWR-style cache hit 立即回應，把已暖機場景的感知白屏降為 0
+ * - 對版本撕裂的防護：activate 時清掉舊 HTML runtime cache，避免新 SW 先回舊 HTML
  *
  * @see https://developer.chrome.com/docs/workbox/modules/workbox-strategies#stale-while-revalidate
  */
-const navigationStrategy = new StaleWhileRevalidate({
-  cacheName: 'html-cache',
-  plugins: [
-    new CacheableResponsePlugin({ statuses: [0, 200] }),
-    {
-      // 第一次訪問且網路失敗時的 fallback chain：precache index → precache offline → any cache offline。
-      // SWR 在 cache miss 時必須等 fetch；fetch 失敗才會進入 handlerDidError。
-      handlerDidError: async () => {
-        // 最後防線：搜尋任何快取中的 offline.html；若全數失守，回 inline emergency HTML，
-        // 避免 Workbox 在 plugin 已回傳 Response.error() 後不再進入全域 setCatchHandler。
-        return resolveOfflineDocumentFallback({
-          emergencyReason: 'emergency-navigation-fallback',
-          matchPrecache,
-          matchOfflineHtmlInAnyCache: () => caches.match('offline.html'),
-        });
-      },
-    },
-  ],
-});
+function resolveNavigationFallback(): Promise<Response> {
+  return resolveOfflineDocumentFallback({
+    emergencyReason: 'emergency-navigation-fallback',
+    matchPrecache,
+    matchOfflineHtmlInAnyCache: () => caches.match('offline.html'),
+  });
+}
 
-registerRoute(new NavigationRoute(navigationStrategy));
+async function fetchAndCacheNavigation(request: Request, cache: Cache): Promise<Response> {
+  const response = await fetch(new Request(request, { cache: 'no-cache' }));
+  if (response.status === 0 || response.status === 200) {
+    try {
+      await cache.put(request, response.clone());
+    } catch {
+      // 即使 runtime cache 寫入失敗，仍應回傳最新網路 HTML。
+    }
+  }
+  return response;
+}
+
+async function handleNavigationRequest({
+  event,
+  request,
+}: {
+  event: ExtendableEvent;
+  request: Request;
+}): Promise<Response> {
+  const cache = await caches.open(HTML_CACHE_NAME);
+  const cached = await cache.match(request);
+  if (cached) {
+    event.waitUntil(
+      fetchAndCacheNavigation(request, cache)
+        .then(() => undefined)
+        .catch(() => undefined),
+    );
+    return cached;
+  }
+
+  const networkResponse = fetchAndCacheNavigation(request, cache).catch(() =>
+    resolveNavigationFallback(),
+  );
+  const timeoutFallback = new Promise<Response>((resolve) => {
+    setTimeout(() => {
+      resolve(resolveNavigationFallback());
+    }, NAVIGATION_NETWORK_TIMEOUT_MS);
+  });
+
+  return Promise.race([networkResponse, timeoutFallback]);
+}
+
+registerRoute(new NavigationRoute(handleNavigationRequest));
 
 // 歷史匯率 aggregate（30 天合併 JSON）：StaleWhileRevalidate，每日更新。
 registerRoute(

--- a/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
+++ b/apps/ratewise/tests/e2e/offline-cold-start.spec.ts
@@ -529,6 +529,46 @@ test.describe('飛航模式冷啟動診斷', () => {
     expect(cssCacheCount, '快取中應有 CSS files').toBeGreaterThanOrEqual(1);
   });
 
+  test('SWR navigation：暖機後 html-cache 應命中即時回應（零等待）', async ({ browser }) => {
+    const ctx = await browser.newContext({ serviceWorkers: 'allow' });
+    const page = await ctx.newPage();
+
+    // Phase 1：暖機讓 html-cache 寫入 navigation 響應。
+    await page.goto(BASE, { waitUntil: 'networkidle', timeout: 60_000 });
+    await page.waitForFunction(
+      async () => {
+        const reg = await navigator.serviceWorker?.getRegistration();
+        return reg?.active?.state === 'activated';
+      },
+      undefined,
+      { timeout: 60_000 },
+    );
+    await waitForOfflineReadiness(page, BASE);
+
+    // 觸發一次 navigation 寫入 html-cache（StaleWhileRevalidate 安裝期 cache miss → fetch + put）。
+    await page.goto(BASE, { waitUntil: 'networkidle', timeout: 60_000 });
+
+    // Phase 2：驗證 html-cache 含 navigation 響應。
+    const htmlCacheReport = await page.evaluate(async () => {
+      const cacheNames = await caches.keys();
+      const hasHtmlCache = cacheNames.includes('html-cache');
+      let entries = 0;
+      if (hasHtmlCache) {
+        const cache = await caches.open('html-cache');
+        const keys = await cache.keys();
+        entries = keys.length;
+      }
+      return { hasHtmlCache, entries, cacheNames };
+    });
+
+    expect(htmlCacheReport.hasHtmlCache, 'html-cache 應已建立（SWR 寫回 navigation 響應）').toBe(
+      true,
+    );
+    expect(htmlCacheReport.entries, 'html-cache 應有 navigation 響應條目').toBeGreaterThan(0);
+
+    await ctx.close();
+  });
+
   test('即使 root 提前出現假節點，冷啟動 watchdog 仍應顯示全屏診斷 UI', async ({ browser }) => {
     const context = await browser.newContext({
       serviceWorkers: 'allow',

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -858,8 +858,3 @@
 - ID：ratewise-lhci-homepage-runtime-refresh-guard
 - 原因：PR #350 的 Lighthouse CI 在首頁 `/` 掉到 `0.87~0.88`，根因為 LHCI 離線模式下首頁仍執行 runtime 匯率 refresh，失敗後插入 stale warning 與額外背景工作，拉低首屏效能。
 - 解法：在 `exchangeRateService` 與 `useExchangeRates` 增加 `VITE_LHCI_OFFLINE` 穩定分支，LHCI 直接使用 build-time 匯率並跳過 runtime refresh / polling，另補 service 與 hook 回歸測試鎖住行為。
-
-- 日期：2026-05-07
-- ID：ratewise-sw-navigation-swr
-- 原因：SPA navigation 採 NetworkFirst + 3s timeout，慢網路或離線時最多等 3 秒才 fallback，是冷啟動感知白屏的時序根因之一；installed PWA 與已 visited 瀏覽器都應該優先吃 cache 而非為了新鮮度等網路。
-- 解法：將 navigationStrategy 改為 StaleWhileRevalidate（cache hit 立即返回 + 背景 revalidate），版本切換仍由 controllerchange + UpdatePrompt + handleVersionUpdate 雙重檢查；handlerDidError 的三層 fallback 完整保留，僅在 cache miss + 網路失敗時才會走到。同步更新 sw.test.ts 與 pwa-offline.test.ts 鎖住 SWR 並禁回退 NetworkFirst。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -850,6 +850,6 @@
 - 解法：在 `exchangeRateService` 與 `useExchangeRates` 增加 `VITE_LHCI_OFFLINE` 穩定分支，LHCI 直接使用 build-time 匯率並跳過 runtime refresh / polling，另補 service 與 hook 回歸測試鎖住行為。
 
 - 日期：2026-05-07
-- ID：ratewise-watchdog-preserve-ssg-content
-- 原因：60 天內 PWA 冷啟動白屏修復累積 11+ 次仍復發，根本反模式為 `index.html` watchdog 5 秒 timeout 後執行 `root.innerHTML=''` 直接抹除 vite-react-ssg 預渲染的 144KB 內容，使用者從「可看靜態頁」降級為「白屏 + 錯誤面板」。
-- 解法：watchdog 加 `hasPrerenderedRootContent()` 偵測（`data-server-rendered` 或 `#root.children.length > 0`），有 SSG 內容時改採 floating banner 並附加到 `<body>`，保留 `#root`；無 SSG 時沿用原全屏 fallback。新增 vitest 靜態回歸與 E2E 鎖住雙模式分支；同步關閉 PR #367 emergency HTML（與本修正重複）。
+- ID：ratewise-sw-navigation-swr
+- 原因：SPA navigation 採 NetworkFirst + 3s timeout，慢網路或離線時最多等 3 秒才 fallback，是冷啟動感知白屏的時序根因之一；installed PWA 與已 visited 瀏覽器都應該優先吃 cache 而非為了新鮮度等網路。
+- 解法：將 navigationStrategy 改為 StaleWhileRevalidate（cache hit 立即返回 + 背景 revalidate），版本切換仍由 controllerchange + UpdatePrompt + handleVersionUpdate 雙重檢查；handlerDidError 的三層 fallback 完整保留，僅在 cache miss + 網路失敗時才會走到。同步更新 sw.test.ts 與 pwa-offline.test.ts 鎖住 SWR 並禁回退 NetworkFirst。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr372-cache-miss-navigation-waituntil
+- 原因：Codex review 指出 bounded SWR cache miss 超時回 fallback 後，慢網路 fetch 未掛入 `event.waitUntil`，SW 可能被終止而無法暖起 `html-cache`。
+- 解法：將 cache miss 的 `networkResponse` 同步掛入 `event.waitUntil`，保留 3 秒 fallback 體感，同時確保背景 HTML cache 寫入有生命週期保護。
+
+- 日期：2026-05-07
 - ID：pr372-bounded-swr-navigation-cache-guard
 - 原因：PR #372 初版直接使用 Workbox SWR，cache miss 時缺少有界 fallback，且新版 SW 啟用後可能先回舊 `html-cache` HTML。
 - 解法：改為自訂 bounded SWR-style navigation handler，cache hit 立即回並背景更新、cache miss 3 秒內未取得網路即回 precache fallback，且 activate 時清除舊 HTML runtime cache。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr372-bounded-swr-navigation-cache-guard
+- 原因：PR #372 初版直接使用 Workbox SWR，cache miss 時缺少有界 fallback，且新版 SW 啟用後可能先回舊 `html-cache` HTML。
+- 解法：改為自訂 bounded SWR-style navigation handler，cache hit 立即回並背景更新、cache miss 3 秒內未取得網路即回 precache fallback，且 activate 時清除舊 HTML runtime cache。
+
+- 日期：2026-05-07
 - ID：pr371-watchdog-overlay-dedupe
 - 原因：Codex review 指出 SSG banner 模式下 timeout 與後續 script error 可能連續觸發 `showColdStartError()`，造成多個 cold-start banner 重疊。
 - 解法：在建立新 watchdog overlay 前先呼叫 `removeColdStartOverlay()`，讓 banner/fullscreen fallback 都維持單一可見診斷視窗。


### PR DESCRIPTION
## 摘要

- `sw.ts` SPA `navigationStrategy` 由 `NetworkFirst + 3s timeout` 改為 `StaleWhileRevalidate`
- 已 install 過的 PWA 與已 visited 的瀏覽器：cache hit 立即返回（零白屏冷啟動）
- 背景 revalidate 抓最新 HTML，下次 navigation 自動拿到新版
- handlerDidError 三層 fallback 完整保留（cache miss + 網路失敗才走）

## 背景與根因

冷啟動白屏的時序根因之一：原本 `NetworkFirst` 即使 cache 已有 navigation 響應，仍優先嘗試網路，最多等 `networkTimeoutSeconds: 3` 才 fallback to cache。在慢 3G、隧道、PWA 冷啟動瞬間，使用者最多看 3 秒空白才有畫面。

業界 [web.dev / Workbox docs](https://developer.chrome.com/docs/workbox/modules/workbox-strategies#stale-while-revalidate) 推薦的零白屏策略是 `StaleWhileRevalidate`：
- cache hit 立即返回（零等待）
- 同時背景 fetch 最新版本寫回 cache
- 下次 navigation 自動拿到新版

## 為什麼安全

舊有版本切換機制完整保留：

1. **`controllerchange` + reload**（main.tsx）— 新 SW 取得控制權時自動 reload
2. **UpdatePrompt** — 偵測 `needRefresh` 在線時自動套用更新
3. **handleVersionUpdate** — 啟動時 runtime 版本檢查，差異時清快取

SWR 唯一不同：使用者**第一次** navigation 後會看到較舊 HTML，下一次（或上述 3 個機制觸發 reload）即拿到新版。對於 SPA shell 這完全可接受。

`handlerDidError` 三層 fallback 仍保留：cache miss + 網路失敗時走 `precache index → precache offline → any cache offline`。

## 變更

| 檔案 | 改動 |
|---|---|
| `apps/ratewise/src/sw.ts` | `NetworkFirst → StaleWhileRevalidate`；移除未使用的 `NetworkFirst` import |
| `apps/ratewise/src/__tests__/sw.test.ts` | 鎖定 SWR 並禁回退 NetworkFirst；handlerDidError fallback 三層仍鎖 |
| `apps/ratewise/src/pwa-offline.test.ts` | 同上靜態回歸 |
| `apps/ratewise/tests/e2e/offline-cold-start.spec.ts` | 新增 SWR 行為驗證：暖機後 `html-cache` 應寫入 navigation 響應 |
| `docs/dev/002_development_reward_penalty_log.md` | 新增 `ratewise-sw-navigation-swr` 條目 |
| `.changeset/ratewise-sw-navigation-swr.md` | patch bump |

## 已執行驗證

- `pnpm --filter @app/ratewise typecheck` ✅
- `pnpm --filter @app/ratewise exec vitest run src/__tests__/sw.test.ts src/pwa-offline.test.ts` ✅ 60/60
- `VITE_RATEWISE_BASE_PATH='/' pnpm build:ratewise` ✅
- pre-push: typecheck + 全 repo test + build:ratewise 全綠
- `dist/sw.js` 含 `StaleWhileRevalidate` + `html-cache` 字串

## 相關

- 配套 P0 PR #371（watchdog 保留 SSG 預渲染內容）
- 同屬 60 天 11+ 次 PWA 冷啟動白屏修復系列的根因收斂

🤖 Generated with [Claude Code](https://claude.ai/code)