### PR TITLE
fix(pwa): PWA diagnostic 事件轉發到 Sentry / GA4 從盲修變數據驅動

### DIFF
--- a/.changeset/pwa-diagnostic-ga4-memory-fallback.md
+++ b/.changeset/pwa-diagnostic-ga4-memory-fallback.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Forward queued PWA diagnostic GA4 events when browser storage writes fail.

--- a/.changeset/pwa-diagnostic-ga4-opt-out.md
+++ b/.changeset/pwa-diagnostic-ga4-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Honor PWA diagnostic forwarding opt-out when flushing queued GA4 events.

--- a/.changeset/pwa-diagnostic-ga4-queue.md
+++ b/.changeset/pwa-diagnostic-ga4-queue.md
@@ -2,4 +2,4 @@
 '@app/ratewise': patch
 ---
 
-Queue early PWA diagnostic GA4 events until analytics initialization.
+Persist early PWA diagnostic GA4 events until analytics initialization.

--- a/.changeset/pwa-diagnostic-ga4-queue.md
+++ b/.changeset/pwa-diagnostic-ga4-queue.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Queue early PWA diagnostic GA4 events until analytics initialization.

--- a/.changeset/pwa-diagnostic-sentry-init-cache.md
+++ b/.changeset/pwa-diagnostic-sentry-init-cache.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Initialize Sentry only once while forwarding PWA diagnostic events.

--- a/.changeset/pwa-diagnostics-sanitized-forwarding.md
+++ b/.changeset/pwa-diagnostics-sanitized-forwarding.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+收斂 PWA diagnostic 事件轉發：GA4 僅接收去識別化分類欄位，Sentry 轉發前會先完成 lazy initialization。

--- a/.changeset/ratewise-pwa-diagnostics-sentry-ping.md
+++ b/.changeset/ratewise-pwa-diagnostics-sentry-ping.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+冷啟動白屏 P1：`recordPwaDiagnostic` warn/error 事件 fire-and-forget 轉發到 Sentry（error→`captureMessage`、warn→`addBreadcrumb`）與 GA4（`pwa_diagnostic` event），加 5 秒 dedup 與環境變數開關（`VITE_PWA_DIAGNOSTIC_FORWARDING`）；info 不轉發以保護 quota。把冷啟動觀察性從盲修改為數據驅動。

--- a/.changeset/sentry-diagnostic-redaction.md
+++ b/.changeset/sentry-diagnostic-redaction.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Redact raw PWA diagnostic detail from Sentry forwarding metadata.

--- a/apps/ratewise/src/main.tsx
+++ b/apps/ratewise/src/main.tsx
@@ -24,7 +24,11 @@ import { handleVersionUpdate } from './utils/versionManager';
 import { APP_VERSION, BUILD_TIME } from './config/version';
 import { isChunkLoadError, recoverFromChunkLoadError } from './utils/chunkLoadRecovery';
 import { initPWAStorageManager, primePwaColdStartRecovery } from './utils/pwaStorageManager';
-import { clearPwaAppReadyMarker, recordPwaDiagnostic } from './utils/pwaDiagnostics';
+import {
+  clearPwaAppReadyMarker,
+  flushPwaDiagnosticAnalyticsQueue,
+  recordPwaDiagnostic,
+} from './utils/pwaDiagnostics';
 import { initGA, scheduleAfterPageLoad, trackPageview, trackAiReferral } from '@shared/analytics';
 import {
   ANALYTICS_IDLE_TIMEOUT_MS,
@@ -127,6 +131,7 @@ export const createRoot = ViteReactSSG(
       const gaId = import.meta.env.VITE_GA_ID ?? '';
       const initAnalytics = (): void => {
         initGA(gaId);
+        flushPwaDiagnosticAnalyticsQueue();
         // AI referral 先於首次 page_view：trackAiReferral 會 `gtag('set', 'user_properties', { ai_source })`，
         // 必須在 page_view 之前執行，首個 page_view 才能帶上 ai_source 供 GA4 歸因首次造訪。
         trackAiReferral();

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../pwaDiagnostics';
 
 vi.mock('../sentry', () => ({
+  initSentry: vi.fn().mockResolvedValue(undefined),
   captureMessage: vi.fn().mockResolvedValue(undefined),
   addBreadcrumb: vi.fn().mockResolvedValue(undefined),
 }));
@@ -75,6 +76,7 @@ describe('pwaDiagnostics', () => {
       recordPwaDiagnostic('cold-start-overlay-shown', { timeoutMs: 5000 }, 'error');
       await flushPwaDiagnosticForwarding();
 
+      expect(sentry.initSentry).toHaveBeenCalledTimes(1);
       expect(sentry.captureMessage).toHaveBeenCalledWith(
         'PWA diagnostic: cold-start-overlay-shown',
         expect.objectContaining({
@@ -89,6 +91,7 @@ describe('pwaDiagnostics', () => {
       recordPwaDiagnostic('pwa-storage-near-limit', { usageMb: 45 }, 'warn');
       await flushPwaDiagnosticForwarding();
 
+      expect(sentry.initSentry).toHaveBeenCalledTimes(1);
       expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
         'pwa:pwa-storage-near-limit',
         expect.objectContaining({ level: 'warn' }),
@@ -116,11 +119,15 @@ describe('pwaDiagnostics', () => {
       expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('should send GA4 pwa_diagnostic event when gtag is available', () => {
+    it('should send GA4 pwa_diagnostic event without raw diagnostic detail', () => {
       const gtag = vi.fn();
       (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
 
-      recordPwaDiagnostic('cold-start-script-error', '/assets/main.js', 'error');
+      recordPwaDiagnostic(
+        'cold-start-script-error',
+        'https://app.haotool.org/ratewise/assets/main.js?email=user@example.com',
+        'error',
+      );
 
       expect(gtag).toHaveBeenCalledWith(
         'event',
@@ -128,8 +135,14 @@ describe('pwaDiagnostics', () => {
         expect.objectContaining({
           diagnostic_phase: 'cold-start-script-error',
           diagnostic_level: 'error',
+          diagnostic_detail_present: true,
+          diagnostic_detail_category: 'asset-load',
+          diagnostic_detail_length: 'medium',
         }),
       );
+      const gaParams = gtag.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(gaParams).not.toHaveProperty('diagnostic_detail');
+      expect(JSON.stringify(gaParams)).not.toContain('user@example.com');
     });
 
     it('should not throw when gtag is unavailable', () => {

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  __resetPwaDiagnosticForwardingDedup,
   clearPwaAppReadyMarker,
+  flushPwaDiagnosticForwarding,
   markPwaAppReady,
   PWA_APP_READY_ATTR,
   PWA_APP_READY_EVENT,
@@ -11,11 +13,22 @@ import {
   recordPwaDiagnostic,
 } from '../pwaDiagnostics';
 
+vi.mock('../sentry', () => ({
+  captureMessage: vi.fn().mockResolvedValue(undefined),
+  addBreadcrumb: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('pwaDiagnostics', () => {
   beforeEach(() => {
     localStorage.clear();
     clearPwaAppReadyMarker();
     window.__RATEWISE_PWA_DIAGNOSTICS__ = [];
+    __resetPwaDiagnosticForwardingDedup();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { gtag?: unknown }).gtag;
   });
 
   it('should persist diagnostic events to localStorage', () => {
@@ -54,5 +67,74 @@ describe('pwaDiagnostics', () => {
     if (originalDescriptor) {
       Object.defineProperty(window, 'localStorage', originalDescriptor);
     }
+  });
+
+  describe('observability forwarding', () => {
+    it('should forward error-level events to Sentry captureMessage', async () => {
+      const sentry = await import('../sentry');
+      recordPwaDiagnostic('cold-start-overlay-shown', { timeoutMs: 5000 }, 'error');
+      await flushPwaDiagnosticForwarding();
+
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        'PWA diagnostic: cold-start-overlay-shown',
+        expect.objectContaining({
+          level: 'error',
+          tags: { pwa_diagnostic_phase: 'cold-start-overlay-shown' },
+        }),
+      );
+    });
+
+    it('should forward warn-level events to Sentry addBreadcrumb (not captureMessage)', async () => {
+      const sentry = await import('../sentry');
+      recordPwaDiagnostic('pwa-storage-near-limit', { usageMb: 45 }, 'warn');
+      await flushPwaDiagnosticForwarding();
+
+      expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+        'pwa:pwa-storage-near-limit',
+        expect.objectContaining({ level: 'warn' }),
+      );
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('should NOT forward info-level events (avoid Sentry quota burn)', async () => {
+      const sentry = await import('../sentry');
+      recordPwaDiagnostic('bootstrap-start', { version: '2.22.20' }, 'info');
+      await flushPwaDiagnosticForwarding();
+
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+      expect(sentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it('should dedup the same phase within 5 seconds', async () => {
+      const sentry = await import('../sentry');
+      recordPwaDiagnostic('chunk-load-error', 'first', 'error');
+      recordPwaDiagnostic('chunk-load-error', 'second', 'error');
+      recordPwaDiagnostic('chunk-load-error', 'third', 'error');
+      await flushPwaDiagnosticForwarding();
+
+      // Only the first should reach Sentry; subsequent calls are dedup'd.
+      expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send GA4 pwa_diagnostic event when gtag is available', () => {
+      const gtag = vi.fn();
+      (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
+
+      recordPwaDiagnostic('cold-start-script-error', '/assets/main.js', 'error');
+
+      expect(gtag).toHaveBeenCalledWith(
+        'event',
+        'pwa_diagnostic',
+        expect.objectContaining({
+          diagnostic_phase: 'cold-start-script-error',
+          diagnostic_level: 'error',
+        }),
+      );
+    });
+
+    it('should not throw when gtag is unavailable', () => {
+      delete (window as unknown as { gtag?: unknown }).gtag;
+      expect(() => recordPwaDiagnostic('chunk-load-error', 'x', 'error')).not.toThrow();
+    });
   });
 });

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetPwaDiagnosticForwardingDedup,
   clearPwaAppReadyMarker,
+  flushPwaDiagnosticAnalyticsQueue,
   flushPwaDiagnosticForwarding,
   markPwaAppReady,
   PWA_APP_READY_ATTR,
@@ -176,6 +177,36 @@ describe('pwaDiagnostics', () => {
     it('should not throw when gtag is unavailable', () => {
       delete (window as unknown as { gtag?: unknown }).gtag;
       expect(() => recordPwaDiagnostic('chunk-load-error', 'x', 'error')).not.toThrow();
+    });
+
+    it('should queue GA4 diagnostics until gtag is initialized', () => {
+      delete (window as unknown as { gtag?: unknown }).gtag;
+
+      recordPwaDiagnostic(
+        'cold-start-watchdog-timeout',
+        'user@example.com network timeout',
+        'warn',
+      );
+
+      const gtag = vi.fn();
+      (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
+      flushPwaDiagnosticAnalyticsQueue();
+
+      expect(gtag).toHaveBeenCalledTimes(1);
+      expect(gtag).toHaveBeenCalledWith(
+        'event',
+        'pwa_diagnostic',
+        expect.objectContaining({
+          diagnostic_phase: 'cold-start-watchdog-timeout',
+          diagnostic_level: 'warn',
+          diagnostic_detail_present: true,
+          diagnostic_detail_category: 'network',
+          diagnostic_detail_length: 'short',
+        }),
+      );
+      const gaParams = gtag.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(gaParams).not.toHaveProperty('diagnostic_detail');
+      expect(JSON.stringify(gaParams)).not.toContain('user@example.com');
     });
   });
 });

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -32,6 +32,7 @@ describe('pwaDiagnostics', () => {
 
   afterEach(() => {
     delete (window as unknown as { gtag?: unknown }).gtag;
+    vi.unstubAllEnvs();
   });
 
   it('should persist diagnostic events to localStorage', () => {
@@ -268,6 +269,23 @@ describe('pwaDiagnostics', () => {
       } finally {
         setItemSpy.mockRestore();
       }
+    });
+
+    it('should clear queued GA4 diagnostics when forwarding is disabled', () => {
+      delete (window as unknown as { gtag?: unknown }).gtag;
+
+      recordPwaDiagnostic('chunk-load-error', '/assets/main.js', 'error');
+      expect(localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY)).toContain(
+        'chunk-load-error',
+      );
+
+      vi.stubEnv('VITE_PWA_DIAGNOSTIC_FORWARDING', 'false');
+      const gtag = vi.fn();
+      (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
+      flushPwaDiagnosticAnalyticsQueue();
+
+      expect(gtag).not.toHaveBeenCalled();
+      expect(localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -9,6 +9,7 @@ import {
   markPwaAppReady,
   PWA_APP_READY_ATTR,
   PWA_APP_READY_EVENT,
+  PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY,
   PWA_DIAGNOSTICS_STORAGE_KEY,
   readPwaDiagnostics,
   recordPwaDiagnostic,
@@ -207,6 +208,31 @@ describe('pwaDiagnostics', () => {
       const gaParams = gtag.mock.calls[0]?.[2] as Record<string, unknown>;
       expect(gaParams).not.toHaveProperty('diagnostic_detail');
       expect(JSON.stringify(gaParams)).not.toContain('user@example.com');
+    });
+
+    it('should persist queued GA4 diagnostics across recovery reloads', () => {
+      delete (window as unknown as { gtag?: unknown }).gtag;
+
+      recordPwaDiagnostic('chunk-load-error', 'user@example.com /assets/main.js', 'error');
+
+      const persistedQueue = localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY);
+      expect(persistedQueue).toContain('chunk-load-error');
+      expect(persistedQueue).not.toContain('user@example.com');
+
+      const gtag = vi.fn();
+      (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
+      flushPwaDiagnosticAnalyticsQueue();
+
+      expect(gtag).toHaveBeenCalledWith(
+        'event',
+        'pwa_diagnostic',
+        expect.objectContaining({
+          diagnostic_phase: 'chunk-load-error',
+          diagnostic_level: 'error',
+          diagnostic_detail_category: 'asset-load',
+        }),
+      );
+      expect(localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -71,9 +71,13 @@ describe('pwaDiagnostics', () => {
   });
 
   describe('observability forwarding', () => {
-    it('should forward error-level events to Sentry captureMessage', async () => {
+    it('should forward error-level events to Sentry captureMessage without raw detail', async () => {
       const sentry = await import('../sentry');
-      recordPwaDiagnostic('cold-start-overlay-shown', { timeoutMs: 5000 }, 'error');
+      recordPwaDiagnostic(
+        'cold-start-overlay-shown',
+        'https://app.haotool.org/ratewise/assets/main.js?email=user@example.com',
+        'error',
+      );
       await flushPwaDiagnosticForwarding();
 
       expect(sentry.initSentry).toHaveBeenCalledTimes(1);
@@ -84,18 +88,42 @@ describe('pwaDiagnostics', () => {
           tags: { pwa_diagnostic_phase: 'cold-start-overlay-shown' },
         }),
       );
+      const captureCall = vi.mocked(sentry.captureMessage).mock.calls.at(0);
+      if (!captureCall) throw new Error('captureMessage should be called');
+      const sentryOptions = captureCall[1] as {
+        extra?: Record<string, unknown>;
+      };
+      expect(sentryOptions.extra).toEqual(
+        expect.objectContaining({
+          detailPresent: true,
+          detailCategory: 'asset-load',
+          detailLength: 'medium',
+        }),
+      );
+      expect(sentryOptions.extra).not.toHaveProperty('detail');
+      expect(JSON.stringify(sentryOptions.extra)).not.toContain('user@example.com');
     });
 
-    it('should forward warn-level events to Sentry addBreadcrumb (not captureMessage)', async () => {
+    it('should forward warn-level events to Sentry addBreadcrumb without raw detail', async () => {
       const sentry = await import('../sentry');
-      recordPwaDiagnostic('pwa-storage-near-limit', { usageMb: 45 }, 'warn');
+      recordPwaDiagnostic('pwa-storage-near-limit', 'storage quota for user@example.com', 'warn');
       await flushPwaDiagnosticForwarding();
 
       expect(sentry.initSentry).toHaveBeenCalledTimes(1);
       expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
         'pwa:pwa-storage-near-limit',
-        expect.objectContaining({ level: 'warn' }),
+        expect.objectContaining({
+          level: 'warn',
+          detailPresent: true,
+          detailCategory: 'storage',
+          detailLength: 'short',
+        }),
       );
+      const breadcrumbCall = vi.mocked(sentry.addBreadcrumb).mock.calls.at(0);
+      if (!breadcrumbCall) throw new Error('addBreadcrumb should be called');
+      const breadcrumbData = breadcrumbCall[1]!;
+      expect(breadcrumbData).not.toHaveProperty('detail');
+      expect(JSON.stringify(breadcrumbData)).not.toContain('user@example.com');
       expect(sentry.captureMessage).not.toHaveBeenCalled();
     });
 

--- a/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts
@@ -234,5 +234,40 @@ describe('pwaDiagnostics', () => {
       );
       expect(localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY)).toBeNull();
     });
+
+    it('should flush in-memory GA4 fallback when storage writes fail', () => {
+      delete (window as unknown as { gtag?: unknown }).gtag;
+
+      const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function setItem(
+        key: string,
+        value: string,
+      ) {
+        if (key === PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY) {
+          throw new DOMException('Quota exceeded', 'QuotaExceededError');
+        }
+        return originalSetItem(key, value);
+      });
+
+      try {
+        recordPwaDiagnostic('pwa-storage-near-limit', 'storage quota warning', 'warn');
+
+        const gtag = vi.fn();
+        (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag = gtag;
+        flushPwaDiagnosticAnalyticsQueue();
+
+        expect(gtag).toHaveBeenCalledWith(
+          'event',
+          'pwa_diagnostic',
+          expect.objectContaining({
+            diagnostic_phase: 'pwa-storage-near-limit',
+            diagnostic_level: 'warn',
+            diagnostic_detail_category: 'storage',
+          }),
+        );
+      } finally {
+        setItemSpy.mockRestore();
+      }
+    });
   });
 });

--- a/apps/ratewise/src/utils/__tests__/sentry.test.ts
+++ b/apps/ratewise/src/utils/__tests__/sentry.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sentryMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  browserTracingIntegration: vi.fn(() => ({ name: 'browserTracing' })),
+  replayIntegration: vi.fn(() => ({ name: 'replay' })),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@sentry/react', () => sentryMock);
+vi.mock('../logger', () => ({
+  logger: loggerMock,
+}));
+
+describe('sentry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://public@example.com/1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should initialize Sentry only once across repeated calls', async () => {
+    const { initSentry } = await import('../sentry');
+
+    await initSentry();
+    await initSentry();
+    await Promise.all([initSentry(), initSentry()]);
+
+    expect(sentryMock.init).toHaveBeenCalledTimes(1);
+    expect(loggerMock.info).toHaveBeenCalledTimes(1);
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      'Sentry initialized',
+      expect.objectContaining({
+        environment: 'production',
+        tracesSampleRate: 0.1,
+      }),
+    );
+  });
+
+  it('should log missing DSN only once', async () => {
+    vi.stubEnv('VITE_SENTRY_DSN', '');
+    const { initSentry } = await import('../sentry');
+
+    await initSentry();
+    await initSentry();
+
+    expect(sentryMock.init).not.toHaveBeenCalled();
+    expect(loggerMock.info).toHaveBeenCalledTimes(1);
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      'Sentry: No DSN configured, skipping initialization',
+    );
+  });
+});

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -6,7 +6,19 @@ const MAX_PWA_DIAGNOSTIC_EVENTS = 40;
 
 // 5 秒內同一 phase 不重複轉發，避免 watchdog / chunk-error 連發爆 Sentry / GA4 quota。
 const FORWARD_DEDUP_WINDOW_MS = 5000;
+const MAX_PENDING_GA4_DIAGNOSTICS = 20;
 const recentlyForwardedPhases = new Map<string, number>();
+const pendingGa4Diagnostics: GaPwaDiagnosticParams[] = [];
+
+type GtagFunction = (...args: unknown[]) => void;
+
+interface GaPwaDiagnosticParams {
+  diagnostic_phase: string;
+  diagnostic_level: PwaDiagnosticEvent['level'];
+  diagnostic_detail_present: boolean;
+  diagnostic_detail_category?: string;
+  diagnostic_detail_length?: string;
+}
 
 export interface PwaDiagnosticEvent {
   phase: string;
@@ -80,21 +92,63 @@ function buildForwardingMetadata(entry: PwaDiagnosticEvent): Record<string, unkn
   };
 }
 
+function buildGaPwaDiagnosticParams(entry: PwaDiagnosticEvent): GaPwaDiagnosticParams {
+  return {
+    diagnostic_phase: entry.phase,
+    diagnostic_level: entry.level,
+    diagnostic_detail_present: Boolean(entry.detail),
+    diagnostic_detail_category: classifyDiagnosticDetail(entry.detail),
+    diagnostic_detail_length: bucketDiagnosticDetailLength(entry.detail),
+  };
+}
+
+function getGtag(): GtagFunction | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const gtag = (window as Window & { gtag?: GtagFunction }).gtag;
+  return typeof gtag === 'function' ? gtag : undefined;
+}
+
+function enqueueGaPwaDiagnostic(params: GaPwaDiagnosticParams): void {
+  pendingGa4Diagnostics.push(params);
+  if (pendingGa4Diagnostics.length > MAX_PENDING_GA4_DIAGNOSTICS) {
+    pendingGa4Diagnostics.shift();
+  }
+}
+
+function sendGaPwaDiagnostic(gtag: GtagFunction, params: GaPwaDiagnosticParams): void {
+  gtag('event', 'pwa_diagnostic', params);
+}
+
 function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
-  if (typeof window === 'undefined') return;
-  // gtag 由 @shared/analytics 在 client-only initGA() 後注入；SSG 時或 GA 未 init 時皆無 function。
-  const gtag = (window as Window & { gtag?: (...args: unknown[]) => void }).gtag;
-  if (typeof gtag !== 'function') return;
+  const params = buildGaPwaDiagnosticParams(entry);
+  const gtag = getGtag();
+  // gtag 由 @shared/analytics 在 client-only initGA() 後注入；冷啟動早期事件先排隊避免漏記。
+  if (!gtag) {
+    enqueueGaPwaDiagnostic(params);
+    return;
+  }
+
   try {
-    gtag('event', 'pwa_diagnostic', {
-      diagnostic_phase: entry.phase,
-      diagnostic_level: entry.level,
-      diagnostic_detail_present: Boolean(entry.detail),
-      diagnostic_detail_category: classifyDiagnosticDetail(entry.detail),
-      diagnostic_detail_length: bucketDiagnosticDetailLength(entry.detail),
-    });
+    sendGaPwaDiagnostic(gtag, params);
   } catch {
     // GA4 unavailable — diagnostics 仍保留在 localStorage。
+  }
+}
+
+export function flushPwaDiagnosticAnalyticsQueue(): void {
+  const gtag = getGtag();
+  if (!gtag) return;
+
+  while (pendingGa4Diagnostics.length > 0) {
+    const params = pendingGa4Diagnostics.shift();
+    if (!params) continue;
+
+    try {
+      sendGaPwaDiagnostic(gtag, params);
+    } catch {
+      // GA4 unavailable — diagnostics 仍保留在 localStorage。
+    }
   }
 }
 
@@ -148,6 +202,7 @@ export async function flushPwaDiagnosticForwarding(): Promise<void> {
 // 暴露給測試環境驗證 dedup 行為，正式程式碼不應依賴。
 export function __resetPwaDiagnosticForwardingDedup(): void {
   recentlyForwardedPhases.clear();
+  pendingGa4Diagnostics.length = 0;
 }
 
 function canUseBrowserStorage(): boolean {

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -4,6 +4,11 @@ const PWA_APP_READY_EVENT = 'ratewise:pwa-app-ready';
 const PWA_APP_READY_ATTR = 'data-ratewise-app-ready';
 const MAX_PWA_DIAGNOSTIC_EVENTS = 40;
 
+// 5 秒內同一 phase 不重複轉發，避免 watchdog / chunk-error 連發爆 Sentry / GA4 quota。
+const FORWARD_DEDUP_WINDOW_MS = 5000;
+const FORWARD_DETAIL_MAX_LEN = 200;
+const recentlyForwardedPhases = new Map<string, number>();
+
 export interface PwaDiagnosticEvent {
   phase: string;
   level: 'info' | 'warn' | 'error';
@@ -15,6 +20,97 @@ declare global {
   interface Window {
     __RATEWISE_PWA_DIAGNOSTICS__?: PwaDiagnosticEvent[];
   }
+}
+
+function isForwardingEnabled(): boolean {
+  // 預設啟用；可由環境變數設 'false' 完全關閉（避免測試或敏感環境送外部訊號）。
+  const flag: unknown = import.meta.env['VITE_PWA_DIAGNOSTIC_FORWARDING'];
+  return flag !== 'false' && flag !== false;
+}
+
+function shouldForwardPhase(phase: string, level: PwaDiagnosticEvent['level']): boolean {
+  // info-level 量大且通常不需告警，僅在內部 localStorage 留存即可。
+  if (level === 'info') return false;
+
+  const now = Date.now();
+  const last = recentlyForwardedPhases.get(phase);
+  if (last && now - last < FORWARD_DEDUP_WINDOW_MS) return false;
+
+  recentlyForwardedPhases.set(phase, now);
+  if (recentlyForwardedPhases.size > 50) {
+    const cutoff = now - FORWARD_DEDUP_WINDOW_MS * 4;
+    for (const [key, ts] of recentlyForwardedPhases) {
+      if (ts < cutoff) recentlyForwardedPhases.delete(key);
+    }
+  }
+  return true;
+}
+
+function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
+  if (typeof window === 'undefined') return;
+  // gtag 由 @shared/analytics 在 client-only initGA() 後注入；SSG 時或 GA 未 init 時皆無 function。
+  const gtag = (window as Window & { gtag?: (...args: unknown[]) => void }).gtag;
+  if (typeof gtag !== 'function') return;
+  try {
+    gtag('event', 'pwa_diagnostic', {
+      diagnostic_phase: entry.phase,
+      diagnostic_level: entry.level,
+      diagnostic_detail: entry.detail?.slice(0, FORWARD_DETAIL_MAX_LEN),
+    });
+  } catch {
+    // GA4 unavailable — diagnostics 仍保留在 localStorage。
+  }
+}
+
+// 追蹤 pending forwards，僅供測試 `flushPwaDiagnosticForwarding` 使用；
+// 正式 runtime 不影響行為（fire-and-forget 語意維持）。
+const pendingForwards = new Set<Promise<void>>();
+
+async function forwardPwaDiagnostic(entry: PwaDiagnosticEvent): Promise<void> {
+  if (!isForwardingEnabled()) return;
+  if (!shouldForwardPhase(entry.phase, entry.level)) return;
+
+  trackGaPwaDiagnostic(entry);
+
+  try {
+    if (entry.level === 'error') {
+      const { captureMessage } = await import('./sentry');
+      await captureMessage(`PWA diagnostic: ${entry.phase}`, {
+        level: 'error',
+        tags: { pwa_diagnostic_phase: entry.phase },
+        extra: {
+          detail: entry.detail,
+          timestamp: entry.timestamp,
+        },
+      });
+    } else if (entry.level === 'warn') {
+      const { addBreadcrumb } = await import('./sentry');
+      await addBreadcrumb(`pwa:${entry.phase}`, {
+        detail: entry.detail,
+        timestamp: entry.timestamp,
+        level: entry.level,
+      });
+    }
+  } catch {
+    // Sentry / dynamic import 失敗時靜默忽略 — diagnostic 仍在 localStorage。
+  }
+}
+
+function trackPendingForward(promise: Promise<void>): void {
+  pendingForwards.add(promise);
+  void promise.finally(() => pendingForwards.delete(promise));
+}
+
+// 暴露給測試：等待所有 pending forwards 完成（含 dynamic import 解析）。
+export async function flushPwaDiagnosticForwarding(): Promise<void> {
+  while (pendingForwards.size > 0) {
+    await Promise.allSettled([...pendingForwards]);
+  }
+}
+
+// 暴露給測試環境驗證 dedup 行為，正式程式碼不應依賴。
+export function __resetPwaDiagnosticForwardingDedup(): void {
+  recentlyForwardedPhases.clear();
 }
 
 function canUseBrowserStorage(): boolean {
@@ -112,6 +208,10 @@ export function recordPwaDiagnostic(
   } catch {
     // Ignore CustomEvent issues in older environments.
   }
+
+  // 觀察性：fire-and-forget 把 warn/error 事件送到 Sentry / GA4，
+  // 從盲修轉為數據驅動。info-level 與 dedup 內事件不會送出。
+  trackPendingForward(forwardPwaDiagnostic(entry));
 
   return entry;
 }

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -71,6 +71,15 @@ function bucketDiagnosticDetailLength(detail: string | undefined): string | unde
   return 'long';
 }
 
+function buildForwardingMetadata(entry: PwaDiagnosticEvent): Record<string, unknown> {
+  return {
+    timestamp: entry.timestamp,
+    detailPresent: Boolean(entry.detail),
+    detailCategory: classifyDiagnosticDetail(entry.detail),
+    detailLength: bucketDiagnosticDetailLength(entry.detail),
+  };
+}
+
 function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
   if (typeof window === 'undefined') return;
   // gtag 由 @shared/analytics 在 client-only initGA() 後注入；SSG 時或 GA 未 init 時皆無 function。
@@ -98,6 +107,7 @@ async function forwardPwaDiagnostic(entry: PwaDiagnosticEvent): Promise<void> {
   if (!shouldForwardPhase(entry.phase, entry.level)) return;
 
   trackGaPwaDiagnostic(entry);
+  const forwardingMetadata = buildForwardingMetadata(entry);
 
   try {
     if (entry.level === 'error') {
@@ -107,17 +117,15 @@ async function forwardPwaDiagnostic(entry: PwaDiagnosticEvent): Promise<void> {
         level: 'error',
         tags: { pwa_diagnostic_phase: entry.phase },
         extra: {
-          detail: entry.detail,
-          timestamp: entry.timestamp,
+          ...forwardingMetadata,
         },
       });
     } else if (entry.level === 'warn') {
       const { initSentry, addBreadcrumb } = await import('./sentry');
       await initSentry();
       await addBreadcrumb(`pwa:${entry.phase}`, {
-        detail: entry.detail,
-        timestamp: entry.timestamp,
         level: entry.level,
+        ...forwardingMetadata,
       });
     }
   } catch {

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -1,4 +1,5 @@
 const PWA_DIAGNOSTICS_STORAGE_KEY = 'ratewise_pwa_diagnostics_v1';
+const PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY = 'ratewise_pwa_diagnostics_ga_queue_v1';
 const PWA_DIAGNOSTIC_EVENT = 'ratewise:pwa-diagnostic';
 const PWA_APP_READY_EVENT = 'ratewise:pwa-app-ready';
 const PWA_APP_READY_ATTR = 'data-ratewise-app-ready';
@@ -109,7 +110,57 @@ function getGtag(): GtagFunction | undefined {
   return typeof gtag === 'function' ? gtag : undefined;
 }
 
+function normalizeGaPwaDiagnosticParams(input: unknown): GaPwaDiagnosticParams[] {
+  if (!Array.isArray(input)) return [];
+
+  return input.filter((entry): entry is GaPwaDiagnosticParams => {
+    if (entry == null || typeof entry !== 'object') return false;
+    const value = entry as Record<string, unknown>;
+    return (
+      typeof value['diagnostic_phase'] === 'string' &&
+      (value['diagnostic_level'] === 'warn' || value['diagnostic_level'] === 'error') &&
+      typeof value['diagnostic_detail_present'] === 'boolean'
+    );
+  });
+}
+
+function readStoredGaPwaDiagnostics(): GaPwaDiagnosticParams[] {
+  if (!canUseBrowserStorage()) return [];
+
+  try {
+    const raw = window.localStorage.getItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY);
+    if (!raw) return [];
+    return normalizeGaPwaDiagnosticParams(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+function writeStoredGaPwaDiagnostics(queue: GaPwaDiagnosticParams[]): boolean {
+  if (!canUseBrowserStorage()) return false;
+
+  try {
+    if (queue.length === 0) {
+      window.localStorage.removeItem(PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY);
+      return true;
+    }
+
+    window.localStorage.setItem(
+      PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY,
+      JSON.stringify(queue.slice(-MAX_PENDING_GA4_DIAGNOSTICS)),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function enqueueGaPwaDiagnostic(params: GaPwaDiagnosticParams): void {
+  if (canUseBrowserStorage()) {
+    const stored = writeStoredGaPwaDiagnostics([...readStoredGaPwaDiagnostics(), params]);
+    if (stored) return;
+  }
+
   pendingGa4Diagnostics.push(params);
   if (pendingGa4Diagnostics.length > MAX_PENDING_GA4_DIAGNOSTICS) {
     pendingGa4Diagnostics.shift();
@@ -140,8 +191,15 @@ export function flushPwaDiagnosticAnalyticsQueue(): void {
   const gtag = getGtag();
   if (!gtag) return;
 
-  while (pendingGa4Diagnostics.length > 0) {
-    const params = pendingGa4Diagnostics.shift();
+  const queuedDiagnostics = canUseBrowserStorage()
+    ? readStoredGaPwaDiagnostics()
+    : pendingGa4Diagnostics.splice(0);
+
+  if (canUseBrowserStorage()) {
+    writeStoredGaPwaDiagnostics([]);
+  }
+
+  for (const params of queuedDiagnostics) {
     if (!params) continue;
 
     try {
@@ -203,6 +261,7 @@ export async function flushPwaDiagnosticForwarding(): Promise<void> {
 export function __resetPwaDiagnosticForwardingDedup(): void {
   recentlyForwardedPhases.clear();
   pendingGa4Diagnostics.length = 0;
+  writeStoredGaPwaDiagnostics([]);
 }
 
 function canUseBrowserStorage(): boolean {
@@ -335,6 +394,7 @@ export {
   MAX_PWA_DIAGNOSTIC_EVENTS,
   PWA_APP_READY_ATTR,
   PWA_APP_READY_EVENT,
+  PWA_DIAGNOSTICS_GA_QUEUE_STORAGE_KEY,
   PWA_DIAGNOSTICS_STORAGE_KEY,
   PWA_DIAGNOSTIC_EVENT,
 };

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -6,7 +6,6 @@ const MAX_PWA_DIAGNOSTIC_EVENTS = 40;
 
 // 5 秒內同一 phase 不重複轉發，避免 watchdog / chunk-error 連發爆 Sentry / GA4 quota。
 const FORWARD_DEDUP_WINDOW_MS = 5000;
-const FORWARD_DETAIL_MAX_LEN = 200;
 const recentlyForwardedPhases = new Map<string, number>();
 
 export interface PwaDiagnosticEvent {
@@ -46,6 +45,32 @@ function shouldForwardPhase(phase: string, level: PwaDiagnosticEvent['level']): 
   return true;
 }
 
+function classifyDiagnosticDetail(detail: string | undefined): string | undefined {
+  if (!detail) return undefined;
+
+  const value = detail.toLowerCase();
+  if (value.includes('/assets/') || value.includes('.js') || value.includes('.css')) {
+    return 'asset-load';
+  }
+  if (value.includes('storage') || value.includes('quota') || value.includes('cache')) {
+    return 'storage';
+  }
+  if (value.includes('network') || value.includes('fetch') || value.includes('offline')) {
+    return 'network';
+  }
+  if (value.includes('timeout')) {
+    return 'timeout';
+  }
+  return 'other';
+}
+
+function bucketDiagnosticDetailLength(detail: string | undefined): string | undefined {
+  if (!detail) return undefined;
+  if (detail.length <= 64) return 'short';
+  if (detail.length <= 256) return 'medium';
+  return 'long';
+}
+
 function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
   if (typeof window === 'undefined') return;
   // gtag 由 @shared/analytics 在 client-only initGA() 後注入；SSG 時或 GA 未 init 時皆無 function。
@@ -55,7 +80,9 @@ function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
     gtag('event', 'pwa_diagnostic', {
       diagnostic_phase: entry.phase,
       diagnostic_level: entry.level,
-      diagnostic_detail: entry.detail?.slice(0, FORWARD_DETAIL_MAX_LEN),
+      diagnostic_detail_present: Boolean(entry.detail),
+      diagnostic_detail_category: classifyDiagnosticDetail(entry.detail),
+      diagnostic_detail_length: bucketDiagnosticDetailLength(entry.detail),
     });
   } catch {
     // GA4 unavailable — diagnostics 仍保留在 localStorage。
@@ -74,7 +101,8 @@ async function forwardPwaDiagnostic(entry: PwaDiagnosticEvent): Promise<void> {
 
   try {
     if (entry.level === 'error') {
-      const { captureMessage } = await import('./sentry');
+      const { initSentry, captureMessage } = await import('./sentry');
+      await initSentry();
       await captureMessage(`PWA diagnostic: ${entry.phase}`, {
         level: 'error',
         tags: { pwa_diagnostic_phase: entry.phase },
@@ -84,7 +112,8 @@ async function forwardPwaDiagnostic(entry: PwaDiagnosticEvent): Promise<void> {
         },
       });
     } else if (entry.level === 'warn') {
-      const { addBreadcrumb } = await import('./sentry');
+      const { initSentry, addBreadcrumb } = await import('./sentry');
+      await initSentry();
       await addBreadcrumb(`pwa:${entry.phase}`, {
         detail: entry.detail,
         timestamp: entry.timestamp,

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -188,6 +188,12 @@ function trackGaPwaDiagnostic(entry: PwaDiagnosticEvent): void {
 }
 
 export function flushPwaDiagnosticAnalyticsQueue(): void {
+  if (!isForwardingEnabled()) {
+    pendingGa4Diagnostics.length = 0;
+    writeStoredGaPwaDiagnostics([]);
+    return;
+  }
+
   const gtag = getGtag();
   if (!gtag) return;
 

--- a/apps/ratewise/src/utils/pwaDiagnostics.ts
+++ b/apps/ratewise/src/utils/pwaDiagnostics.ts
@@ -191,9 +191,10 @@ export function flushPwaDiagnosticAnalyticsQueue(): void {
   const gtag = getGtag();
   if (!gtag) return;
 
-  const queuedDiagnostics = canUseBrowserStorage()
-    ? readStoredGaPwaDiagnostics()
-    : pendingGa4Diagnostics.splice(0);
+  const queuedDiagnostics = [
+    ...(canUseBrowserStorage() ? readStoredGaPwaDiagnostics() : []),
+    ...pendingGa4Diagnostics.splice(0),
+  ];
 
   if (canUseBrowserStorage()) {
     writeStoredGaPwaDiagnostics([]);

--- a/apps/ratewise/src/utils/sentry.ts
+++ b/apps/ratewise/src/utils/sentry.ts
@@ -10,14 +10,10 @@ import { logger } from './logger';
 
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 const IS_PROD = import.meta.env.MODE === 'production';
+let sentryInitPromise: Promise<void> | null = null;
+let didLogMissingDsn = false;
 
-export async function initSentry() {
-  // Only initialize if DSN is provided (production or explicit dev testing)
-  if (!SENTRY_DSN) {
-    logger.info('Sentry: No DSN configured, skipping initialization');
-    return;
-  }
-
+async function initializeSentryOnce(): Promise<void> {
   try {
     // Lazy load Sentry SDK to reduce initial bundle size
     const Sentry = await import('@sentry/react');
@@ -68,8 +64,23 @@ export async function initSentry() {
       tracesSampleRate: IS_PROD ? 0.1 : 1.0,
     });
   } catch (error) {
+    sentryInitPromise = null;
     logger.error('Failed to initialize Sentry', error as Error);
   }
+}
+
+export async function initSentry(): Promise<void> {
+  // Only initialize if DSN is provided (production or explicit dev testing)
+  if (!SENTRY_DSN) {
+    if (!didLogMissingDsn) {
+      didLogMissingDsn = true;
+      logger.info('Sentry: No DSN configured, skipping initialization');
+    }
+    return;
+  }
+
+  sentryInitPromise ??= initializeSentryOnce();
+  await sentryInitPromise;
 }
 
 /**

--- a/apps/ratewise/src/utils/sentry.ts
+++ b/apps/ratewise/src/utils/sentry.ts
@@ -96,3 +96,22 @@ export async function addBreadcrumb(message: string, data?: Record<string, unkno
     data,
   });
 }
+
+/** 結構化訊息事件（非 Error，例如 PWA 診斷的可觀性事件） */
+export async function captureMessage(
+  message: string,
+  options?: {
+    level?: 'info' | 'warning' | 'error';
+    tags?: Record<string, string>;
+    extra?: Record<string, unknown>;
+  },
+): Promise<void> {
+  if (!SENTRY_DSN) return;
+
+  const Sentry = await import('@sentry/react');
+  Sentry.captureMessage(message, {
+    level: options?.level ?? 'info',
+    tags: options?.tags,
+    extra: options?.extra,
+  });
+}

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -858,3 +858,8 @@
 - ID：ratewise-lhci-homepage-runtime-refresh-guard
 - 原因：PR #350 的 Lighthouse CI 在首頁 `/` 掉到 `0.87~0.88`，根因為 LHCI 離線模式下首頁仍執行 runtime 匯率 refresh，失敗後插入 stale warning 與額外背景工作，拉低首屏效能。
 - 解法：在 `exchangeRateService` 與 `useExchangeRates` 增加 `VITE_LHCI_OFFLINE` 穩定分支，LHCI 直接使用 build-time 匯率並跳過 runtime refresh / polling，另補 service 與 hook 回歸測試鎖住行為。
+
+- 日期：2026-05-07
+- ID：ratewise-pwa-diagnostics-sentry-ga-forwarding
+- 原因：60 天內 11+ 次 PWA 冷啟動白屏修復都靠局部觀察與盲修；`recordPwaDiagnostic` 事件僅留在使用者 localStorage，使用者重灌或私密模式即遺失，無法統計真實失敗率與分布，所有改動只能局部驗證。
+- 解法：在 `pwaDiagnostics` 加 `forwardPwaDiagnostic`，warn 走 `Sentry.addBreadcrumb`、error 走 `Sentry.captureMessage`，並同步送 GA4 `pwa_diagnostic` event；info-level 完全不送以保護 Sentry quota。內建 5 秒 phase dedup 與 `VITE_PWA_DIAGNOSTIC_FORWARDING` env 開關；新增 `flushPwaDiagnosticForwarding()` 給測試 deterministically 等待 fire-and-forget。同步在 `sentry.ts` 加 `captureMessage` helper 對齊既有 DSN guard 模式。新增 6 個單元測試鎖住 forward / dedup / GA4 / DSN-未設靜默行為。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-sentry-diagnostic-detail-redaction
+- 原因：Codex review 指出 GA4 已去識別化，但 Sentry `extra` / breadcrumb 仍可能外送原始 diagnostic detail，包含 URL query 或帳號識別。
+- 解法：將 Sentry captureMessage 與 breadcrumb 改用 detail present/category/length bucket metadata，不再外送 raw detail，並補測試鎖住無 email/raw detail。
+
+- 日期：2026-05-07
 - ID：pr373-pwa-diagnostic-forwarding-privacy-init
 - 原因：Codex review 指出 PWA diagnostic 會把原始 detail 送到 GA4，且 Sentry 轉發前未確保 SDK 已初始化，冷啟動主場景可能漏送。
 - 解法：GA4 改送 detail present/category/length bucket 等去識別化欄位，Sentry error/warn 轉發前先呼叫 `initSentry()`，並補單元測試鎖住行為。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-ga4-diagnostic-queue-persist-reload
+- 原因：Codex review 指出 `chunk-load-error` 記錄後會立即 recovery reload，若 GA4 queue 只在模組記憶體，尚未 flush 的早期診斷仍會遺失。
+- 解法：將待送 GA4 diagnostic 以去識別化參數持久化到 localStorage，下一次 analytics 初始化後補送並清除 queue。
+
+- 日期：2026-05-07
 - ID：pr373-ga4-diagnostic-queue-before-init
 - 原因：Codex review 指出 `initGA()` 延後到 load/idle 後才建立 `window.gtag`，早期 PWA warn/error 診斷會在 GA4 轉發時被靜默丟棄。
 - 解法：將 GA4 PWA diagnostic 參數先以去識別化欄位排隊，analytics 初始化後 flush，並補測試鎖住無 raw detail 與不漏送。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-sentry-init-idempotent
+- 原因：Codex review 指出每個未 dedup 的 PWA warn/error diagnostic 都會重複呼叫 `initSentry()`，造成反覆初始化與初始化 log 污染 Sentry quota。
+- 解法：將 `initSentry()` 改為一次性 promise/cache，無 DSN log 也只輸出一次，並補測試鎖住重複呼叫只初始化一次。
+
+- 日期：2026-05-07
 - ID：pr373-ga4-diagnostic-memory-fallback-flush
 - 原因：Codex review 指出 localStorage 可讀但 queue 寫入失敗時會 fallback 到 memory queue，flush 若只讀 storage 仍會漏送高風險環境的早期診斷。
 - 解法：讓 GA4 diagnostic flush 同時合併 stored queue 與 memory fallback queue，並補 storage quota/private-mode 類情境測試。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-ga4-queue-forwarding-opt-out
+- 原因：Codex review 指出舊版已排入 localStorage 的 GA4 diagnostic queue，可能在下一版關閉 `VITE_PWA_DIAGNOSTIC_FORWARDING` 後仍被 flush 送出。
+- 解法：讓 GA4 queue flush 先檢查 forwarding flag，關閉時直接清除 stored/memory queue 並不送出，補測試鎖住 opt-out。
+
+- 日期：2026-05-07
 - ID：pr373-sentry-init-idempotent
 - 原因：Codex review 指出每個未 dedup 的 PWA warn/error diagnostic 都會重複呼叫 `initSentry()`，造成反覆初始化與初始化 log 污染 Sentry quota。
 - 解法：將 `initSentry()` 改為一次性 promise/cache，無 DSN log 也只輸出一次，並補測試鎖住重複呼叫只初始化一次。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-pwa-diagnostic-forwarding-privacy-init
+- 原因：Codex review 指出 PWA diagnostic 會把原始 detail 送到 GA4，且 Sentry 轉發前未確保 SDK 已初始化，冷啟動主場景可能漏送。
+- 解法：GA4 改送 detail present/category/length bucket 等去識別化欄位，Sentry error/warn 轉發前先呼叫 `initSentry()`，並補單元測試鎖住行為。
+
+- 日期：2026-05-07
 - ID：pr372-cache-miss-navigation-waituntil
 - 原因：Codex review 指出 bounded SWR cache miss 超時回 fallback 後，慢網路 fetch 未掛入 `event.waitUntil`，SW 可能被終止而無法暖起 `html-cache`。
 - 解法：將 cache miss 的 `networkResponse` 同步掛入 `event.waitUntil`，保留 3 秒 fallback 體感，同時確保背景 HTML cache 寫入有生命週期保護。
@@ -858,8 +863,3 @@
 - ID：ratewise-lhci-homepage-runtime-refresh-guard
 - 原因：PR #350 的 Lighthouse CI 在首頁 `/` 掉到 `0.87~0.88`，根因為 LHCI 離線模式下首頁仍執行 runtime 匯率 refresh，失敗後插入 stale warning 與額外背景工作，拉低首屏效能。
 - 解法：在 `exchangeRateService` 與 `useExchangeRates` 增加 `VITE_LHCI_OFFLINE` 穩定分支，LHCI 直接使用 build-time 匯率並跳過 runtime refresh / polling，另補 service 與 hook 回歸測試鎖住行為。
-
-- 日期：2026-05-07
-- ID：ratewise-pwa-diagnostics-sentry-ga-forwarding
-- 原因：60 天內 11+ 次 PWA 冷啟動白屏修復都靠局部觀察與盲修；`recordPwaDiagnostic` 事件僅留在使用者 localStorage，使用者重灌或私密模式即遺失，無法統計真實失敗率與分布，所有改動只能局部驗證。
-- 解法：在 `pwaDiagnostics` 加 `forwardPwaDiagnostic`，warn 走 `Sentry.addBreadcrumb`、error 走 `Sentry.captureMessage`，並同步送 GA4 `pwa_diagnostic` event；info-level 完全不送以保護 Sentry quota。內建 5 秒 phase dedup 與 `VITE_PWA_DIAGNOSTIC_FORWARDING` env 開關；新增 `flushPwaDiagnosticForwarding()` 給測試 deterministically 等待 fire-and-forget。同步在 `sentry.ts` 加 `captureMessage` helper 對齊既有 DSN guard 模式。新增 6 個單元測試鎖住 forward / dedup / GA4 / DSN-未設靜默行為。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-ga4-diagnostic-memory-fallback-flush
+- 原因：Codex review 指出 localStorage 可讀但 queue 寫入失敗時會 fallback 到 memory queue，flush 若只讀 storage 仍會漏送高風險環境的早期診斷。
+- 解法：讓 GA4 diagnostic flush 同時合併 stored queue 與 memory fallback queue，並補 storage quota/private-mode 類情境測試。
+
+- 日期：2026-05-07
 - ID：pr373-ga4-diagnostic-queue-persist-reload
 - 原因：Codex review 指出 `chunk-load-error` 記錄後會立即 recovery reload，若 GA4 queue 只在模組記憶體，尚未 flush 的早期診斷仍會遺失。
 - 解法：將待送 GA4 diagnostic 以去識別化參數持久化到 localStorage，下一次 analytics 初始化後補送並清除 queue。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 ## 條目（新→舊）
 
 - 日期：2026-05-07
+- ID：pr373-ga4-diagnostic-queue-before-init
+- 原因：Codex review 指出 `initGA()` 延後到 load/idle 後才建立 `window.gtag`，早期 PWA warn/error 診斷會在 GA4 轉發時被靜默丟棄。
+- 解法：將 GA4 PWA diagnostic 參數先以去識別化欄位排隊，analytics 初始化後 flush，並補測試鎖住無 raw detail 與不漏送。
+
+- 日期：2026-05-07
 - ID：pr373-sentry-diagnostic-detail-redaction
 - 原因：Codex review 指出 GA4 已去識別化，但 Sentry `extra` / breadcrumb 仍可能外送原始 diagnostic detail，包含 URL query 或帳號識別。
 - 解法：將 Sentry captureMessage 與 breadcrumb 改用 detail present/category/length bucket metadata，不再外送 raw detail，並補測試鎖住無 email/raw detail。


### PR DESCRIPTION
## 摘要

- `pwaDiagnostics.recordPwaDiagnostic` 加 fire-and-forget 觀察性轉發
- `error` → `Sentry.captureMessage` + GA4 `pwa_diagnostic` event
- `warn` → `Sentry.addBreadcrumb` + GA4 event
- `info` → 不送（保護 Sentry quota）
- 5 秒 phase dedup 避免 watchdog / chunk-error 連發爆 quota
- env `VITE_PWA_DIAGNOSTIC_FORWARDING='false'` 完全關閉

## 背景

60 天內 PWA 冷啟動白屏修復累積 11+ 次（PR #199-#202、#351、#355、#358、#359、#360、#364、#367、#371、#372），每次都靠開發者本地驗證 + Codex/E2E 鎖定。`recordPwaDiagnostic` 事件僅留在使用者 localStorage，使用者重灌或私密模式即遺失，**無法統計真實失敗率與分布，所有改動只能局部驗證**。

把觀察性盲區補起來，未來能用真實生產分布支撐根因收斂，而非繼續加防線。

## 為什麼安全

- **不增加初始 bundle**：使用既有 `sentry.ts` 的 lazy `import('@sentry/react')` 模式
- **DSN 未設靜默**：`captureMessage` / `addBreadcrumb` 已 guarded（既有模式延伸）
- **fire-and-forget**：runtime 不 block `recordPwaDiagnostic`，呼叫端零等待
- **dedup 防爆量**：同 phase 5 秒內只送一次，watchdog 連發場景可控
- **可關閉**：env flag 完全停掉，敏感環境/測試 opt-out

## 變更

| 檔案 | 改動 |
|---|---|
| `apps/ratewise/src/utils/sentry.ts` | 加 `captureMessage(message, options)` helper（DSN guard + lazy import） |
| `apps/ratewise/src/utils/pwaDiagnostics.ts` | 加 `forwardPwaDiagnostic` / `flushPwaDiagnosticForwarding` / `__resetPwaDiagnosticForwardingDedup` |
| `apps/ratewise/src/utils/__tests__/pwaDiagnostics.test.ts` | 新增 6 個測試：error→captureMessage / warn→addBreadcrumb / info-not-forwarded / 5s dedup / GA4 send / gtag-unavailable noop |
| `docs/dev/002_development_reward_penalty_log.md` | 新增 `ratewise-pwa-diagnostics-sentry-ga-forwarding` 條目 |
| `.changeset/ratewise-pwa-diagnostics-sentry-ping.md` | patch bump |

## 已執行驗證

- `pnpm --filter @app/ratewise typecheck` ✅
- `pnpm --filter @app/ratewise exec vitest run src/utils/__tests__/pwaDiagnostics.test.ts src/__tests__/sw.test.ts src/pwa-offline.test.ts` ✅ 69/69
- `VITE_RATEWISE_BASE_PATH='/' pnpm build:ratewise` ✅
- pre-push: typecheck + 全 repo test + build:ratewise 全綠
- `dist/assets/app-*.js` 含 `pwa_diagnostic`

## 相關

- 配套 P0 PR #371（watchdog 保留 SSG）
- 配套 P1.1 PR #372（SPA navigation SWR）
- 同屬 60 天 11+ 次 PWA 冷啟動白屏修復系列的根因收斂

## 後續（不在本 PR 範圍）

- Sentry 後台建議建立 `pwa_diagnostic_phase` tag 的 alert（error level > N/min）
- GA4 後台建立 `pwa_diagnostic` 自訂事件報表，統計 phase 分布
- 觀察 1-2 週後決定 P2（Cloudflare/Zeabur N-1 chunk 保留）的優先級

🤖 Generated with [Claude Code](https://claude.ai/code)