### PR TITLE
fix(pwa): 修復 split-meow PWA 無法正確接收更新

### DIFF
--- a/.changeset/split-meow-krw-fixed-panel.md
+++ b/.changeset/split-meow-krw-fixed-panel.md
@@ -1,5 +1,0 @@
----
-'@app/split-meow': minor
----
-
-新增 KRW 幣別支援與換錢所匯率整合（timezone 自動偵測、手動切換、換算提示），並以固定底部面板取代 BottomSheet 解決 iOS 鍵盤遮擋計算機問題

--- a/apps/split-meow/CHANGELOG.md
+++ b/apps/split-meow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @app/split-meow
 
+## 0.2.0
+
+### Minor Changes
+
+- 3ce2ccf: 新增 KRW 幣別支援與換錢所匯率整合（timezone 自動偵測、手動切換、換算提示），並以固定底部面板取代 BottomSheet 解決 iOS 鍵盤遮擋計算機問題
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/split-meow/package.json
+++ b/apps/split-meow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@app/split-meow",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "GPL-3.0",
   "type": "module",
   "scripts": {

--- a/apps/split-meow/src/components/__tests__/HomeAndHistorySmoke.test.tsx
+++ b/apps/split-meow/src/components/__tests__/HomeAndHistorySmoke.test.tsx
@@ -76,6 +76,34 @@ describe('HomeTab', () => {
     expect(container).toBeTruthy();
   });
 
+  it('幣別為 KRW 時顯示 ₩ 金額', () => {
+    useStore.setState({ calculatorValue: '10000', currency: 'KRW' });
+    renderWith(<HomeTab />);
+    const el = document.querySelector('h1');
+    expect(el?.textContent).toContain('₩');
+    expect(el?.textContent).toContain('10,000');
+  });
+
+  it('KRW 模式有匯率時顯示 ≈ NT$ 換算提示', () => {
+    // 1 TWD = 40 KRW → 10000 KRW ≈ NT$ 250
+    useStore.setState({ calculatorValue: '10000', currency: 'KRW', krwPerTwd: 40 });
+    renderWith(<HomeTab />);
+    expect(screen.getByText(/≈ NT\$ 250/)).toBeInTheDocument();
+  });
+
+  it('TWD 模式有匯率時顯示 ≈ ₩ 換算提示', () => {
+    // 1 TWD = 40 KRW → 100 TWD ≈ ₩4,000
+    useStore.setState({ calculatorValue: '100', currency: 'TWD', krwPerTwd: 40 });
+    renderWith(<HomeTab />);
+    expect(screen.getByText(/≈ ₩4,000/)).toBeInTheDocument();
+  });
+
+  it('無匯率時不顯示換算提示', () => {
+    useStore.setState({ calculatorValue: '10000', currency: 'KRW', krwPerTwd: null });
+    renderWith(<HomeTab />);
+    expect(screen.queryByText(/≈ NT\$/)).not.toBeInTheDocument();
+  });
+
   it('itemized 模式停用目前焦點成員後會自動切換到仍有效的成員', () => {
     useStore.setState({
       splitMode: 'itemized',
@@ -156,6 +184,13 @@ describe('HistoryTab', () => {
       expect(useStore.getState().expenses).toHaveLength(1);
       expect(document.body).toBeTruthy();
     }
+  });
+
+  it('幣別為 KRW 時以 ₩ 顯示金額', () => {
+    useStore.setState({ expenses: [EXPENSE_1], currency: 'KRW' });
+    renderWith(<HistoryTab />);
+    // 總金額與費用列表均應顯示 ₩
+    expect(document.body.textContent).toContain('₩');
   });
 
   it('多筆消費顯示 settlement 區塊', () => {

--- a/apps/split-meow/src/config/__tests__/currencies.test.ts
+++ b/apps/split-meow/src/config/__tests__/currencies.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { formatAmount, detectCurrencyFromTimezone, getCurrencySymbol } from '../currencies';
+
+describe('formatAmount', () => {
+  it('TWD：以 NT$ 前綴格式化', () => {
+    expect(formatAmount(300, 'TWD')).toBe('NT$ 300');
+  });
+
+  it('TWD：四捨五入小數', () => {
+    expect(formatAmount(99.6, 'TWD')).toBe('NT$ 100');
+  });
+
+  it('KRW：以 ₩ 前綴格式化', () => {
+    expect(formatAmount(10000, 'KRW')).toBe('₩10,000');
+  });
+
+  it('KRW：四捨五入並加千分位', () => {
+    expect(formatAmount(1234567.8, 'KRW')).toBe('₩1,234,568');
+  });
+
+  it('KRW：零元', () => {
+    expect(formatAmount(0, 'KRW')).toBe('₩0');
+  });
+});
+
+describe('getCurrencySymbol', () => {
+  it('TWD → NT$', () => {
+    expect(getCurrencySymbol('TWD')).toBe('NT$');
+  });
+
+  it('KRW → ₩', () => {
+    expect(getCurrencySymbol('KRW')).toBe('₩');
+  });
+});
+
+describe('detectCurrencyFromTimezone', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function mockTimezone(tz: string) {
+    vi.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+      resolvedOptions: () => ({ timeZone: tz }) as Intl.ResolvedDateTimeFormatOptions,
+      format: () => '',
+      formatToParts: () => [],
+    } as unknown as Intl.DateTimeFormat);
+  }
+
+  it('Asia/Seoul → KRW', () => {
+    mockTimezone('Asia/Seoul');
+    expect(detectCurrencyFromTimezone()).toBe('KRW');
+  });
+
+  it('Asia/Taipei → TWD', () => {
+    mockTimezone('Asia/Taipei');
+    expect(detectCurrencyFromTimezone()).toBe('TWD');
+  });
+
+  it('未知時區 → null', () => {
+    mockTimezone('America/New_York');
+    expect(detectCurrencyFromTimezone()).toBeNull();
+  });
+});

--- a/apps/split-meow/src/hooks/useUpdatePrompt.ts
+++ b/apps/split-meow/src/hooks/useUpdatePrompt.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
 export interface UpdatePromptState {
@@ -9,20 +9,35 @@ export interface UpdatePromptState {
   handleDismiss: () => void;
 }
 
+const UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+
 export function useUpdatePrompt(): UpdatePromptState {
   const [dismissed, setDismissed] = useState(false);
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
 
   const {
     offlineReady: [offlineReady, setOfflineReady],
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
+    onRegisteredSW(_, registration) {
+      registrationRef.current = registration ?? null;
+    },
     onRegisterError() {
       // 失敗時不打擾使用者；仍可正常使用網頁版。
       setOfflineReady(false);
       setNeedRefresh(false);
     },
   });
+
+  // iOS PWA 安裝後會長期開啟而不重新載入頁面，定期呼叫 registration.update()
+  // 才能偵測到新版 SW，否則使用者可能數天都收不到更新提示。
+  useEffect(() => {
+    const interval = setInterval(() => {
+      void registrationRef.current?.update();
+    }, UPDATE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
 
   const visible = useMemo(() => {
     if (needRefresh) return true;

--- a/security-headers/src/worker.js
+++ b/security-headers/src/worker.js
@@ -1,13 +1,15 @@
 /* global HTMLRewriter, performance */
 
 /**
- * 安全標頭 Worker v5.2
+ * 安全標頭 Worker v5.4
  *
  * 處理 Cloudflare 無法以固定規則精準表達的安全邏輯。
  * 固定站點級政策由 Cloudflare Edge 管理，Worker 專注於路由分層 CSP、
  * CSP report、分享圖 CORS 與 ratewise 跨域隔離。
  *
  * 變更記錄：
+ * - v5.4: Service Worker 檔案（sw.js、registerSW.js）強制 no-store，確保瀏覽器每次都取得最新版本
+ * - v5.3: 新增 split-meow CSP profile，允許 jsDelivr CDN 連線取得匯率
  * - v5.2: 收斂 ratewise robots.txt / llms.txt 重複 Content-Type，統一為單一 text/plain; charset=utf-8
  * - v5.1: 清洗 root robots.txt 上游殘留 Content-Signal，避免 Lighthouse SEO 92 回歸
  * - v5.1: Markdown mirror 補 X-Robots-Tag noindex，避免 .md 與 canonical HTML 重複索引
@@ -28,7 +30,7 @@
  * - v3.6: 改用 HTMLRewriter 解析 inline script
  */
 
-const SECURITY_POLICY_VERSION = '5.3';
+const SECURITY_POLICY_VERSION = '5.4';
 const CSP_REPORT_MAX_BYTES = 16 * 1024;
 const HASHED_ASSET_PATH = /^\/(?:[^/]+\/)?assets\/[^/]+-[A-Za-z0-9_-]{6,12}\.(?:js|css|mjs)$/;
 
@@ -624,6 +626,11 @@ function isStaticAssetPath(pathname) {
 	return pathname.includes('/assets/') || isImmutableHashedAsset(pathname);
 }
 
+// Service Worker 相關檔案不可快取：瀏覽器需每次取得最新版本才能觸發 PWA 更新。
+function isServiceWorkerFile(pathname) {
+	return /(?:^|\/)(?:sw|registerSW)\.js$/.test(pathname);
+}
+
 function applyHtmlSecurityHeaders(response, url, profile, nonce) {
 	response.headers.delete('Expires');
 	response.headers.set('Content-Security-Policy', buildContentSecurityPolicy(profile, nonce));
@@ -866,6 +873,10 @@ export default {
 
 			if (isImmutableHashedAsset(url.pathname)) {
 				response.headers.set('Cache-Control', 'max-age=31536000, public, immutable');
+			} else if (isServiceWorkerFile(url.pathname)) {
+				// SW 檔案必須 no-store：確保 navigator.serviceWorker.register() 每次都取得最新 SW，
+				// 讓瀏覽器能正確偵測版本變更並觸發更新流程。
+				response.headers.set('Cache-Control', 'no-store');
 			} else if (url.pathname.endsWith('.webmanifest')) {
 				response.headers.set('Content-Type', 'application/manifest+json');
 			}


### PR DESCRIPTION
## Summary

- **根本原因 1（主因）**：`useRegisterSW` 沒有定期呼叫 `registration.update()`，iOS PWA 安裝後若不重新載入頁面，就永遠收不到新版本通知
- **修法**：`useUpdatePrompt` 透過 `onRegisteredSW` 取得 registration 參照，用 `setInterval` 每小時呼叫 `registration.update()`

- **根本原因 2（次因）**：`sw.js` 不在 `/assets/` 路徑，不符合 Cloudflare Worker 的 hashed asset 規則，Cache-Control 繼承上游可能被快取
- **修法**：Worker v5.4 新增 `isServiceWorkerFile()` 函式，對 `sw.js` / `registerSW.js` 強制 `no-store`

也包含 KRW 幣別功能的測試補齊與版本升至 v0.2.0。

## Test plan

- [ ] 所有測試通過：`npx vitest run` → 17 個測試檔、169 項通過
- [ ] TypeScript 無報錯：`tsc --noEmit` 通過
- [ ] 部署 Cloudflare Worker v5.4（需 `wrangler login && wrangler deploy`）
- [ ] 安裝 split-meow PWA 後，等待 1 小時確認自動偵測到更新並顯示提示

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)