### PR TITLE
ci(playwright): 升級 Playwright browser cache 至 actions/cache@v6

### DIFF
--- a/.changeset/converge-ci-playwright-cache-v6.md
+++ b/.changeset/converge-ci-playwright-cache-v6.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+CI Playwright 快取 action 升級至 actions/cache@v6，消除 Node 20 deprecation warning；僅 CI 基礎設施變更，使用者無可見影響。

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: pw-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-chromium-${{ runner.os }}-${{ steps.pw-version.outputs.version }}


### PR DESCRIPTION
## 摘要
Playwright 快取 action `actions/cache@v4 → @v6`，消除 Node 20 deprecation warning。

## 變更
- `.github/actions/setup-playwright/action.yml` 單行升級
- v6.0.0（2026-06-23）為當前 Node24 相容 major，input 無遷移

## 注意
- Base 為 `governance-v2`（stacked PR）
- changeset: @app/ratewise patch（純 CI，使用者無感）

🤖 Generated with [Claude Code](https://claude.com/claude-code)