### PR TITLE
fix(ratewise): 收斂熱門幣別導覽 SSOT

### DIFF
--- a/.changeset/ratewise-popular-currency-ssot.md
+++ b/.changeset/ratewise-popular-currency-ssot.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+收斂首頁、footer、攻略頁熱門幣別導覽 SSOT，並讓首頁熱門幣別清單輸出可見內容對齊的 ItemList schema。

--- a/apps/ratewise/public/about.md
+++ b/apps/ratewise/public/about.md
@@ -54,7 +54,7 @@ HaoRate 是以臺灣銀行牌告匯率為基礎的換匯工具，重點是幫台
 
 ### 6. 這個網站使用哪些結構化資料幫助搜尋引擎與 AI 系統理解內容？
 
-目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、CurrencyConversionService（首頁）、ExchangeRateSpecification（幣對頁與金額頁的匯率數值）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、HowTo（Guide 教學頁）、FAQPage（僅 /faq/ 主 FAQ 頁）、Dataset（開放資料）與 ImageObject（分享圖片授權）。首頁與內容頁仍保留可讀 FAQ HTML，但不會在所有頁面重複輸出 FAQPage JSON-LD；幣別換算頁則以可稽核的匯率數值 schema 為主，避免把 FAQ rich result 訊號擴散到金融頁。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。
+目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、CurrencyConversionService（首頁）、ItemList（首頁熱門幣別導覽）、ExchangeRateSpecification（幣對頁與金額頁的匯率數值）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、HowTo（Guide 教學頁）、FAQPage（僅 /faq/ 主 FAQ 頁）、Dataset（開放資料）與 ImageObject（分享圖片授權）。首頁與內容頁仍保留可讀 FAQ HTML，但不會在所有頁面重複輸出 FAQPage JSON-LD；幣別換算頁則以可稽核的匯率數值 schema 為主，避免把 FAQ rich result 訊號擴散到金融頁。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。
 
 ### 7. HaoRate 是否支援 AI 搜尋引擎與 LLM 引用？
 

--- a/apps/ratewise/src/components/Footer.tsx
+++ b/apps/ratewise/src/components/Footer.tsx
@@ -100,7 +100,7 @@ export function Footer() {
   return (
     <footer className="bg-gradient-to-br from-footer-from via-footer-via to-footer-to text-surface mt-16">
       {/* 行動版簡潔 Footer */}
-      <div className="md:hidden max-w-6xl mx-auto px-4 py-8">
+      <div data-testid="footer-mobile" className="md:hidden max-w-6xl mx-auto px-4 py-8">
         {/* 匯率來源與更新時間 */}
         <div className="flex flex-col items-center justify-center gap-4 mb-6">
           <a
@@ -254,7 +254,10 @@ export function Footer() {
       </div>
 
       {/* 電腦版完整 Footer - 整合簡潔風格 + SEO 連結 */}
-      <div className="hidden md:block container mx-auto px-4 md:px-6 py-12 max-w-6xl">
+      <div
+        data-testid="footer-desktop"
+        className="hidden md:block container mx-auto px-4 md:px-6 py-12 max-w-6xl"
+      >
         {/* 匯率來源與更新時間 */}
         <div className="flex flex-row items-center justify-center gap-4 mb-6">
           <a
@@ -308,37 +311,6 @@ export function Footer() {
         {/* 免責聲明 */}
         <div className="text-center mb-6">
           <p className="text-xs text-white/70 leading-relaxed">{t('footer.disclaimer')}</p>
-        </div>
-
-        {/* 快速連結 */}
-        <div className="flex flex-wrap items-center justify-center gap-5 text-xs text-white/80 mb-6">
-          <Link
-            to="/faq/"
-            className="inline-flex items-center gap-1.5 hover:text-white transition-colors duration-200"
-          >
-            <span aria-hidden="true" className="text-white/50">
-              ?
-            </span>
-            {t('footer.faq')}
-          </Link>
-          <Link
-            to="/about/"
-            className="inline-flex items-center gap-1.5 hover:text-white transition-colors duration-200"
-          >
-            <span aria-hidden="true" className="text-white/50">
-              i
-            </span>
-            {t('footer.about')}
-          </Link>
-          <Link
-            to="/privacy/"
-            className="inline-flex items-center gap-1.5 hover:text-white transition-colors duration-200"
-          >
-            <span aria-hidden="true" className="text-white/50">
-              🔒
-            </span>
-            {t('footer.privacyPolicy')}
-          </Link>
         </div>
 
         {/* 分隔線 */}

--- a/apps/ratewise/src/components/HomepageSEOSection.tsx
+++ b/apps/ratewise/src/components/HomepageSEOSection.tsx
@@ -1,31 +1,14 @@
 import { Link } from 'react-router-dom';
-import { CURRENCY_DEFINITIONS } from '../features/ratewise/constants';
+import { POPULAR_FROM_TWD_LINKS, POPULAR_TO_TWD_LINKS } from '../config/popular-currency-links';
 import { HOMEPAGE_SEO } from '../config/seo-metadata';
 import { AnswerCapsule } from './AnswerCapsule';
-
-/** 熱門幣對：外幣換台幣（依台灣旅遊熱度排序）。 */
-const HOT_TO_TWD = ['JPY', 'KRW', 'USD', 'EUR', 'HKD', 'SGD', 'THB', 'VND', 'AUD', 'GBP'] as const;
-
-/** 熱門幣對：台幣換外幣（出國換匯常見方向）。 */
-const HOT_FROM_TWD = [
-  'JPY',
-  'KRW',
-  'USD',
-  'EUR',
-  'HKD',
-  'SGD',
-  'THB',
-  'VND',
-  'AUD',
-  'GBP',
-] as const;
 
 export function HomepageSEOSection() {
   const { content, howTo, faqContent, answerCapsule } = HOMEPAGE_SEO;
 
   return (
     <section
-      aria-labelledby="homepage-seo-heading"
+      aria-labelledby="homepage-seo-section-heading"
       className="px-5 pt-5 pb-3 max-w-md mx-auto w-full"
     >
       <div className="rounded-[28px] border border-black/5 bg-surface shadow-card p-5">
@@ -72,40 +55,36 @@ export function HomepageSEOSection() {
 
       {/* 熱門幣別換算：內部連結區塊，提升幣對落地頁 PageRank 傳遞。 */}
       <div className="mt-4 rounded-[28px] border border-black/5 bg-surface shadow-card p-5">
-        <h2 className="text-lg font-black text-text">熱門幣別換算</h2>
+        <h2 id="popular-currency-heading" className="text-lg font-black text-text">
+          熱門幣別換算
+        </h2>
 
         <p className="mt-1 text-xs text-text-muted">外幣換台幣</p>
         <div className="mt-2 grid grid-cols-2 gap-1.5">
-          {HOT_TO_TWD.map((code) => {
-            const def = CURRENCY_DEFINITIONS[code];
-            return (
-              <Link
-                key={`to-twd-${code}`}
-                to={`/${code.toLowerCase()}-twd/`}
-                className="flex items-center gap-2 rounded-2xl border border-primary/10 bg-primary/5 px-3 py-2 text-xs font-bold text-primary transition hover:bg-primary/10"
-              >
-                <span aria-hidden="true">{def.flag}</span>
-                <span>{def.name}換台幣</span>
-              </Link>
-            );
-          })}
+          {POPULAR_TO_TWD_LINKS.map((link) => (
+            <Link
+              key={`to-twd-${link.code}`}
+              to={link.href}
+              className="flex items-center gap-2 rounded-2xl border border-primary/10 bg-primary/5 px-3 py-2 text-xs font-bold text-primary transition hover:bg-primary/10"
+            >
+              <span aria-hidden="true">{link.flag}</span>
+              <span>{link.label}</span>
+            </Link>
+          ))}
         </div>
 
         <p className="mt-4 text-xs text-text-muted">台幣換外幣</p>
         <div className="mt-2 grid grid-cols-2 gap-1.5">
-          {HOT_FROM_TWD.map((code) => {
-            const def = CURRENCY_DEFINITIONS[code];
-            return (
-              <Link
-                key={`from-twd-${code}`}
-                to={`/twd-${code.toLowerCase()}/`}
-                className="flex items-center gap-2 rounded-2xl border border-primary/10 bg-primary/5 px-3 py-2 text-xs font-bold text-primary transition hover:bg-primary/10"
-              >
-                <span aria-hidden="true">{def.flag}</span>
-                <span>台幣換{def.name}</span>
-              </Link>
-            );
-          })}
+          {POPULAR_FROM_TWD_LINKS.map((link) => (
+            <Link
+              key={`from-twd-${link.code}`}
+              to={link.href}
+              className="flex items-center gap-2 rounded-2xl border border-primary/10 bg-primary/5 px-3 py-2 text-xs font-bold text-primary transition hover:bg-primary/10"
+            >
+              <span aria-hidden="true">{link.flag}</span>
+              <span>{link.label}</span>
+            </Link>
+          ))}
         </div>
       </div>
 

--- a/apps/ratewise/src/components/__tests__/Footer.test.tsx
+++ b/apps/ratewise/src/components/__tests__/Footer.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { Footer } from '../Footer';
@@ -58,5 +58,16 @@ describe('Footer', () => {
       expect(timeSlot).toHaveClass('font-mono');
       expect(timeSlot).toHaveClass('tabular-nums');
     }
+  });
+
+  it('keeps desktop footer rendered hrefs unique', () => {
+    renderFooter();
+    const desktopFooter = screen.getByTestId('footer-desktop');
+    const hrefs = within(desktopFooter)
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('href'))
+      .filter((href): href is string => Boolean(href));
+
+    expect(new Set(hrefs).size).toBe(hrefs.length);
   });
 });

--- a/apps/ratewise/src/components/__tests__/HomepageSEOSection.test.tsx
+++ b/apps/ratewise/src/components/__tests__/HomepageSEOSection.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { POPULAR_FROM_TWD_LINKS, POPULAR_TO_TWD_LINKS } from '../../config/popular-currency-links';
+import { HomepageSEOSection } from '../HomepageSEOSection';
+
+describe('HomepageSEOSection', () => {
+  it('labels the section with its own heading instead of the app shell heading', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HomepageSEOSection />
+      </MemoryRouter>,
+    );
+
+    const section = container.querySelector('section');
+    const heading = container.querySelector('#homepage-seo-section-heading');
+
+    expect(section).toHaveAttribute('aria-labelledby', 'homepage-seo-section-heading');
+    expect(heading).toHaveTextContent('即時匯率換算');
+  });
+
+  it('renders popular currency links from the shared SSOT', () => {
+    render(
+      <MemoryRouter>
+        <HomepageSEOSection />
+      </MemoryRouter>,
+    );
+
+    for (const link of [...POPULAR_TO_TWD_LINKS, ...POPULAR_FROM_TWD_LINKS]) {
+      expect(screen.getByRole('link', { name: link.label })).toHaveAttribute('href', link.href);
+    }
+  });
+});

--- a/apps/ratewise/src/config/__tests__/footer-links.spec.ts
+++ b/apps/ratewise/src/config/__tests__/footer-links.spec.ts
@@ -11,12 +11,12 @@ describe('footer links config', () => {
   it('keeps popular rate links ordered by priority', () => {
     const labels = POPULAR_RATE_LINKS.map((link) => link.label);
     expect(labels).toEqual([
-      'USD 美元',
       'JPY 日圓',
+      'KRW 韓元',
+      'USD 美元',
       'EUR 歐元',
       'HKD 港幣',
-      'CNY 人民幣',
-      'KRW 韓元',
+      'SGD 新加坡幣',
     ]);
   });
 });

--- a/apps/ratewise/src/config/__tests__/popular-currency-links.test.ts
+++ b/apps/ratewise/src/config/__tests__/popular-currency-links.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCanonicalUrl,
+  buildPopularCurrencyItemListJsonLd,
+  CARD_RATE_GUIDE_PAGE,
+  CASH_VS_SPOT_RATE_PAGE,
+  HOMEPAGE_SEO,
+  SELL_RATE_VS_MID_RATE_PAGE,
+} from '../seo-metadata';
+import {
+  POPULAR_CURRENCY_CODES,
+  POPULAR_FROM_TWD_LINKS,
+  POPULAR_ITEM_LIST_LINKS,
+  POPULAR_RATE_LINKS,
+  POPULAR_RELATED_CURRENCY_LINKS,
+  POPULAR_TO_TWD_LINKS,
+} from '../popular-currency-links';
+import { FOOTER_SECTIONS, POPULAR_RATE_LINKS as FOOTER_POPULAR_RATE_LINKS } from '../footer-links';
+
+describe('popular currency links SSOT', () => {
+  it('keeps homepage forward and reverse links aligned to the same popular currency order', () => {
+    expect(POPULAR_TO_TWD_LINKS.map((link) => link.code)).toEqual([...POPULAR_CURRENCY_CODES]);
+    expect(POPULAR_FROM_TWD_LINKS.map((link) => link.code)).toEqual([...POPULAR_CURRENCY_CODES]);
+
+    for (const link of POPULAR_TO_TWD_LINKS) {
+      expect(link.href).toBe(`/${link.code.toLowerCase()}-twd/`);
+      expect(link.label).toMatch(/換台幣$/);
+    }
+
+    for (const link of POPULAR_FROM_TWD_LINKS) {
+      expect(link.href).toBe(`/twd-${link.code.toLowerCase()}/`);
+      expect(link.label).toMatch(/^台幣換/);
+    }
+  });
+
+  it('derives footer popular rates and authority-guide related currencies from the same top links', () => {
+    const topCodes = POPULAR_CURRENCY_CODES.slice(0, POPULAR_RATE_LINKS.length);
+
+    expect(POPULAR_RATE_LINKS.map((link) => link.code)).toEqual(topCodes);
+    expect(POPULAR_RELATED_CURRENCY_LINKS.map((link) => link.code)).toEqual(topCodes);
+    expect(FOOTER_POPULAR_RATE_LINKS).toEqual(POPULAR_RATE_LINKS);
+    expect(FOOTER_SECTIONS.find((section) => section.title === '熱門匯率')?.links).toEqual(
+      POPULAR_RATE_LINKS,
+    );
+  });
+
+  it('keeps guide related currency links in parity with the popular currency SSOT', () => {
+    for (const page of [SELL_RATE_VS_MID_RATE_PAGE, CASH_VS_SPOT_RATE_PAGE, CARD_RATE_GUIDE_PAGE]) {
+      expect(page.relatedCurrencies).toEqual(POPULAR_RELATED_CURRENCY_LINKS);
+    }
+  });
+
+  it('exposes homepage ItemList JSON-LD for the visible popular currency links', () => {
+    const itemList = buildPopularCurrencyItemListJsonLd();
+    const homepageItemList = HOMEPAGE_SEO.jsonLd.find((schema) => schema['@type'] === 'ItemList');
+
+    expect(homepageItemList).toEqual(itemList);
+    expect(itemList['numberOfItems']).toBe(POPULAR_ITEM_LIST_LINKS.length);
+
+    const elements = itemList['itemListElement'] as Record<string, unknown>[];
+    expect(elements).toHaveLength(POPULAR_ITEM_LIST_LINKS.length);
+
+    elements.forEach((element, index) => {
+      const link = POPULAR_ITEM_LIST_LINKS[index]!;
+      expect(element['@type']).toBe('ListItem');
+      expect(element['position']).toBe(index + 1);
+      expect(element['name']).toBe(link.label);
+      expect(element['url']).toBe(buildCanonicalUrl(link.href));
+    });
+  });
+});

--- a/apps/ratewise/src/config/footer-links.ts
+++ b/apps/ratewise/src/config/footer-links.ts
@@ -1,3 +1,5 @@
+import { POPULAR_RATE_LINKS } from './popular-currency-links';
+
 export interface FooterLink {
   label: string;
   href: string;
@@ -8,14 +10,7 @@ export interface FooterSection {
   links: FooterLink[];
 }
 
-export const POPULAR_RATE_LINKS: FooterLink[] = [
-  { label: 'USD 美元', href: '/usd-twd/' },
-  { label: 'JPY 日圓', href: '/jpy-twd/' },
-  { label: 'EUR 歐元', href: '/eur-twd/' },
-  { label: 'HKD 港幣', href: '/hkd-twd/' },
-  { label: 'CNY 人民幣', href: '/cny-twd/' },
-  { label: 'KRW 韓元', href: '/krw-twd/' },
-];
+export { POPULAR_RATE_LINKS };
 
 export const FOOTER_SECTIONS: FooterSection[] = [
   {
@@ -34,10 +29,10 @@ export const FOOTER_SECTIONS: FooterSection[] = [
     links: POPULAR_RATE_LINKS,
   },
   {
-    // 移除與熱門匯率重複的 USD/JPY/HKD/CNY/KRW，改為非重複的亞洲幣別。
+    // 移除與熱門匯率重複的 JPY/KRW/HKD/SGD，改為非重複的亞洲幣別。
     title: '亞洲貨幣',
     links: [
-      { label: 'SGD 新加坡幣', href: '/sgd-twd/' },
+      { label: 'CNY 人民幣', href: '/cny-twd/' },
       { label: 'THB 泰銖', href: '/thb-twd/' },
       { label: 'PHP 菲律賓披索', href: '/php-twd/' },
       { label: 'MYR 馬來幣', href: '/myr-twd/' },

--- a/apps/ratewise/src/config/popular-currency-links.ts
+++ b/apps/ratewise/src/config/popular-currency-links.ts
@@ -1,0 +1,78 @@
+import { CURRENCY_DEFINITIONS } from '../features/ratewise/constants';
+import type { CurrencyCode } from '../features/ratewise/types';
+
+export interface PopularCurrencyLink {
+  code: CurrencyCode;
+  href: string;
+  label: string;
+}
+
+interface PopularCurrencyNavLink extends PopularCurrencyLink {
+  flag: string;
+  rateLabel: string;
+  shortLabel: string;
+}
+
+/** 首頁與 SEO ItemList 的熱門外幣順序；同時服務外幣→台幣與台幣→外幣導覽。 */
+export const POPULAR_CURRENCY_CODES = [
+  'JPY',
+  'KRW',
+  'USD',
+  'EUR',
+  'HKD',
+  'SGD',
+  'THB',
+  'VND',
+  'AUD',
+  'GBP',
+] as const satisfies readonly CurrencyCode[];
+
+const buildToTwdLink = (code: (typeof POPULAR_CURRENCY_CODES)[number]): PopularCurrencyNavLink => {
+  const definition = CURRENCY_DEFINITIONS[code];
+
+  return {
+    code,
+    flag: definition.flag,
+    href: `/${code.toLowerCase()}-twd/`,
+    label: `${definition.name}換台幣`,
+    rateLabel: `${definition.name}匯率`,
+    shortLabel: `${code} ${definition.name}`,
+  };
+};
+
+const buildFromTwdLink = (
+  code: (typeof POPULAR_CURRENCY_CODES)[number],
+): PopularCurrencyNavLink => {
+  const definition = CURRENCY_DEFINITIONS[code];
+
+  return {
+    code,
+    flag: definition.flag,
+    href: `/twd-${code.toLowerCase()}/`,
+    label: `台幣換${definition.name}`,
+    rateLabel: `${definition.name}匯率`,
+    shortLabel: `${code} ${definition.name}`,
+  };
+};
+
+export const POPULAR_TO_TWD_LINKS = POPULAR_CURRENCY_CODES.map(buildToTwdLink);
+
+export const POPULAR_FROM_TWD_LINKS = POPULAR_CURRENCY_CODES.map(buildFromTwdLink);
+
+export const POPULAR_ITEM_LIST_LINKS = [...POPULAR_TO_TWD_LINKS, ...POPULAR_FROM_TWD_LINKS];
+
+export const POPULAR_RATE_LINKS: PopularCurrencyLink[] = POPULAR_TO_TWD_LINKS.slice(0, 6).map(
+  ({ code, href, shortLabel }) => ({
+    code,
+    href,
+    label: shortLabel,
+  }),
+);
+
+export const POPULAR_RELATED_CURRENCY_LINKS: PopularCurrencyLink[] = POPULAR_RATE_LINKS.map(
+  ({ code, href }) => ({
+    code,
+    href,
+    label: `${CURRENCY_DEFINITIONS[code].name}匯率`,
+  }),
+);

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -1,6 +1,7 @@
 import { CURRENCY_DEFINITIONS, SUPPORTED_CURRENCY_COUNT } from '../features/ratewise/constants';
 import { APP_INFO, AUTHOR_PERSON, SEO_SOCIAL_LINKS } from './app-info';
 import { DEFAULT_TITLE, GUIDE_PAGE_TITLE } from './seo-static';
+import { POPULAR_ITEM_LIST_LINKS, POPULAR_RELATED_CURRENCY_LINKS } from './popular-currency-links';
 import {
   SEO_RATE_EXAMPLES,
   SEO_RATE_EXAMPLES_DATE,
@@ -510,6 +511,23 @@ export function buildCurrencyConversionServiceJsonLd(): JsonLdBlock {
   };
 }
 
+export function buildPopularCurrencyItemListJsonLd(): JsonLdBlock {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    '@id': `${buildCanonicalUrl('/')}#popular-currency-links`,
+    name: `${APP_INFO.name} 熱門幣別換算`,
+    itemListOrder: 'https://schema.org/ItemListOrderDescending',
+    numberOfItems: POPULAR_ITEM_LIST_LINKS.length,
+    itemListElement: POPULAR_ITEM_LIST_LINKS.map((link, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: link.label,
+      url: buildCanonicalUrl(link.href),
+    })),
+  };
+}
+
 /**
  * 生成 WebPage JSON-LD。
  * 用於首頁等非 Article 類型頁面，支援 speakable 屬性標記語音搜尋可朗讀區塊。
@@ -922,6 +940,8 @@ export const HOMEPAGE_SEO = {
     }),
     // CurrencyConversionService：精確定義此工具的核心功能，AI 引擎優先引用。
     buildCurrencyConversionServiceJsonLd(),
+    // ItemList：對應首頁可見熱門幣別導覽，讓搜尋與 AI 系統理解內部連結優先序。
+    buildPopularCurrencyItemListJsonLd(),
   ],
   content: {
     eyebrow: '臺灣銀行牌告匯率 · 每 5 分鐘同步 · 顯示實際買賣價',
@@ -1334,7 +1354,7 @@ export const ABOUT_PAGE_FAQ = [
   },
   {
     question: '這個網站使用哪些結構化資料幫助搜尋引擎與 AI 系統理解內容？',
-    answer: `目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、CurrencyConversionService（首頁）、ExchangeRateSpecification（幣對頁與金額頁的匯率數值）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、HowTo（Guide 教學頁）、FAQPage（僅 /faq/ 主 FAQ 頁）、Dataset（開放資料）與 ImageObject（分享圖片授權）。首頁與內容頁仍保留可讀 FAQ HTML，但不會在所有頁面重複輸出 FAQPage JSON-LD；幣別換算頁則以可稽核的匯率數值 schema 為主，避免把 FAQ rich result 訊號擴散到金融頁。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。`,
+    answer: `目前站內實際部署的 schema.org JSON-LD 包含 WebSite（全站識別）、SoftwareApplication（產品資訊）、Organization（聯絡資訊）、CurrencyConversionService（首頁）、ItemList（首頁熱門幣別導覽）、ExchangeRateSpecification（幣對頁與金額頁的匯率數值）、BreadcrumbList（麵包屑導覽）、Article（內容頁）、HowTo（Guide 教學頁）、FAQPage（僅 /faq/ 主 FAQ 頁）、Dataset（開放資料）與 ImageObject（分享圖片授權）。首頁與內容頁仍保留可讀 FAQ HTML，但不會在所有頁面重複輸出 FAQPage JSON-LD；幣別換算頁則以可稽核的匯率數值 schema 為主，避免把 FAQ rich result 訊號擴散到金融頁。sitemap.xml 只收錄公開可索引 URL，並同步 hreflang 資訊。`,
   },
   {
     question: `${APP_INFO.shortName} 是否支援 AI 搜尋引擎與 LLM 引用？`,
@@ -1416,14 +1436,7 @@ export const ABOUT_PAGE_SEO = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** 熱門幣別連結：攻略頁連結至最常用的幣別頁。 */
-const RELATED_CURRENCIES: RelatedCurrencyLink[] = [
-  { href: '/jpy-twd/', label: '日圓匯率', code: 'JPY' },
-  { href: '/usd-twd/', label: '美金匯率', code: 'USD' },
-  { href: '/krw-twd/', label: '韓元匯率', code: 'KRW' },
-  { href: '/eur-twd/', label: '歐元匯率', code: 'EUR' },
-  { href: '/cny-twd/', label: '人民幣匯率', code: 'CNY' },
-  { href: '/thb-twd/', label: '泰銖匯率', code: 'THB' },
-];
+const RELATED_CURRENCIES: RelatedCurrencyLink[] = POPULAR_RELATED_CURRENCY_LINKS;
 
 const GUIDE_LINK_SELL_RATE_VS_MID_RATE: RelatedGuideLink = {
   href: '/sell-rate-vs-mid-rate/',

--- a/apps/ratewise/src/config/seo-schema-registry.ts
+++ b/apps/ratewise/src/config/seo-schema-registry.ts
@@ -39,6 +39,13 @@ export const SEO_SCHEMA_REGISTRY = [
     enabled: true,
   },
   {
+    type: 'ItemList',
+    desc: '首頁可見熱門幣別導覽清單',
+    pages: '首頁',
+    icon: Link2,
+    enabled: true,
+  },
+  {
     type: 'ExchangeRateSpecification',
     desc: '幣對頁 / 金額頁的匯率數值、來源與換算金額',
     pages: '幣別落地頁 / 金額頁',

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1）｜累計總分：+58
+> 本次分數變化：+1（reward 1）｜累計總分：+59
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-05-17
+- ID：reward-ratewise-popular-currency-link-ssot
+- 原因：首頁熱門幣別、footer 熱門匯率與攻略頁相關幣別各自維護清單，首頁熱門區 aria-labelledby 也指向 app shell heading
+- 解法：新增 popular-currency-links SSOT 並由首頁、footer、攻略頁與 ItemList JSON-LD 共用，同步修正 aria-labelledby、SeoTech schema registry 與 footer 去重測試
 
 - 日期：2026-05-17
 - ID：reward-ratewise-support-copy-i18n-shell


### PR DESCRIPTION
## 摘要
- 疊在 PR #405 之後，新增 popular-currency-links SSOT，讓首頁熱門幣別、footer 熱門匯率、攻略頁相關幣別與首頁 ItemList JSON-LD 共用同一份排序與連結資料
- 修正首頁 SEO section 的 aria-labelledby，避免指向 app shell heading
- 移除桌機 footer 重複 quick links，保留行動版快速連結，並補 rendered desktop footer href 去重測試
- 同步 SeoTech schema registry、About markdown mirror、changeset 與 002 稽核記錄

## 依據
- Google Search Central Structured Data Guidelines：結構化資料需對應使用者可見內容
- schema.org ItemList/ListItem：以 ListItem position + URL 描述有序清單
- React official docs：list rendering 使用穩定 key，ARIA props 與 HTML 屬性同名

## 驗證
- pnpm --filter @app/ratewise test -- src/config/__tests__/popular-currency-links.test.ts src/components/__tests__/HomepageSEOSection.test.tsx src/components/__tests__/Footer.test.tsx src/config/__tests__/footer-links.spec.ts src/config/__tests__/footer-links.test.ts src/pages/__tests__/SeoTech.ssot.test.tsx src/config/__tests__/seo-ssot.test.ts
- pnpm --filter @app/ratewise typecheck
- pnpm build:ratewise
- pnpm typecheck
- pnpm test
- Chromium desktop / WebKit mobile production smoke：首頁熱門幣別、footer visible href 去重、ItemList JSON-LD、無 console/pageerror、無水平 overflow
- Code review agent：無 CRITICAL/HIGH；增量 footer review 無阻擋問題