### PR TITLE
fix(ci): E2E Playwright 快取與 timeout 防護

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
     name: E2E Tests
     needs: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -168,6 +169,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter @app/ratewise exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
       - name: Build
         env:
           VITE_RATEWISE_BASE_PATH: '/'
@@ -175,7 +187,14 @@ jobs:
         run: pnpm build:ratewise
 
       - name: Install Playwright browsers
-        run: pnpm --filter @app/ratewise exec playwright install --with-deps chromium firefox
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        env:
+          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
+        run: pnpm --filter @app/ratewise exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @app/ratewise exec playwright install-deps chromium
 
       - name: Start preview server
         env:


### PR DESCRIPTION
## Summary
- E2E job 加入 `timeout-minutes: 15`，避免 Playwright CDN 下載卡住時等待 6 小時（預設值）
- 快取 `~/.cache/ms-playwright`，cache hit 時跳過瀏覽器下載，只安裝系統依賴
- 只安裝 chromium（CI 只跑 `chromium-desktop` 和 `chromium-mobile`，不需要 firefox）
- 設定 `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000` 延長連線超時

## Context
PR #415 的 E2E Tests 連續 3 次因 `playwright install` 下載 chromium 從 `cdn.playwright.dev` 超時（每次卡 14+ 分鐘）而被 cancel。根因是 GitHub runner 到 Playwright CDN 的網路不穩定。

## Test plan
- [ ] CI E2E job 在 15 分鐘內完成或被 timeout 正確終止
- [ ] 首次 run 後 Playwright 瀏覽器被快取
- [ ] 後續 run cache hit 時跳過下載，只安裝系統依賴

🤖 Generated with [Claude Code](https://claude.ai/code)