### PR TITLE
ci(e2e): 修復 Playwright setup 掛起並加 timeout

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,5 +1,5 @@
 name: Setup Playwright Chromium
-description: 快取並安裝 Playwright Chromium（分層 cache-hit 僅裝 OS deps）
+description: 快取並安裝 Playwright Chromium（瀏覽器下載與 OS deps 拆分並加 timeout，避免掛起燒滿 job 逾時）
 
 inputs:
   app-filter:
@@ -26,14 +26,18 @@ runs:
         restore-keys: |
           playwright-chromium-${{ runner.os }}-
 
-    - name: Install Playwright browsers
+    # 僅在 cache miss 時下載瀏覽器；以 timeout 防止下載卡死燒滿 job 逾時。
+    - name: Install Playwright browser (Chromium)
       if: steps.pw-cache.outputs.cache-hit != 'true'
       shell: bash
       env:
         PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
-      run: pnpm --filter "${{ inputs.app-filter }}" exec playwright install --with-deps chromium
+      run: timeout 600 pnpm --filter "${{ inputs.app-filter }}" exec playwright install chromium
 
-    - name: Install Playwright system deps
-      if: steps.pw-cache.outputs.cache-hit == 'true'
+    # OS 相依套件不在 cache 內，cache hit/miss 皆需安裝。
+    # 與瀏覽器下載拆開並加 timeout，避免 apt lock/網路問題無限掛起。
+    - name: Install Playwright system deps (Chromium)
       shell: bash
-      run: pnpm --filter "${{ inputs.app-filter }}" exec playwright install-deps chromium
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: timeout 300 pnpm --filter "${{ inputs.app-filter }}" exec playwright install-deps chromium


### PR DESCRIPTION
## 摘要

修復 E2E Smoke / E2E Full 在 **Setup Playwright Chromium** 步驟掛起、燒滿 30 分鐘 job timeout 的 CI infra 問題。

## 背景 / 證據

PR #430 的 E2E Smoke 連續兩次都卡在 `playwright install --with-deps chromium`，跑滿 30 分鐘被取消（`Build` / `Run E2E smoke tests` 從未執行）。根因：`--with-deps` 內含 `apt-get` OS 套件安裝，**無 timeout**，遇 apt lock / 網路問題會無限掛起；既有的 `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` 只管瀏覽器下載連線，管不到 apt。

## 變更內容

`.github/actions/setup-playwright/action.yml`：

- 將 `playwright install --with-deps chromium` **拆成兩步**：瀏覽器下載 + OS deps。
- 瀏覽器下載（僅 cache miss）以 `timeout 600` 包裹。
- OS deps 改為 cache hit/miss **皆執行**（OS 套件不在 cache 內），以 `timeout 300` + `DEBIAN_FRONTEND=noninteractive` 防掛起。

任一步驟卡住會在數分鐘內**快速失敗**，而非燒滿 job 逾時。

## 影響範圍

僅 CI 設定，無 app / runtime 變更。`@app/ratewise` E2E job 兩處 `setup-playwright` 引用皆受惠。

## Test plan

- [x] `action.yml` YAML 靜態驗證通過
- [ ] 本 PR 的 E2E Smoke 應在 setup 步驟正常完成（不再 30 分鐘 timeout）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
