### PR TITLE
ci(e2e): 加速 PR E2E 並分層 Playwright 快取

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,39 @@
+name: Setup Playwright Chromium
+description: 快取並安裝 Playwright Chromium（分層 cache-hit 僅裝 OS deps）
+
+inputs:
+  app-filter:
+    description: pnpm filter（例如 @app/ratewise）
+    required: true
+    default: '@app/ratewise'
+
+runs:
+  using: composite
+  steps:
+    - name: Get Playwright version
+      id: pw-version
+      shell: bash
+      run: |
+        version=$(pnpm --filter "${{ inputs.app-filter }}" exec playwright --version | awk '{print $2}')
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: pw-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+        restore-keys: |
+          playwright-chromium-${{ runner.os }}-
+
+    - name: Install Playwright browsers
+      if: steps.pw-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
+      run: pnpm --filter "${{ inputs.app-filter }}" exec playwright install --with-deps chromium
+
+    - name: Install Playwright system deps
+      if: steps.pw-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: pnpm --filter "${{ inputs.app-filter }}" exec playwright install-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     name: E2E Tests
     needs: quality
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,18 @@ name: CI
 # 完整核心 CI Pipeline
 # 功能: lint / format / typecheck / test / build / security / e2e
 #
-# 更新時間: 2026-01-29
-# 依據: [CLAUDE.md:CI/CD 品質門檻][GitHub Actions Best Practices 2025]
+# 更新時間: 2026-06-26
+# 依據: [CLAUDE.md:CI/CD 品質門檻][Playwright CI docs][GitHub Actions Best Practices 2025]
 
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -141,13 +145,40 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # NOTE: E2E tests currently target ratewise only.
-  # To add other apps, convert to a matrix strategy with app-specific config.
-  e2e:
-    name: E2E Tests
-    needs: quality
+  # E2E path filter：PR 僅在 ratewise/nihonname/shared 或 lockfile 變更時執行。
+  e2e-filter:
+    name: E2E Path Filter
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Detect E2E-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'apps/ratewise/**'
+              - 'apps/nihonname/**'
+              - 'apps/shared/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/setup-playwright/**'
+
+  # PR：核心 smoke（desktop 單專案 + 3 個核心 spec），預估 5–8 分鐘。
+  e2e-smoke:
+    name: E2E Smoke (PR)
+    needs: [quality, e2e-filter]
+    if: |
+      needs.quality.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      needs.e2e-filter.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -169,16 +200,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(pnpm --filter @app/ratewise exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
+      - name: Setup Playwright Chromium
+        uses: ./.github/actions/setup-playwright
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+          app-filter: '@app/ratewise'
 
       - name: Build
         env:
@@ -186,23 +211,13 @@ jobs:
           RATING_API_URL: ${{ secrets.RATING_API_URL }}
         run: pnpm build:ratewise
 
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        env:
-          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
-        run: pnpm --filter @app/ratewise exec playwright install --with-deps chromium
-
-      - name: Install Playwright system deps
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @app/ratewise exec playwright install-deps chromium
-
       - name: Start preview server
         env:
           VITE_RATEWISE_BASE_PATH: '/'
         run: |
           pnpm --filter @app/ratewise preview --host 0.0.0.0 --port 4173 --strictPort &
           echo $! > .preview-server.pid
-          for i in {1..10}; do
+          for i in {1..15}; do
             if curl --silent --fail http://127.0.0.1:4173 > /dev/null; then
               exit 0
             fi
@@ -211,12 +226,17 @@ jobs:
           echo "Preview server failed to start"
           exit 1
 
-      - name: Run E2E tests
+      - name: Run E2E smoke tests
         env:
           CI: true
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:4173
           E2E_BASE_PATH: '/'
-        run: pnpm --filter @app/ratewise exec playwright test --project=chromium-desktop --project=chromium-mobile
+        run: |
+          pnpm --filter @app/ratewise exec playwright test \
+            tests/e2e/ratewise.spec.ts \
+            tests/e2e/calculator-fix-verification.spec.ts \
+            tests/e2e/mobile-parity.spec.ts \
+            --project=chromium-desktop
 
       - name: Stop preview server
         if: always()
@@ -230,9 +250,147 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
+          name: playwright-report-smoke
           path: apps/ratewise/playwright-report
           retention-days: 7
+
+  # main / workflow_dispatch：完整 E2E，2-way sharding + blob merge。
+  e2e-full:
+    name: E2E Full (${{ matrix.shard }}/2)
+    needs: [quality, e2e-filter]
+    if: |
+      needs.quality.result == 'success' &&
+      github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [1, 2]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Playwright Chromium
+        uses: ./.github/actions/setup-playwright
+        with:
+          app-filter: '@app/ratewise'
+
+      - name: Build
+        env:
+          VITE_RATEWISE_BASE_PATH: '/'
+          RATING_API_URL: ${{ secrets.RATING_API_URL }}
+        run: pnpm build:ratewise
+
+      - name: Start preview server
+        env:
+          VITE_RATEWISE_BASE_PATH: '/'
+        run: |
+          pnpm --filter @app/ratewise preview --host 0.0.0.0 --port 4173 --strictPort &
+          echo $! > .preview-server.pid
+          for i in {1..15}; do
+            if curl --silent --fail http://127.0.0.1:4173 > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Preview server failed to start"
+          exit 1
+
+      - name: Run E2E tests (shard ${{ matrix.shard }}/2)
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:4173
+          E2E_BASE_PATH: '/'
+        run: |
+          pnpm --filter @app/ratewise exec playwright test \
+            --project=chromium-desktop \
+            --project=chromium-mobile \
+            --shard=${{ matrix.shard }}/2 \
+            --reporter=blob \
+            --reporter=github \
+            --reporter=list
+
+      - name: Stop preview server
+        if: always()
+        run: |
+          if [ -f .preview-server.pid ]; then
+            kill "$(cat .preview-server.pid)" || true
+            rm .preview-server.pid
+          fi
+
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: apps/ratewise/blob-report
+          retention-days: 1
+
+  e2e-merge-reports:
+    name: E2E Merge Reports
+    needs: e2e-full
+    if: ${{ always() && !cancelled() && needs.e2e-full.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge Playwright reports
+        run: pnpm --filter @app/ratewise exec playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-merged
+          path: apps/ratewise/playwright-report
+          retention-days: 7
+
+      - name: Propagate shard failures
+        if: needs.e2e-full.result != 'success'
+        run: exit 1
 
   lighthouse:
     name: Lighthouse CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ Agent **必須**先完成：
 3. `pnpm build:ratewise`
 
 - E2E / coverage / Lighthouse 由 CI 執行（本地 pre-push 不做完整長時間檢查）
+- PR CI E2E 為 smoke 子集（3 核心 spec × desktop）；main push 為 sharded 完整套件（見 `docs/dev/039_ci_e2e_speed_optimization.md`）
 
 ## Commit Format（commitlint SSOT）
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -13,6 +13,11 @@
 
 ## 條目（新→舊）
 
+- 日期：2026-06-26
+- ID：reward-ci-e2e-timeout-30
+- 原因：E2E job timeout-minutes 15 不足，Playwright 冷快取安裝階段遭 GitHub Actions 取消
+- 解法：ci.yml E2E job timeout 調整為 30 分鐘
+
 - 日期：2026-05-15
 - ID：reward-ratewise-moneybox-aggregate-trend
 - 原因：換錢所（KRW/MoneyBox）趨勢線在生產環境每次載入觸發 30 個 daily fetch，且大多數 ~30 天前的日檔 404，與台銀 history-30d.json aggregate SSOT 飄移

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1）｜累計總分：前次總分 +54
+> 本次分數變化：+1（reward 1）｜累計總分：前次總分 +55
 
 ## 新增模板（4 行）
 
@@ -14,9 +14,14 @@
 ## 條目（新→舊）
 
 - 日期：2026-06-26
+- ID：reward-ci-e2e-speed-optimization
+- 原因：PR E2E 每次跑完整 96 測試 + 冷 Playwright 安裝，常超過 15 分鐘且 docs-only PR 也觸發
+- 解法：path filter + Playwright 分層快取 composite action + PR smoke（38 desktop tests）+ main 2-way sharding 與 merge-reports
+
+- 日期：2026-06-26
 - ID：reward-ci-e2e-timeout-30
 - 原因：E2E job timeout-minutes 15 不足，Playwright 冷快取安裝階段遭 GitHub Actions 取消
-- 解法：ci.yml E2E job timeout 調整為 30 分鐘
+- 解法：ci.yml E2E job timeout 調整為 30 分鐘（已由 e2e-speed-optimization 取代為 smoke 15 / full 20 min）
 
 - 日期：2026-05-15
 - ID：reward-ratewise-moneybox-aggregate-trend

--- a/docs/dev/039_ci_e2e_speed_optimization.md
+++ b/docs/dev/039_ci_e2e_speed_optimization.md
@@ -1,0 +1,42 @@
+# CI E2E 速度優化（039）
+
+## 文件控制
+
+| 欄位     | 內容                       |
+| -------- | -------------------------- |
+| 建立日期 | 2026-06-26                 |
+| 狀態     | Active                     |
+| SSOT     | `.github/workflows/ci.yml` |
+
+## 背景
+
+PR CI 的 E2E job 原先每次執行完整 96 測試（desktop + mobile），含 Playwright 冷快取安裝時常超過 15 分鐘。`pre-push` hook 刻意不跑 E2E（見 `AGENTS.md` AGT-PP-01），因此 CI 是唯一自動化 E2E 閘門，必須在速度與覆蓋率間取得平衡。
+
+## 策略摘要
+
+| 情境                          | Job                        | 測試範圍                                   | 預估時間                     |
+| ----------------------------- | -------------------------- | ------------------------------------------ | ---------------------------- |
+| PR（無 E2E 相關變更）         | 跳過                       | —                                          | 0 min                        |
+| PR（有 E2E 相關變更）         | `E2E Smoke (PR)`           | 3 核心 spec × desktop（~38 tests）         | 5–8 min                      |
+| main push / workflow_dispatch | `E2E Full (1/2)` + `(2/2)` | desktop + mobile，2-way shard（~96 tests） | 6–10 min（wall clock，並行） |
+
+## 實作要點
+
+1. **Path filter**（`dorny/paths-filter@v3`）：僅在 `apps/ratewise/**`、`apps/nihonname/**`、`apps/shared/**`、`pnpm-lock.yaml`、`package.json`、CI workflow 變更時於 PR 觸發 E2E。
+2. **Playwright 分層快取**（`.github/actions/setup-playwright`）：cache key 含 Playwright 版本 + OS；cache miss 跑 `install --with-deps chromium`；cache hit 僅 `install-deps chromium`。
+3. **PR smoke**：`ratewise.spec.ts`、`calculator-fix-verification.spec.ts`、`mobile-parity.spec.ts`，僅 `chromium-desktop`。
+4. **main 完整套件 + sharding**：`--shard=1/2` 與 `--shard=2/2`，blob reporter + `merge-reports` 合併 HTML。
+5. **Concurrency**：`cancel-in-progress: false`，避免同一 PR 反覆 push 造成 cancel loop。
+
+## 外部依據
+
+- [Playwright CI 官方文件](https://playwright.dev/docs/ci)
+- [Playwright Sharding](https://playwright.dev/docs/test-sharding)
+- [Playwright 瀏覽器快取建議](https://playwright.dev/docs/ci#caching-browsers)
+- [dorny/paths-filter](https://github.com/dorny/paths-filter)
+
+## 驗收
+
+- docs-only PR 不觸發 E2E job。
+- ratewise 功能 PR 觸發 smoke，時間 < 15 min。
+- main push 執行 sharded full suite，merge job 產出合併 HTML report。


### PR DESCRIPTION
## Summary

- **Path filter**：PR 僅在 `apps/ratewise/**`、`apps/nihonname/**`、`apps/shared/**`、`pnpm-lock.yaml`、`package.json` 或 CI workflow 變更時執行 E2E；docs-only PR 完全跳過（0 min）。
- **PR smoke**：3 核心 spec（`ratewise`、`calculator-fix-verification`、`mobile-parity`）× `chromium-desktop`（~38 tests，預估 **5–8 min**）。
- **main 完整套件**：2-way sharding + blob `merge-reports`（~96 tests，wall clock **6–10 min** 並行）。
- **Playwright 分層快取**：新增 `.github/actions/setup-playwright` composite action（cache miss → `install --with-deps chromium`；cache hit → `install-deps` only）。
- **Concurrency**：`cancel-in-progress: false`，避免同一 PR 反覆 push 造成 cancel loop。

## Before / After 時間估算

| 情境 | 改前 | 改後 |
|------|------|------|
| docs-only PR | ~12–20 min（完整 E2E） | **0 min**（跳過） |
| ratewise 功能 PR | ~12–20 min（96 tests × 2 projects） | **5–8 min**（38 smoke tests × desktop） |
| main push | ~12–20 min（單 job 序列） | **6–10 min**（2 shard 並行） |
| Playwright 冷快取 | ~3–5 min `--with-deps` | cache hit **~30 s** `install-deps` |

## 參考來源

- [Playwright CI 官方文件](https://playwright.dev/docs/ci)
- [Playwright Sharding](https://playwright.dev/docs/test-sharding)
- [Playwright 瀏覽器快取建議](https://playwright.dev/docs/ci#caching-browsers)
- [dorny/paths-filter](https://github.com/dorny/paths-filter)
- [Argos: Speed up Playwright tests](https://argos-ci.com/blog/speed-up-playwright)

## 文件

- `docs/dev/039_ci_e2e_speed_optimization.md`（策略 SSOT）
- `AGENTS.md` pre-push 章節補充 PR smoke vs main full 語意

## 注意事項

- Branch protection 若綁定舊 check 名稱 `E2E Tests`，需改為 `E2E Smoke (PR)`（PR）或 `E2E Full (1/2)` / `E2E Full (2/2)` + `E2E Merge Reports`（main）。

## Test plan

- [ ] docs-only PR 確認 E2E jobs skipped
- [ ] ratewise 功能 PR 確認 `E2E Smoke (PR)` 通過且 < 15 min
- [ ] merge 後 main push 確認 sharded full suite + merged HTML report
- [ ] Playwright cache hit 第二次 run 明顯縮短 install 步驟


Made with [Cursor](https://cursor.com)