### PR TITLE
fix(ci): MoneyBox history 改用 Asia/Seoul 日期 SSOT

### DIFF
--- a/.github/workflows/update-moneybox-rates.yml
+++ b/.github/workflows/update-moneybox-rates.yml
@@ -94,7 +94,7 @@ jobs:
         id: save-history
         if: steps.fetch-rates.outcome == 'success'
         run: |
-          CURRENT_DATE=$(TZ=Asia/Taipei date +%Y-%m-%d)
+          CURRENT_DATE=$(TZ=Asia/Seoul date +%Y-%m-%d)
           MONEYBOX_HISTORY_FILE="${MONEYBOX_HISTORY_DIR}/${CURRENT_DATE}.json"
           mkdir -p "$MONEYBOX_HISTORY_DIR"
           if [[ ! -f "$MONEYBOX_FETCH_OUTPUT_FILE" ]]; then

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+3（reward 3、penalty 0）｜累計總分：+62
+> 本次分數變化：+1（reward 1、penalty 0）｜累計總分：+63
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-26
+- ID：reward-moneybox-seoul-date-ssot
+- 原因：MoneyBox workflow 用 Asia/Taipei 產生 history 檔名，首爾午夜換日時會把新日資料寫入前一日 history
+- 解法：update-moneybox-rates.yml Save history 步驟改 TZ=Asia/Seoul 對齊 fetch-moneybox-rates.js SSOT
 
 - 日期：2026-06-26
 - ID：neutral-002-score-header-correction-pr425


### PR DESCRIPTION
## Summary
- `update-moneybox-rates.yml` Save history 步驟 `CURRENT_DATE` 由 `Asia/Taipei` 改為 `Asia/Seoul`
- 對齊 `fetch-moneybox-rates.js` 與 Codex P2 review（#411 review #1）：避免 UTC 15:00–15:59 首爾換日時 history 檔名錯標

## Context
PR #425 已合併 P0 PWA/ETag 修復；本 PR 為 #411 收斂 follow-up，**不整包合併 #411**。

## Test plan
- [ ] CI Quality Checks 通過（workflow-only 變更）
- [ ] 下次 MoneyBox 排程執行後確認 history 檔名日期與 Seoul updateTime 一致

Made with [Cursor](https://cursor.com)