### PR TITLE
fix(ci): Playwright 快取 action 升級 actions/cache@v6

### DIFF
--- a/.changeset/ci-playwright-cache-v6.md
+++ b/.changeset/ci-playwright-cache-v6.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+CI Playwright 快取 action 升級至 actions/cache@v6，消除 Node 20 deprecation warning；僅 CI 基礎設施變更，使用者無可見影響。

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: pw-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-chromium-${{ runner.os }}-${{ steps.pw-version.outputs.version }}

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+2（reward 2、penalty 0）｜累計總分：+68
+> 本次分數變化：+1（reward 1、penalty 0）｜累計總分：+69
 
 ## 新增模板（4 行）
 
@@ -22,6 +22,11 @@
 - ID：reward-pr426-sw-bounded-nav-case3-002-audit
 - 原因：PR 426 review P1 指出 SW case-3 有界網路 fallback 與測試 lint 修改的 commit 未含 002 稽核軌跡；該功能已隨 #433 生產治理進 main，但稽核條目隨被取代的 #411 分支遺失。
 - 解法：補本條目搶救稽核軌跡；SW case-3 setCatchHandler 有界 fallback 本體已於 #433 收斂進 main。
+
+- 日期：2026-06-26
+- ID：reward-ci-playwright-cache-v6
+- 原因：setup-playwright composite action 仍用 actions/cache@v4，在 Node 24 CI 觸發 Node 20 deprecation warning
+- 解法：升級 actions/cache@v6 並補 patch changeset
 
 - 日期：2026-06-26
 - ID：reward-pr435-code-reviewer-hardening


### PR DESCRIPTION
## Summary
- `setup-playwright` composite action：`actions/cache@v4` → `@v6`
- 消除 Node 24 CI workflow 的 Node 20 JavaScript action deprecation warning
- patch changeset + 002 條目

## Test plan
- [x] `python3 yaml.safe_load` 驗證 action.yml
- [x] pre-commit 002 / changeset 已更新
- [ ] CI Quality Checks 通過

Made with [Cursor](https://cursor.com)