### PR TITLE
fix(security): 新增 split-meow CSP profile 允許 jsDelivr CDN 匯率 API

### DIFF
--- a/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
+++ b/apps/ratewise/src/__tests__/securityHeadersWorker.test.ts
@@ -197,7 +197,7 @@ describe('security-headers worker', () => {
     expect(csp).toContain('https://fonts.googleapis.com');
   });
 
-  it('未定義專屬 profile 的 app 路徑應保留 fallback CSP，避免 legacy 遠端頭像被誤擋', async () => {
+  it('split-meow 應使用專屬 profile，connect-src 含 jsdelivr 以允許匯率 API 請求', async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValue(
@@ -205,6 +205,21 @@ describe('security-headers worker', () => {
       );
 
     const response = await worker.fetch(new Request('https://app.haotool.org/split-meow/'));
+    const csp = response.headers.get('content-security-policy') ?? '';
+
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain('https://fonts.googleapis.com');
+    expect(csp).toContain('https://cdn.jsdelivr.net');
+  });
+
+  it('未定義專屬 profile 的 app 路徑應保留 fallback CSP，避免 legacy 遠端頭像被誤擋', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        createHtmlResponse('<!doctype html><html><head></head><body></body></html>'),
+      );
+
+    const response = await worker.fetch(new Request('https://app.haotool.org/unknown-app/'));
     const csp = response.headers.get('content-security-policy') ?? '';
 
     expect(csp).toContain("script-src 'self' 'unsafe-inline'");

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -28,7 +28,7 @@
  * - v3.6: 改用 HTMLRewriter 解析 inline script
  */
 
-const SECURITY_POLICY_VERSION = '5.2';
+const SECURITY_POLICY_VERSION = '5.3';
 const CSP_REPORT_MAX_BYTES = 16 * 1024;
 const HASHED_ASSET_PATH = /^\/(?:[^/]+\/)?assets\/[^/]+-[A-Za-z0-9_-]{6,12}\.(?:js|css|mjs)$/;
 
@@ -496,6 +496,14 @@ const QUAKE_SCHOOL_HTML_PROFILE = createHtmlProfile({
 	connectSources: [CLOUDFLARE_INSIGHTS_SCRIPT],
 });
 
+const SPLIT_MEOW_HTML_PROFILE = createHtmlProfile({
+	scriptMode: 'unsafe-inline',
+	scriptSources: [CLOUDFLARE_INSIGHTS_SCRIPT],
+	styleSources: ['https://fonts.googleapis.com'],
+	fontSources: ['https://fonts.gstatic.com'],
+	connectSources: [CLOUDFLARE_INSIGHTS_SCRIPT, 'https://cdn.jsdelivr.net'],
+});
+
 const RATEWISE_HTML_PROFILE = createHtmlProfile({
 	scriptMode: 'nonce',
 	scriptSources: ['https://static.cloudflareinsights.com', 'https://www.googletagmanager.com'],
@@ -527,6 +535,9 @@ function normalizeHtmlPath(pathname) {
 function resolveHtmlProfile(url) {
 	if (url.pathname.startsWith('/ratewise/')) {
 		return RATEWISE_HTML_PROFILE;
+	}
+	if (url.pathname.startsWith('/split-meow/')) {
+		return SPLIT_MEOW_HTML_PROFILE;
 	}
 	if (url.pathname.startsWith('/nihonname/')) {
 		return NIHONNAME_HTML_PROFILE;


### PR DESCRIPTION
## 問題

split-meow 生產環境 KRW 換算提示永遠不顯示，console 錯誤：

```
Connecting to 'https://cdn.jsdelivr.net/...' violates the following
Content Security Policy directive: "connect-src 'self' https://static.cloudflareinsights.com"
```

**根本原因**：`/split-meow/` 路徑沒有對應的 profile，落到 `FALLBACK_HTML_PROFILE`，
其 `connect-src` 不含 `cdn.jsdelivr.net`，導致 `fetchMoneyboxRate()` 被 CSP 攔截，
`krwPerTwd` 始終為 `null`，換算提示（`≈ ₩...`）永遠不渲染。

## 修復

- 新增 `SPLIT_MEOW_HTML_PROFILE`：`connect-src` 含 `cdn.jsdelivr.net` + Cloudflare analytics
  同時補齊 `styleSources` 含 Google Fonts（Material Symbols）
- `resolveHtmlProfile()` 加入 `/split-meow/` 路由規則
- `SECURITY_POLICY_VERSION` 升至 `5.3`

## 驗證

```bash
# 部署後確認 CSP header
curl -sI https://app.haotool.org/split-meow/ | grep -i content-security-policy
# 應包含 cdn.jsdelivr.net
```

## 測試

- [x] 新增 `securityHeadersWorker.test.ts` 測試 split-meow CSP 含 `cdn.jsdelivr.net`
- [x] 保留 fallback test 但改用 `/unknown-app/` 路徑（更準確）
- [x] 24/24 worker 測試通過

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)