### PR TITLE
docs(ratewise): 記錄匯率卡倒數顯示設計決策

### DIFF
--- a/.changeset/reciprocal-rate-docs.md
+++ b/.changeset/reciprocal-rate-docs.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+docs: 記錄匯率卡倒數顯示設計決策（Google-style）

--- a/apps/ratewise/src/utils/exchangeRateCalculation.ts
+++ b/apps/ratewise/src/utils/exchangeRateCalculation.ts
@@ -421,6 +421,13 @@ export function getUnitExchangeRate(
   );
 }
 
+/**
+ * 匯率卡倒數顯示（Google-style）：「1 TO = 1/rate FROM」
+ *
+ * 設計決策：使用數學倒數而非反向呼叫 getUnitExchangeRate，因為：
+ * - 用戶視角：同一匯率的正向與倒數，可直接乘除快速換算
+ * - 若用反向計算會得到不同匯率（買賣價差），造成用戶困惑
+ */
 export function getReciprocalExchangeRate(rate: number): number {
   if (!Number.isFinite(rate) || rate <= 0) return 0;
   return 1 / rate;


### PR DESCRIPTION
## Summary

- 新增 getReciprocalExchangeRate 函數的設計決策註解
- 記錄為何使用數學倒數而非反向計算（Google-style 匯率顯示）
- 回應 PR #387 的 Codex P2 review thread

## 設計決策

匯率卡顯示：
- 1 USD = 31.87 TWD（當前方向的匯率）
- 1 TWD = 0.0314 USD（數學倒數）

使用數學倒數的原因：
1. 用戶可直接乘除快速換算
2. 若用反向計算會得到不同匯率（買賣價差），造成用戶困惑

## Test plan

- [x] typecheck 通過
- [x] 2389 tests 全通過

Made with [Cursor](https://cursor.com)