### PR TITLE
fix(ratewise): 修復冷啟動未還原單/多幣別模式與強化 PWA https 啟動

### DIFF
--- a/.changeset/hotfix-pwa-coldstart-view-https.md
+++ b/.changeset/hotfix-pwa-coldstart-view-https.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復冷啟動時未還原上次停留的單/多幣別換算模式（hydrate 前偏好被預設值覆寫的競態）；PWA manifest 改用絕對 HTTPS start_url，降低獨立啟動情境下的安全連線警告。

--- a/apps/ratewise/public/manifest.webmanifest
+++ b/apps/ratewise/public/manifest.webmanifest
@@ -6,7 +6,7 @@
   "background_color": "#E8ECF4",
   "display": "standalone",
   "scope": "/ratewise/",
-  "start_url": "/ratewise/",
+  "start_url": "https://app.haotool.org/ratewise/",
   "id": "/ratewise/",
   "orientation": "portrait-primary",
   "categories": [

--- a/apps/ratewise/scripts/generate-manifest.mjs
+++ b/apps/ratewise/scripts/generate-manifest.mjs
@@ -25,7 +25,9 @@ const manifest = {
   background_color: '#E8ECF4',
   display: 'standalone',
   scope: '/ratewise/',
-  start_url: '/ratewise/',
+  // 絕對 HTTPS start_url：避免獨立 PWA partition + Chrome HTTPS-First 在啟動時以 http 語意解析。
+  // id/scope 維持相對（id 變更會被視為新 PWA 身分，破壞既有安裝更新連續性）。
+  start_url: APP_INFO.siteUrl,
   id: '/ratewise/',
   orientation: 'portrait-primary',
   categories: ['finance', 'utilities', 'productivity'],

--- a/apps/ratewise/src/features/ratewise/RateWise.tsx
+++ b/apps/ratewise/src/features/ratewise/RateWise.tsx
@@ -35,12 +35,15 @@ import {
   resolveRateTypeByAvailability,
 } from '../../utils/exchangeRateCalculation';
 
-const RateWise = () => {
+const RateWise = ({ rememberConverterView = true }: { rememberConverterView?: boolean } = {}) => {
   const [searchParams] = useSearchParams();
   // deep-link（分享連結帶 from/to/amount）只是臨時進入，不應覆寫上次停留模式偏好。
   const isDeepLink =
     searchParams.has('from') || searchParams.has('to') || searchParams.has('amount');
-  useRememberConverterView(DEFAULT_CONVERTER_MODE, { enabled: !isDeepLink });
+  // 還原決策完成前（hydrate 中或將導向 multi）不得寫入，否則會把 persist 的 multi 覆寫成 single。
+  useRememberConverterView(DEFAULT_CONVERTER_MODE, {
+    enabled: !isDeepLink && rememberConverterView,
+  });
   const { t } = useTranslation();
   // Main container ref for pull-to-refresh
   const mainRef = useRef<HTMLDivElement>(null);

--- a/apps/ratewise/src/features/ratewise/components/RememberedHomeRoute.tsx
+++ b/apps/ratewise/src/features/ratewise/components/RememberedHomeRoute.tsx
@@ -29,6 +29,8 @@ export function RememberedHomeRoute() {
   const hasDeepLink =
     searchParams.has('from') || searchParams.has('to') || searchParams.has('amount');
   const restoreToMulti = shouldRestoreToMulti({ hydrated, hasDeepLink, lastConverterView });
+  // hydrate 未完成或即將導向 multi 時，禁止 RateWise 寫入偏好，避免覆寫 persist 的 lastConverterView。
+  const allowRememberView = hydrated && !restoreToMulti;
 
   // hydrate 完成後標記已嘗試還原，確保冷啟動只導向一次。
   useEffect(() => {
@@ -41,5 +43,5 @@ export function RememberedHomeRoute() {
     return <Navigate to="/multi" replace />;
   }
 
-  return <RateWise />;
+  return <RateWise rememberConverterView={allowRememberView} />;
 }

--- a/apps/ratewise/src/features/ratewise/components/__tests__/RememberedHomeRoute.test.tsx
+++ b/apps/ratewise/src/features/ratewise/components/__tests__/RememberedHomeRoute.test.tsx
@@ -9,7 +9,11 @@ import { __resetColdStartRestoreForTests, markRestoreAttempted } from '../coldSt
 import { useConverterStore } from '../../../../stores/converterStore';
 
 vi.mock('../../RateWise', () => ({
-  default: () => <div data-testid="ratewise-single">Single</div>,
+  default: ({ rememberConverterView = true }: { rememberConverterView?: boolean }) => (
+    <div data-testid="ratewise-single" data-remember={String(rememberConverterView)}>
+      Single
+    </div>
+  ),
 }));
 
 const MultiMarker = () => <div data-testid="multi-page">Multi</div>;
@@ -53,6 +57,16 @@ describe('RememberedHomeRoute', () => {
 
     expect(await screen.findByTestId('ratewise-single')).toBeInTheDocument();
     expect(screen.queryByTestId('multi-page')).not.toBeInTheDocument();
+  });
+
+  it('停留 single 還原決策完成後才允許 RateWise 寫入偏好（rememberConverterView=true）', async () => {
+    vi.spyOn(useConverterStore.persist, 'hasHydrated').mockReturnValue(true);
+    useConverterStore.setState({ lastConverterView: 'single' });
+
+    renderHome('/');
+
+    // 還原決策完成（hydrated 且不導向 multi）後才開放寫入，避免覆寫 persist 的 lastConverterView。
+    expect(await screen.findByTestId('ratewise-single')).toHaveAttribute('data-remember', 'true');
   });
 
   it('deep-link query 存在時不導向，即使 lastConverterView=multi', async () => {


### PR DESCRIPTION
## P0 Hotfix — PWA 冷啟動問題

依使用者回報的三個冷啟動症狀，分派 3 個 Cursor 子代理（read-only 調查）+ 主代理綜合根因後做業界最佳實踐 hotfix。

### 症狀 1：未還原上次單/多幣別頁面（根因確定，本 PR 修復）
- **根因**：`RememberedHomeRoute` 在 persist hydrate 完成前就掛載 `RateWise`，`useRememberConverterView` 把預設 `single` 寫入 persist，覆寫了儲存的 `multi`，導致還原 `/multi` 的導向永不觸發（microtask 只是緩解非解法）。
- **修法**：新增 `rememberConverterView` prop，於 `hydrated && !restoreToMulti` 才開放寫入；補 prop 契約測試。

### 症狀 2：HTTPS-First 攔截頁「此連線並不安全」（強化）
- **查證**：production 邊緣設定正確（HSTS `max-age=31536000; preload`、http→https 301 至 https）。攔截為間斷性，最符合相對 `start_url` 在獨立 PWA partition + 慢網路下 HTTPS 升級逾時。
- **修法（defense-in-depth）**：manifest `start_url` 改絕對 HTTPS；`id`/`scope` 維持相對（避免 PWA 身分變更破壞既有安裝）。

### 症狀 3：載入慢（本 PR 不含，故意延後）
- 調查發現 `recacheCriticalResourcesOnLaunch` 對 `./`/`offline.html`/`manifest`（非 hashed）用 `cache:'reload'` 與首屏競爭頻寬。但這些是 mutable 資源，改快取模式有**版本撕裂**風險 → 需獨立 PR + E2E 驗證，不在本快速 hotfix 強行處理。

## 驗證
- typecheck ✓ · vitest 169 tests ✓（RememberedHomeRoute/converterStore/coldStartRestore/build-scripts）
- pre-push 全綠（typecheck + test + build）· manifest diff 僅 start_url 一行

## 版本
- changeset patch → 合併後 release 自動升版 + Zeabur 部署

🤖 Generated with [Claude Code](https://claude.com/claude-code)