### PR TITLE
chore(ops): 重觸正式站 Zeabur 部署 2.25.2

### DIFF
--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+3（reward 3、penalty 0）｜累計總分：+62
+> 本次分數變化：0（reward 0、penalty 0）｜累計總分：+62
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-26
+- ID：neutral-retrigger-prod-deploy-2252
+- 原因：Release run 28213399513 Zeabur GitHub deployment 回報 success（2306994）但 Zeabur RUNNING pod 仍為 6/25 舊版，正式站 app-version 卡 2.25.1
+- 解法：最小 PR 重觸 main push 促使 Zeabur 重新部署 2.25.2，版本切換後手動 CF purge 與 live precache 驗證
 
 - 日期：2026-06-26
 - ID：neutral-002-score-header-correction-pr425


### PR DESCRIPTION
## Summary
- Release run 28213399513 因正式站 app-version 卡在 2.25.1 而 timeout
- GitHub deployment 5204853286（SHA 2306994）回報 success，但 Zeabur RUNNING pod 仍為 6/25 舊版（deployment `6a3d7609`）
- 最小 002 neutral 條目重觸 main push，促使 Zeabur 重新 build/deploy 2.25.2

## Test plan
- [ ] 合併後確認 Zeabur 新 deployment 狀態為 RUNNING
- [ ] `curl` 正式站 `app-version` meta 為 2.25.2
- [ ] 手動 CF purge（見 002 條目）後跑 live precache 驗證
- [ ] **不** rerun release run 28213399513（避免 re-tag）


Made with [Cursor](https://cursor.com)