### PR TITLE
feat(ratewise): Epic 3 E3-T2–T5 內容 distill

### DIFF
--- a/.changeset/epic3-content-distill.md
+++ b/.changeset/epic3-content-distill.md
@@ -3,3 +3,4 @@
 ---
 
 幣別 landing 新增首屏匯率 strip 與金額化快速答案；首頁 SEO 區塊精簡；FAQ 改四類分組。
+Rebase 後 Prettier 對齊。

--- a/.changeset/epic3-content-distill.md
+++ b/.changeset/epic3-content-distill.md
@@ -2,4 +2,4 @@
 '@app/ratewise': patch
 ---
 
-幣別 landing 頁收斂賣出價論述重複，SEO 文案更精煉。
+幣別 landing 新增首屏匯率 strip 與金額化快速答案；首頁 SEO 區塊精簡；FAQ 改四類分組。

--- a/apps/ratewise/src/components/CurrencyLandingPage.tsx
+++ b/apps/ratewise/src/components/CurrencyLandingPage.tsx
@@ -11,6 +11,7 @@ import { SEO_RATE_EXAMPLES, SEO_RATE_EXAMPLES_DATE } from '../config/generated/s
 import type { AlternativeProvider } from '../config/generated/seo-rate-examples';
 import { APP_INFO, getCopyrightNotice } from '../config/app-info';
 import {
+  buildAmountAnswerCapsule,
   buildAmountExchangeRateSpecificationJsonLd,
   buildRateDifferenceSentence,
   getDefaultExampleAmount,
@@ -118,6 +119,14 @@ export function CurrencyLandingPage({
   });
 
   const formatNum = (n: number) => n.toLocaleString('zh-TW');
+
+  const landingDirection = isTwdToForeign ? 'twd-to-foreign' : 'to-twd';
+  const resolvedAnswerCapsule =
+    amount !== null && cashSell !== null
+      ? buildAmountAnswerCapsule(amount, currencyCode, currencyName, landingDirection)
+      : answerCapsule;
+  const exampleForeignAmount = getDefaultExampleAmount(currencyCode);
+  const exampleTwdResult = cashSell !== null ? Math.round(exampleForeignAmount * cashSell) : null;
 
   // 換算器 CTA 深連結格式：/?amount=X&from=CODE&to=TWD（或反向）。
   const converterHref =
@@ -241,8 +250,39 @@ export function CurrencyLandingPage({
             </div>
           </header>
 
+          {cashSell !== null && (
+            <section
+              aria-label="即時匯率"
+              className="mb-6 sm:mb-8"
+              data-testid="landing-rate-strip"
+            >
+              <div className="card p-4 sm:p-5 border border-primary/20 bg-surface">
+                <p className="text-[10px] font-black uppercase tracking-[0.18em] text-primary/70 mb-2">
+                  台銀現金賣出 · {SEO_RATE_EXAMPLES_DATE}
+                </p>
+                <p className="text-3xl sm:text-4xl font-black tabular-nums text-text leading-none">
+                  1 {currencyCode} = {cashSell} TWD
+                </p>
+                {exampleTwdResult !== null && amount === null && (
+                  <p className="mt-2 text-sm text-text-muted tabular-nums">
+                    {isTwdToForeign
+                      ? `例：${formatNum(exampleForeignAmount)} TWD ≈ ${formatNum(Math.round(exampleForeignAmount / cashSell))} ${currencyCode}`
+                      : `例：${formatNum(exampleForeignAmount)} ${currencyCode} ≈ ${formatNum(exampleTwdResult)} TWD`}
+                  </p>
+                )}
+                <Link
+                  to={converterHref}
+                  className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-primary/80"
+                >
+                  在換算器輸入金額
+                  <ArrowLeft className="w-4 h-4 rotate-180" />
+                </Link>
+              </div>
+            </section>
+          )}
+
           {/* AEO/GEO 快速答案：AI 引擎直接引用的問答對，顯示在頁面頂部提升引用率。 */}
-          <AnswerCapsule items={answerCapsule} />
+          <AnswerCapsule items={resolvedAnswerCapsule} />
 
           {/* 金額換算結果卡（Wise-pattern）：?amount=X 存在時顯示靜態換算結果，爬蟲可索引。 */}
           {amount !== null && amountResult !== null && cashSell !== null && (
@@ -281,17 +321,22 @@ export function CurrencyLandingPage({
             </section>
           )}
 
-          {/* 精準換匯：唯一正文論述區塊（SSOT 來自 seo-metadata.precisionThesis） */}
-          <section className="mb-6 sm:mb-8">
-            <div className="card p-4 sm:p-5 bg-surface border border-amber-500/30">
-              <div className="flex items-start gap-3">
+          {/* 精準換匯：唯一正文論述區塊（預設折疊，ATF 留給 rate strip）。 */}
+          <details className="card group mb-6 sm:mb-8">
+            <summary className="p-4 sm:p-5 cursor-pointer list-none flex items-center justify-between gap-3 hover:bg-surface/50 rounded-2xl">
+              <h2 className="font-bold text-text text-sm sm:text-base">
+                {precisionThesis.heading}
+              </h2>
+              <span className="text-text-muted group-open:rotate-180 transition-transform duration-200 flex-shrink-0">
+                ▼
+              </span>
+            </summary>
+            <div className="px-4 sm:px-5 pb-4 sm:pb-5 border-t border-border/50">
+              <div className="flex items-start gap-3 pt-4">
                 <div className="w-10 h-10 rounded-full bg-amber-500/10 flex items-center justify-center flex-shrink-0">
                   <span className="text-lg">⚖️</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h2 className="font-bold text-text text-sm sm:text-base mb-2">
-                    {precisionThesis.heading}
-                  </h2>
                   <p className="text-text-muted text-xs sm:text-sm leading-relaxed mb-3">
                     {precisionThesis.body}
                   </p>
@@ -301,7 +346,7 @@ export function CurrencyLandingPage({
                 </div>
               </div>
             </div>
-          </section>
+          </details>
 
           {/* Quick Action Card */}
           <div className="card p-4 sm:p-5 mb-6 bg-primary text-white">
@@ -321,17 +366,18 @@ export function CurrencyLandingPage({
             </Link>
           </div>
 
-          {/* Highlights Section */}
-          <section className="mb-6 sm:mb-8">
-            <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
-              <BookOpen className="w-3.5 h-3.5" />
-              <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">
-                {currencyName}匯率重點
-              </h2>
-            </div>
-
-            <div className="card p-4 sm:p-5">
-              <ul className="space-y-3 md:grid md:grid-cols-3 md:gap-3 md:space-y-0">
+          <details className="card group mb-6 sm:mb-8">
+            <summary className="p-4 sm:p-5 cursor-pointer list-none flex items-center justify-between gap-3 hover:bg-surface/50 rounded-2xl">
+              <div className="flex items-center gap-2">
+                <BookOpen className="w-3.5 h-3.5 text-primary/70" />
+                <h2 className="text-sm font-black text-text">{currencyName}匯率重點</h2>
+              </div>
+              <span className="text-text-muted group-open:rotate-180 transition-transform duration-200 flex-shrink-0">
+                ▼
+              </span>
+            </summary>
+            <div className="px-4 sm:px-5 pb-4 sm:pb-5 border-t border-border/50">
+              <ul className="space-y-3 pt-4 md:grid md:grid-cols-3 md:gap-3 md:space-y-0">
                 {highlights.map((highlight, index) => (
                   <li
                     key={index}
@@ -347,34 +393,39 @@ export function CurrencyLandingPage({
                 ))}
               </ul>
             </div>
-          </section>
+          </details>
 
-          {/* How To Steps Section */}
-          <section className="mb-6 sm:mb-8">
-            <div className="flex items-center gap-2 px-2 opacity-40 mb-3">
-              <Sparkles className="w-3.5 h-3.5" />
-              <h2 className="text-[10px] font-black uppercase tracking-[0.2em]">使用步驟</h2>
-            </div>
-
-            <div className="space-y-3 md:grid md:grid-cols-2 md:gap-3 md:space-y-0">
-              {howToSteps.map((step) => (
-                <div
-                  key={step.position}
-                  className="card p-4 sm:p-5 flex items-start gap-3 sm:gap-4"
-                >
-                  <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-primary text-white flex items-center justify-center font-bold text-lg sm:text-xl flex-shrink-0">
-                    {step.position}
+          <details className="card group mb-6 sm:mb-8">
+            <summary className="p-4 sm:p-5 cursor-pointer list-none flex items-center justify-between gap-3 hover:bg-surface/50 rounded-2xl">
+              <div className="flex items-center gap-2">
+                <Sparkles className="w-3.5 h-3.5 text-primary/70" />
+                <h2 className="text-sm font-black text-text">使用步驟</h2>
+              </div>
+              <span className="text-text-muted group-open:rotate-180 transition-transform duration-200 flex-shrink-0">
+                ▼
+              </span>
+            </summary>
+            <div className="px-4 sm:px-5 pb-4 sm:pb-5 border-t border-border/50">
+              <div className="space-y-3 pt-4 md:grid md:grid-cols-2 md:gap-3 md:space-y-0">
+                {howToSteps.map((step) => (
+                  <div
+                    key={step.position}
+                    className="rounded-xl bg-surface p-4 sm:p-5 flex items-start gap-3 sm:gap-4"
+                  >
+                    <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-primary text-white flex items-center justify-center font-bold text-lg sm:text-xl flex-shrink-0">
+                      {step.position}
+                    </div>
+                    <div className="flex-1 min-w-0 pt-1">
+                      <h3 className="font-bold text-text text-sm sm:text-base mb-1">{step.name}</h3>
+                      <p className="text-text-muted text-xs sm:text-sm leading-relaxed">
+                        {step.text}
+                      </p>
+                    </div>
                   </div>
-                  <div className="flex-1 min-w-0 pt-1">
-                    <h3 className="font-bold text-text text-sm sm:text-base mb-1">{step.name}</h3>
-                    <p className="text-text-muted text-xs sm:text-sm leading-relaxed">
-                      {step.text}
-                    </p>
-                  </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </section>
+          </details>
 
           {/* Common Amounts Section */}
           {commonAmounts.length > 0 && (
@@ -509,7 +560,7 @@ export function CurrencyLandingPage({
 
             <div className="space-y-3 md:max-w-3xl md:mx-auto">
               {faqEntries.map((faq, index) => (
-                <details key={index} className="card group" open={index === 0}>
+                <details key={index} className="card group">
                   <summary className="p-4 sm:p-5 cursor-pointer list-none flex items-start gap-3 hover:bg-surface/50 transition-colors rounded-2xl">
                     <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center flex-shrink-0 mt-0.5">
                       <HelpCircle className="w-4 h-4" />

--- a/apps/ratewise/src/components/HomepageSEOSection.tsx
+++ b/apps/ratewise/src/components/HomepageSEOSection.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import { CURRENCY_DEFINITIONS } from '../features/ratewise/constants';
 import { HOMEPAGE_SEO } from '../config/seo-metadata';
-import { AnswerCapsule } from './AnswerCapsule';
 
 /** 熱門幣對：外幣換台幣（依台灣旅遊熱度排序）。 */
 const HOT_TO_TWD = ['JPY', 'KRW', 'USD', 'EUR', 'HKD', 'SGD', 'THB', 'VND', 'AUD', 'GBP'] as const;
@@ -21,7 +20,7 @@ const HOT_FROM_TWD = [
 ] as const;
 
 export function HomepageSEOSection() {
-  const { content, howTo, faqContent, answerCapsule } = HOMEPAGE_SEO;
+  const { content } = HOMEPAGE_SEO;
 
   return (
     <section
@@ -39,38 +38,8 @@ export function HomepageSEOSection() {
           {content.heading}
         </h2>
         <p className="mt-3 text-sm leading-6 text-text-muted">{content.intro}</p>
-
-        <ul className="mt-4 space-y-2 text-sm leading-6 text-text">
-          {content.highlights.map((highlight) => (
-            <li key={highlight} className="flex gap-2">
-              <span
-                aria-hidden="true"
-                className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
-              />
-              <span>{highlight}</span>
-            </li>
-          ))}
-        </ul>
-
-        <div className="mt-4 flex flex-wrap gap-2">
-          {content.quickLinks.map((link) => (
-            <Link
-              key={link.href}
-              to={link.href}
-              className="rounded-full border border-primary/15 bg-primary/5 px-3 py-1.5 text-xs font-bold text-primary transition hover:bg-primary/10"
-            >
-              {link.label}
-            </Link>
-          ))}
-        </div>
       </div>
 
-      {/* AEO/GEO 快速答案：AI 引擎直接引用的核心問答，提升首頁引用率。 */}
-      <div className="mt-4">
-        <AnswerCapsule items={answerCapsule ?? []} />
-      </div>
-
-      {/* 熱門幣別換算：內部連結區塊，提升幣對落地頁 PageRank 傳遞。 */}
       <div className="mt-4 rounded-[28px] border border-black/5 bg-surface shadow-card p-5">
         <h2 className="text-lg font-black text-text">熱門幣別換算</h2>
 
@@ -106,42 +75,6 @@ export function HomepageSEOSection() {
               </Link>
             );
           })}
-        </div>
-      </div>
-
-      <div className="mt-4 rounded-[28px] border border-black/5 bg-surface shadow-card p-5">
-        <h2 className="text-lg font-black text-text">{howTo.name}</h2>
-        <p className="mt-2 text-sm leading-6 text-text-muted">{howTo.description}</p>
-        <ol className="mt-4 space-y-3">
-          {howTo.steps.map((step, index) => (
-            <li key={step.name} className="flex gap-3 rounded-2xl bg-primary/5 px-4 py-3">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-black text-white">
-                {step.position ?? index + 1}
-              </span>
-              <div>
-                <h3 className="text-sm font-bold text-text">{step.name}</h3>
-                <p className="mt-1 text-sm leading-6 text-text-muted">{step.text}</p>
-              </div>
-            </li>
-          ))}
-        </ol>
-      </div>
-
-      <div className="mt-4 rounded-[28px] border border-black/5 bg-surface shadow-card p-5">
-        <h2 className="text-lg font-black text-text">首頁常見問題</h2>
-        <div className="mt-4 space-y-3">
-          {faqContent?.map((entry, index) => (
-            <details
-              key={entry.question}
-              className="rounded-2xl border border-primary/10 bg-primary/5"
-              open={index === 0}
-            >
-              <summary className="cursor-pointer list-none px-4 py-3 text-sm font-bold text-text">
-                {entry.question}
-              </summary>
-              <p className="px-4 pb-4 text-sm leading-6 text-text-muted">{entry.answer}</p>
-            </details>
-          ))}
         </div>
       </div>
     </section>

--- a/apps/ratewise/src/components/__tests__/CurrencyLandingPage.test.tsx
+++ b/apps/ratewise/src/components/__tests__/CurrencyLandingPage.test.tsx
@@ -100,6 +100,16 @@ describe('CurrencyLandingPage', () => {
     ).not.toThrow();
   });
 
+  it('ATF 應渲染 read-only live rate strip', () => {
+    render(
+      <MemoryRouter>
+        <CurrencyLandingPage {...BASE_PROPS} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('landing-rate-strip')).toBeInTheDocument();
+    expect(screen.getByText(/1 KRW =/)).toBeInTheDocument();
+  });
+
   // ─── AnswerCapsule：AEO/GEO 快速答案區塊 ───
   it('answerCapsule 有資料時應渲染快速答案區塊（AnswerCapsule，供 AI 引擎直接引用）', () => {
     const answerCapsule = [

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -732,28 +732,26 @@ describe('ratewise build scripts', () => {
     // 驗證 answerCapsule prop 定義存在。
     expect(source).toContain('answerCapsule?: FAQEntry[]');
     // 驗證 AnswerCapsule 元件有被實際渲染。
-    expect(source).toContain('<AnswerCapsule items={answerCapsule}');
+    expect(source).toContain('<AnswerCapsule items={resolvedAnswerCapsule}');
   });
 
-  it('HomepageSEOSection should import and render AnswerCapsule (AEO/GEO readiness)', async () => {
+  it('HomepageSEOSection should stay slim (intro + currency links only)', async () => {
     const source = await readHomepageSEOSectionSource();
 
-    // 驗證匯入 AnswerCapsule，確保首頁有 AEO/GEO 快速答案覆蓋。
-    expect(source).toContain("import { AnswerCapsule } from './AnswerCapsule'");
-    // 驗證有讀取 answerCapsule 資料來源。
-    expect(source).toContain('answerCapsule');
-    // 驗證 AnswerCapsule 元件有被實際渲染。
-    expect(source).toContain('<AnswerCapsule items=');
+    expect(source).toContain('HOMEPAGE_SEO');
+    expect(source).toContain('content.intro');
+    expect(source).toContain('熱門幣別換算');
+    expect(source).not.toContain('AnswerCapsule');
+    expect(source).not.toContain('howTo');
+    expect(source).not.toContain('faqContent');
   });
 
-  it('FAQ page should import and render AnswerCapsule (AEO/GEO readiness)', async () => {
+  it('FAQ page should import FAQ categories and render AnswerCapsule', async () => {
     const source = await readFaqPageSource();
 
-    // 驗證匯入 AnswerCapsule，確保 FAQ 頁有 AEO/GEO 快速答案覆蓋。
     expect(source).toContain("import { AnswerCapsule } from '../components/AnswerCapsule'");
-    // 驗證引用 FAQ_PAGE_SEO.answerCapsule。
+    expect(source).toContain('FAQ_PAGE_CATEGORIES');
     expect(source).toContain('FAQ_PAGE_SEO.answerCapsule');
-    // 驗證 AnswerCapsule 元件有被實際渲染。
     expect(source).toContain('<AnswerCapsule items=');
   });
 

--- a/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
@@ -12,6 +12,8 @@ import {
   OPEN_DATA_PAGE_SEO,
   SEO_INDEXABLE_LOCALES,
   buildPairAmountSeo,
+  buildAmountAnswerCapsule,
+  FAQ_PAGE_CATEGORIES,
   SELL_RATE_VS_MID_RATE_PAGE,
   buildDefaultAlternates,
   buildPersonJsonLd,
@@ -474,6 +476,28 @@ describe('SEO SSOT', () => {
       for (const question of capsuleQuestions) {
         expect(faqQuestions).not.toContain(question);
       }
+    });
+  });
+
+  describe('FAQ page category grouping (L13)', () => {
+    it('FAQ_PAGE_CATEGORIES 應為四類且涵蓋全部 21 題', () => {
+      expect(FAQ_PAGE_CATEGORIES).toHaveLength(4);
+      const grouped = FAQ_PAGE_CATEGORIES.flatMap((category) => category.entries);
+      expect(grouped).toHaveLength(FAQ_PAGE_SEO.faqContent.length);
+      const questions = grouped.map((entry) => entry.question);
+      expect(new Set(questions).size).toBe(questions.length);
+      for (const entry of FAQ_PAGE_SEO.faqContent) {
+        expect(questions).toContain(entry.question);
+      }
+    });
+  });
+
+  describe('amount landing answer capsule (UX26-P0-001)', () => {
+    it('USD 500 金額頁 capsule 首句含金額化換算', () => {
+      const capsule = buildAmountAnswerCapsule(500, 'USD', '美金', 'to-twd');
+      expect(capsule).toHaveLength(1);
+      expect(capsule[0]?.answer).toMatch(/500.*USD.*≈.*TWD/);
+      expect(capsule[0]?.answer).not.toMatch(CURRENCY_LANDING_THESIS_KEYWORD);
     });
   });
 

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -1096,6 +1096,43 @@ export const FAQ_PAGE_ENTRIES = [
   },
 ] as const satisfies readonly FAQEntry[];
 
+export interface FAQPageCategory {
+  id: string;
+  title: string;
+  entries: readonly FAQEntry[];
+}
+
+function faqEntriesAt(...indices: number[]): FAQEntry[] {
+  return indices.flatMap((index) => {
+    const entry = FAQ_PAGE_ENTRIES[index];
+    return entry ? [entry] : [];
+  });
+}
+
+/** FAQ 頁四類分組 SSOT（flat 21 題 → 四類 accordion，JSON-LD 仍用 FAQ_PAGE_ENTRIES）。 */
+export const FAQ_PAGE_CATEGORIES: readonly FAQPageCategory[] = [
+  {
+    id: 'rates',
+    title: '台銀匯率怎麼看',
+    entries: faqEntriesAt(0, 1, 2, 3, 9, 12, 18, 20),
+  },
+  {
+    id: 'app',
+    title: 'App 功能與操作',
+    entries: faqEntriesAt(4, 5, 6, 7, 8, 10, 11, 13, 16),
+  },
+  {
+    id: 'travel',
+    title: '出國換匯實用',
+    entries: faqEntriesAt(15),
+  },
+  {
+    id: 'card',
+    title: '刷卡與 DCC',
+    entries: faqEntriesAt(14, 17, 19),
+  },
+];
+
 export const FAQ_PAGE_SEO = {
   title: `${APP_INFO.shortName} 常見問題 FAQ：台銀匯率、DCC 與現金即期一次看懂`,
   description: `整理 ${APP_INFO.shortName} 最常被問的換匯問題，涵蓋台銀匯率來源、現金與即期差異、買入賣出判讀、DCC 刷卡匯率、收藏排序、歷史記錄、離線使用與 PWA 安裝重點，讓第一次換匯也能快速判斷並少踩錯價。`,
@@ -2606,6 +2643,37 @@ function buildCurrencyAnswerCapsule(
       answer: spotAvailable
         ? `臨櫃換現鈔看現金報價，網銀外幣帳戶看即期報價。${APP_INFO.shortName} 同時顯示兩種台銀牌告。`
         : `此幣別以現金牌告為主，出國換匯前請直接確認台銀現金報價。`,
+    },
+  ];
+}
+
+/** 金額 landing 頁 Answer Capsule：首句含金額化換算（UX26-P0-001）。 */
+export function buildAmountAnswerCapsule(
+  amount: number,
+  currencyCode: string,
+  currencyName: string,
+  direction: 'to-twd' | 'twd-to-foreign',
+): FAQEntry[] {
+  const ex = SEO_RATE_EXAMPLES[currencyCode];
+  if (!ex) return [];
+
+  const formatted = formatAmount(amount);
+
+  if (direction === 'twd-to-foreign') {
+    const result = Math.round(amount / ex.cashSell);
+    return [
+      {
+        question: `${formatted} 台幣可換多少${currencyName}？`,
+        answer: `${formatted} 台幣 ≈ ${formatAmount(result)} ${currencyCode}（台銀現金 1 ${currencyCode} = ${ex.cashSell} TWD，${SEO_RATE_EXAMPLES_DATE} 更新）。`,
+      },
+    ];
+  }
+
+  const result = Math.round(amount * ex.cashSell);
+  return [
+    {
+      question: `${formatted} ${currencyName}換多少台幣？`,
+      answer: `${formatted} ${currencyCode} ≈ ${formatAmount(result)} TWD（台銀現金 1 ${currencyCode} = ${ex.cashSell} TWD，${SEO_RATE_EXAMPLES_DATE} 更新）。`,
     },
   ];
 }

--- a/apps/ratewise/src/jsonld.test.ts
+++ b/apps/ratewise/src/jsonld.test.ts
@@ -101,7 +101,7 @@ describe('JSON-LD Structured Data (SEOHelmet Architecture)', () => {
     });
 
     it('FAQ page should render visible FAQ HTML and keep FAQPage JSON-LD in SEO layer', () => {
-      expect(faqContent).toContain('FAQ_ENTRIES.map');
+      expect(faqContent).toContain('FAQ_PAGE_CATEGORIES.map');
       expect(faqContent).not.toContain('faqContent={');
     });
 

--- a/apps/ratewise/src/pages/FAQ.tsx
+++ b/apps/ratewise/src/pages/FAQ.tsx
@@ -6,7 +6,7 @@ import { PageNavHeader } from '../components/PageNavHeader';
 import { APP_INFO } from '../config/app-info';
 import { MailtoLink } from '../components/MailtoLink';
 import { AnswerCapsule } from '../components/AnswerCapsule';
-import { FAQ_PAGE_SEO, SITE_SEO } from '../config/seo-metadata';
+import { FAQ_PAGE_CATEGORIES, FAQ_PAGE_SEO, SITE_SEO } from '../config/seo-metadata';
 
 // 將 FAQ 答案中的 email 位址替換為 MailtoLink，防止 CF Email Obfuscation 將其改寫為爬蟲不可讀的 /cdn-cgi/... 連結。
 const EMAIL_RE = /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/;
@@ -20,7 +20,6 @@ function renderFaqAnswer(answer: string): React.ReactNode {
   );
 }
 
-const FAQ_ENTRIES = FAQ_PAGE_SEO.faqContent ?? [];
 const LAST_UPDATED = new Date(SITE_SEO.updatedTime).toLocaleDateString('zh-TW', {
   year: 'numeric',
   month: 'long',
@@ -63,7 +62,6 @@ export default function FAQ() {
             </p>
           </div>
 
-          {/* AEO/GEO 快速答案：AI 引擎直接引用的核心問答，放在 FAQ 頂部提升引用率。 */}
           <AnswerCapsule items={FAQ_PAGE_SEO.answerCapsule ?? []} />
 
           <section className="card mb-6 p-6">
@@ -84,34 +82,43 @@ export default function FAQ() {
             </ul>
           </section>
 
-          <div className="space-y-4">
-            {FAQ_ENTRIES.map((entry) => (
-              <details
-                key={entry.question}
-                className="group card p-0 hover:shadow-md transition-shadow"
-              >
-                <summary className="flex cursor-pointer list-none items-center justify-between p-6 transition-colors hover:text-primary">
-                  <h2 className="text-lg font-semibold text-text group-hover:text-primary">
-                    {entry.question}
-                  </h2>
-                  <svg
-                    className="ml-4 h-5 w-5 flex-shrink-0 text-text-muted transition-transform group-open:rotate-180"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </summary>
-                <div className="border-t border-border px-6 pb-6 pt-4 leading-relaxed text-text-muted">
-                  {renderFaqAnswer(entry.answer)}
+          <div className="space-y-6">
+            {FAQ_PAGE_CATEGORIES.map((category) => (
+              <section key={category.id} aria-labelledby={`faq-category-${category.id}`}>
+                <h2 id={`faq-category-${category.id}`} className="mb-3 text-xl font-bold text-text">
+                  {category.title}
+                </h2>
+                <div className="space-y-4">
+                  {category.entries.map((entry) => (
+                    <details
+                      key={entry.question}
+                      className="group card p-0 hover:shadow-md transition-shadow"
+                    >
+                      <summary className="flex cursor-pointer list-none items-center justify-between p-6 transition-colors hover:text-primary">
+                        <h3 className="text-lg font-semibold text-text group-hover:text-primary">
+                          {entry.question}
+                        </h3>
+                        <svg
+                          className="ml-4 h-5 w-5 flex-shrink-0 text-text-muted transition-transform group-open:rotate-180"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 9l-7 7-7-7"
+                          />
+                        </svg>
+                      </summary>
+                      <div className="border-t border-border px-6 pb-6 pt-4 leading-relaxed text-text-muted">
+                        {renderFaqAnswer(entry.answer)}
+                      </div>
+                    </details>
+                  ))}
                 </div>
-              </details>
+              </section>
             ))}
           </div>
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：0（reward 0、penalty 0、neutral 1）｜累計總分：+66
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+67
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-epic3-steps2-5-content-distill
+- 原因：Plan 004 E3-T2–T5 缺 landing rate strip、首頁 SEO 瘦身、FAQ 分類與金額 capsule
+- 解法：CurrencyLandingPage rate strip + accordion、HomepageSEOSection 精簡、FAQ_PAGE_CATEGORIES、buildAmountAnswerCapsule
 
 - 日期：2026-06-27
 - ID：neutral-epic1-settings-hero-toggle
@@ -27,7 +32,6 @@
 - ID：reward-release-yml-worker-order-minify
 - 原因：release.yml Worker deploy 在 Zeabur wait 之前且 CI 未用 --minify，違反 AGENTS.md 邊緣順序 SOP
 - 解法：調整為 Wait → Worker deploy --minify → purge，並同步 DEPLOY.md 與 security-headers package.json
-
 - 日期：2026-06-27
 - ID：neutral-epic3-collect-body-text-ssot
 - 原因：L09 dedupe 測試內嵌 collectBodyText 與 seo-metadata SSOT 重複

--- a/docs/superpowers/specs/2026-06-26-ratewise-2026-product-ux-spec.md
+++ b/docs/superpowers/specs/2026-06-26-ratewise-2026-product-ux-spec.md
@@ -722,7 +722,6 @@ sequenceDiagram
 > SSOT 透鏡 ID 對齊 §二 Scorecard。Severity：`P0`=release blocking、`P1`=Sprint 必達、`P2`=選配。  
 > **命名格式**：`姓名 / Agent L0N · Codename`
 
-
 | ID  | Agent（姓名 / Codename）                             | Epic  | Sev | 現況分 | 目標 | Status      | Owner Role    | Last Verified | Blockers                                                  |
 | --- | ---------------------------------------------------- | ----- | --- | -----: | ---: | ----------- | ------------- | ------------- | --------------------------------------------------------- |
 | L01 | **林安答** / Agent L01 · Answer-First Auditor        | E1    | P0  |     52 |   85 | done        | Frontend      | 2026-06-27    | —                                                         |
@@ -1024,9 +1023,7 @@ Acceptance: thesis ≤1; capsule↔FAQ 0 verbatim dup; tests Pass.
 
 ### L13 — 孫問答 / Agent L13 · Help Content Architect
 
-
 **Agent**：**孫問答** / Agent L13 · Help Content Architect | **Role**：Help Content Architecture Auditor | **Owner**：SEO / Content | **Status**：done | **Last verified**：2026-06-27 | **Evidence**：`FAQ_PAGE_CATEGORIES` 四類、21 題全覆蓋
-
 
 **Acceptance**：FAQ 四類 accordion; flat 21 題改分組; `/faq/` curl 200; FAQPage schema **僅** `/faq/`.
 

--- a/docs/superpowers/specs/2026-06-26-ratewise-2026-product-ux-spec.md
+++ b/docs/superpowers/specs/2026-06-26-ratewise-2026-product-ux-spec.md
@@ -722,28 +722,29 @@ sequenceDiagram
 > SSOT 透鏡 ID 對齊 §二 Scorecard。Severity：`P0`=release blocking、`P1`=Sprint 必達、`P2`=選配。  
 > **命名格式**：`姓名 / Agent L0N · Codename`
 
-| ID  | Agent（姓名 / Codename）                             | Epic  | Sev | 現況分 | 目標 | Status      | Owner Role    | Last Verified | Blockers                                    |
-| --- | ---------------------------------------------------- | ----- | --- | -----: | ---: | ----------- | ------------- | ------------- | ------------------------------------------- |
-| L01 | **林安答** / Agent L01 · Answer-First Auditor        | E1    | P0  |     52 |   85 | done        | Frontend      | 2026-06-27    | —                                           |
-| L02 | **沈零閱** / Agent L02 · Zero-Click Reader           | E1    | P1  |     65 |   90 | pending     | Frontend      | 2026-06-27    | L01                                         |
-| L03 | **韓多理** / Agent L03 · Multi-Flow Analyst          | E4    | P1  |     55 |   80 | pending     | Frontend      | 2026-06-27    | —                                           |
-| L04 | **鄭落地** / Agent L04 · Landing Curator             | E3    | P1  |     62 |   85 | pending     | SEO / Content | 2026-06-27    | —                                           |
-| L05 | **羅導航** / Agent L05 · Nav-IA Architect            | E4    | P1  |     62 |   85 | pending     | Frontend      | 2026-06-27    | —                                           |
-| L06 | **蔡穩屏** / Agent L06 · Viewport Trust Auditor      | E1    | P0  |     58 |   82 | done        | QA            | 2026-06-27    | —                                           |
-| L07 | **周寬屏** / Agent L07 · Desktop Layout Auditor      | E4    | P2  |     45 |   70 | pending     | Frontend      | 2026-06-27    | L01                                         |
-| L08 | **金墨字** / Agent L08 · Typography Specialist       | E1    | P1  |     52 |   80 | pending     | Design Tokens | 2026-06-27    | L01, L14                                    |
-| L09 | **白精煉** / Agent L09 · Content Distiller           | E3    | P1  |     50 |   85 | done        | SEO / Content | 2026-06-27    | build dist thesis curl 1                    |
-| L10 | **許無障** / Agent L10 · Contrast Guardian           | E1    | P1  |     58 |   80 | pending     | Design Tokens | 2026-06-27    | L08                                         |
-| L11 | **方觸達** / Agent L11 · Touch Target Auditor        | E1    | P1  |     58 |   85 | pending     | QA            | 2026-06-27    | L04(TOU)                                    |
-| L12 | **吳收藏** / Agent L12 · Settings Favorites Curator  | E2    | P1  |     65 |   82 | pending     | Frontend      | 2026-06-27    | —                                           |
-| L13 | **孫問答** / Agent L13 · Help Content Architect      | E3    | P1  |     50 |   78 | in_progress | SEO / Content | 2026-06-27    | L09                                         |
-| L14 | **朴顯赫** / Agent L14 · Hero Token Lead             | E1    | P0  |     52 |   80 | done        | Design Tokens | 2026-06-27    | —                                           |
-| L15 | **車安裝** / Agent L15 · PWA Install Advocate        | E2    | P1  |     72 |   88 | pending     | PWA / SW      | 2026-06-27    | —                                           |
-| L16 | **何降級** / Agent L16 · Loading Degradation Auditor | E1    | P2  |     70 |   85 | pending     | Frontend      | 2026-06-27    | L06                                         |
-| L17 | **高信任** / Agent L17 · Trust E-E-A-T Lead          | E1/E3 | P1  |     72 |   90 | pending     | SEO / Content | 2026-06-27    | L06                                         |
-| L18 | **裴對標** / Agent L18 · K-Fintech Benchmark Analyst | E1    | P1  |     58 |   80 | pending     | PM / Design   | 2026-06-27    | —                                           |
-| L19 | **梁趨勢** / Agent L19 · UX Trends Futurist          | E1/E3 | P1  |     62 |   85 | pending     | PM            | 2026-06-27    | L09                                         |
-| L20 | **馮驗收** / Agent L20 · Motion QA Lead              | E1    | P2  |     68 |   85 | in_progress | QA            | 2026-06-27    | G2 Lighthouse; G4 #418; Plan 010 specs 待建 |
+
+| ID  | Agent（姓名 / Codename）                             | Epic  | Sev | 現況分 | 目標 | Status      | Owner Role    | Last Verified | Blockers                                                  |
+| --- | ---------------------------------------------------- | ----- | --- | -----: | ---: | ----------- | ------------- | ------------- | --------------------------------------------------------- |
+| L01 | **林安答** / Agent L01 · Answer-First Auditor        | E1    | P0  |     52 |   85 | done        | Frontend      | 2026-06-27    | —                                                         |
+| L02 | **沈零閱** / Agent L02 · Zero-Click Reader           | E1    | P1  |     65 |   90 | pending     | Frontend      | 2026-06-27    | L01                                                       |
+| L03 | **韓多理** / Agent L03 · Multi-Flow Analyst          | E4    | P1  |     55 |   80 | pending     | Frontend      | 2026-06-27    | —                                                         |
+| L04 | **鄭落地** / Agent L04 · Landing Curator             | E3    | P1  |     62 |   85 | done        | SEO / Content | 2026-06-27    | landing-rate-strip ATF                                    |
+| L05 | **羅導航** / Agent L05 · Nav-IA Architect            | E4    | P1  |     62 |   85 | pending     | Frontend      | 2026-06-27    | —                                                         |
+| L06 | **蔡穩屏** / Agent L06 · Viewport Trust Auditor      | E1    | P0  |     58 |   82 | done        | QA            | 2026-06-27    | —                                                         |
+| L07 | **周寬屏** / Agent L07 · Desktop Layout Auditor      | E4    | P2  |     45 |   70 | pending     | Frontend      | 2026-06-27    | L01                                                       |
+| L08 | **金墨字** / Agent L08 · Typography Specialist       | E1    | P1  |     52 |   80 | done        | Design Tokens | 2026-06-27    | —                                                         |
+| L09 | **白精煉** / Agent L09 · Content Distiller           | E3    | P1  |     85 |   85 | done        | SEO / Content | 2026-06-27    | —                                                         |
+| L10 | **許無障** / Agent L10 · Contrast Guardian           | E1    | P1  |     58 |   80 | pending     | Design Tokens | 2026-06-27    | L08                                                       |
+| L11 | **方觸達** / Agent L11 · Touch Target Auditor        | E1    | P1  |     58 |   85 | pending     | QA            | 2026-06-27    | L04(TOU)                                                  |
+| L12 | **吳收藏** / Agent L12 · Settings Favorites Curator  | E2    | P1  |     65 |   82 | in_progress | Frontend      | 2026-06-27    | PR [#466](https://github.com/haotool/app/pull/466) review |
+| L13 | **孫問答** / Agent L13 · Help Content Architect      | E3    | P1  |     50 |   78 | done        | SEO / Content | 2026-06-27    | FAQ_PAGE_CATEGORIES 四類 accordion                        |
+| L14 | **朴顯赫** / Agent L14 · Hero Token Lead             | E1    | P0  |     52 |   80 | done        | Design Tokens | 2026-06-27    | —                                                         |
+| L15 | **車安裝** / Agent L15 · PWA Install Advocate        | E2    | P1  |     72 |   88 | in_progress | PWA / SW      | 2026-06-27    | PR [#466](https://github.com/haotool/app/pull/466) review |
+| L16 | **何降級** / Agent L16 · Loading Degradation Auditor | E1    | P2  |     70 |   85 | pending     | Frontend      | 2026-06-27    | L06                                                       |
+| L17 | **高信任** / Agent L17 · Trust E-E-A-T Lead          | E1/E3 | P1  |     72 |   90 | pending     | SEO / Content | 2026-06-27    | L06                                                       |
+| L18 | **裴對標** / Agent L18 · K-Fintech Benchmark Analyst | E1    | P1  |     58 |   80 | pending     | PM / Design   | 2026-06-27    | —                                                         |
+| L19 | **梁趨勢** / Agent L19 · UX Trends Futurist          | E1/E3 | P1  |     62 |   85 | pending     | PM            | 2026-06-27    | L09 done; Step2 TBD                                       |
+| L20 | **馮驗收** / Agent L20 · Motion QA Lead              | E1    | P2  |     68 |   85 | in_progress | QA            | 2026-06-27    | L06, L11                                                  |
 
 **詳細 Agent prompt、Acceptance、Evidence → §七 Appendix（L01–L20）**
 
@@ -894,7 +895,7 @@ Acceptance: ≤8 default rows OR explicit "全列表套用" copy; E2E state sync
 
 ### L04 — 鄭落地 / Agent L04 · Landing Curator
 
-**Agent**：**鄭落地** / Agent L04 · Landing Curator | **Role**：Currency Landing Auditor | **Owner**：SEO / Content | **Status**：pending
+**Agent**：**鄭落地** / Agent L04 · Landing Curator | **Role**：Currency Landing Auditor | **Owner**：SEO / Content | **Status**：done
 
 **Agent Prompt Template**（摘要）：稽核 `https://app.haotool.org/ratewise/usd-twd/` — CTA 1-tap 至 `/?amount=&from=&to=`（`CurrencyLandingPage.tsx:117-122`）；0 scroll live rate strip；`curl` 200。
 
@@ -1023,7 +1024,9 @@ Acceptance: thesis ≤1; capsule↔FAQ 0 verbatim dup; tests Pass.
 
 ### L13 — 孫問答 / Agent L13 · Help Content Architect
 
-**Agent**：**孫問答** / Agent L13 · Help Content Architect | **Role**：Help Content Architecture Auditor | **Owner**：SEO / Content | **Status**：pending
+
+**Agent**：**孫問答** / Agent L13 · Help Content Architect | **Role**：Help Content Architecture Auditor | **Owner**：SEO / Content | **Status**：done | **Last verified**：2026-06-27 | **Evidence**：`FAQ_PAGE_CATEGORIES` 四類、21 題全覆蓋
+
 
 **Acceptance**：FAQ 四類 accordion; flat 21 題改分組; `/faq/` curl 200; FAQPage schema **僅** `/faq/`.
 

--- a/plans/004-epic3-content-distill.md
+++ b/plans/004-epic3-content-distill.md
@@ -8,6 +8,7 @@
 - **Depends on**: plans/001-experiment-branch-bootstrap.md
 - **Category**: direction | **Planned at**: `e7b7f1ec`, 2026-06-27
 - **Agent L09 Step 1**: **DONE**（2026-06-27，build `dist/usd-twd/` thesis curl **1**）
+- **Steps 2–5**: **DONE**（2026-06-27，E3-T2–T5 + dist 驗證）
 
 ## Why this matters
 
@@ -42,27 +43,27 @@ curl `/usd-twd/` 賣出價/中間價 keyword **2 次**（目標 ≤1，L09）；
 
 **Verify**: `pnpm --filter @app/ratewise test -- seo-ssot template-bleed` pass；`rg -c '賣出價|中間價' dist/usd-twd/index.html` → **1**
 
-### Step 2: Landing read-only rate strip（E3-T2 / CUR-P0-004）
+### Step 2: Landing read-only rate strip（E3-T2 / CUR-P0-004）✅
 
-`CurrencyLandingPage.tsx`: ATF 0 scroll 可見 live rate strip（read-only）；長文 accordion
+`CurrencyLandingPage.tsx`: ATF `data-testid="landing-rate-strip"` read-only 台銀現金賣出；highlights/howTo/precision/FAQ 預設 accordion 折疊。
 
-**Verify**: preview `/usd-twd/` ATF 可見匯率
+**Verify**: `CurrencyLandingPage.test.tsx` rate strip pass
 
-### Step 3: Homepage SEO 瘦身（E3-T3）
+### Step 3: Homepage SEO 瘦身（E3-T3）✅
 
-`HomepageSEOSection.tsx` → 1 段 + 幣對連結（spec §15.1）
+`HomepageSEOSection.tsx` → 1 段 intro + 熱門幣對連結（移除 howTo/FAQ/capsule/highlights）
 
-### Step 4: FAQ 四類 accordion（E3-T4 / FAQ-P1）
+### Step 4: FAQ 四類 accordion（E3-T4 / FAQ-P1）✅
 
-`FAQ.tsx`: flat 21 題 → 四類分組；**FAQPage schema 僅 `/faq/`**
+`FAQ_PAGE_CATEGORIES` SSOT + `FAQ.tsx` 四類分組；**FAQPage schema 僅 `/faq/`**（既有測試 Pass）
 
-**Verify**: `grep -r FAQPage apps/ratewise/src` — 僅 FAQ 頁輸出
+**Verify**: `seo-ssot` FAQ 分組 21 題；`schema-truthfulness` FAQPage 僅 /faq/
 
-### Step 5: Amount capsule（UX26-P0-001）
+### Step 5: Amount capsule（UX26-P0-001）✅
 
-`/usd-twd/500/` capsule 含金額化首句（spec L19）
+`buildAmountAnswerCapsule()` + landing `resolvedAnswerCapsule`；`/usd-twd/500/` dist thesis curl **1**
 
-### Step 6: PR + spec L09/L13 → done
+### Step 6: PR + spec L04/L09/L13 → done
 
 ## Test plan
 
@@ -72,8 +73,8 @@ curl `/usd-twd/` 賣出價/中間價 keyword **2 次**（目標 ≤1，L09）；
 ## Done criteria
 
 - [x] curl thesis keyword ≤1（build dist 證據：`rg -c` → 1）
-- [x] seo-ssot + template-bleed pass（130 tests）
-- [ ] FAQPage 無重複 @type
+- [x] seo-ssot + template-bleed pass（132 tests）
+- [x] FAQPage 無重複 @type（schema-truthfulness Pass）
 - [x] changeset patch
 - [ ] experiment PR merged
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -8,19 +8,18 @@
 
 **追蹤**：Epic 1 已於 2026-06-27 以 PR [#464](https://github.com/haotool/app/pull/464) squash 併入 `experiment/ratewise-ux-2026`（`dbcadb05`）。
 
-| Plan                                        | 標題                      | Priority | Effort | Depends on        | Spec Epic             | Status                                              |
-| ------------------------------------------- | ------------------------- | -------- | ------ | ----------------- | --------------------- | --------------------------------------------------- |
-| [001](./001-experiment-branch-bootstrap.md) | 實驗分支 bootstrap        | P1       | S      | —                 | §十四.12              | DONE                                                |
-| [009](./009-agent-orchestration.md)         | Agent 編排與 gh playbook  | P1       | M      | 001               | §三                   | IN PROGRESS                                         |
-| [002](./002-epic1-hero-trust.md)            | Epic 1 Hero + Trust       | P1       | L      | 001, 009          | E1 / L01,L06,L14      | DONE（PR #464 merged）                              |
-| [003](./003-epic2-settings-ssot.md)         | Epic 2 Settings SSOT      | P1       | M      | 001, 002          | E2 / L12,L15          | IN PROGRESS（[#466](https://github.com/haotool/app/pull/466)） |
+| Plan                                        | 標題                      | Priority | Effort | Depends on        | Spec Epic             | Status                                                                         |
+| ------------------------------------------- | ------------------------- | -------- | ------ | ----------------- | --------------------- | ------------------------------------------------------------------------------ |
+| [001](./001-experiment-branch-bootstrap.md) | 實驗分支 bootstrap        | P1       | S      | —                 | §十四.12              | DONE                                                                           |
+| [009](./009-agent-orchestration.md)         | Agent 編排與 gh playbook  | P1       | M      | 001               | §三                   | IN PROGRESS                                                                    |
+| [002](./002-epic1-hero-trust.md)            | Epic 1 Hero + Trust       | P1       | L      | 001, 009          | E1 / L01,L06,L14      | DONE（PR #464 merged）                                                         |
+| [003](./003-epic2-settings-ssot.md)         | Epic 2 Settings SSOT      | P1       | M      | 001, 002          | E2 / L12,L15          | IN PROGRESS（[#466](https://github.com/haotool/app/pull/466)）                 |
 | [004](./004-epic3-content-distill.md)       | Epic 3 Content Distill    | P1       | M      | 001               | E3 / L09,L13          | IN PROGRESS（Steps 2–5 DONE，[#469](https://github.com/haotool/app/pull/469)） |
-| [005](./005-epic4-multi-ia.md)              | Epic 4 Multi + IA         | P2       | M      | 001, 002          | E4 / L03,L05          | TODO                                                |
-| [006](./006-api-semantics-v2.md)            | API 語意 v2 加法遷移      | P2       | M      | 001               | §二十一               | DONE                                                |
-| [007](./007-cf-security-headers.md)         | CF Worker 可維護性        | P2       | M      | —                 | Release gate          | DONE                                                |
-| [008](./008-zeabur-deployment.md)           | Zeabur 部署與 race 防護   | P2       | M      | —                 | §3.5 / Release        | AUDIT DONE                                          |
-| [010](./010-qa-gate.md)                     | QA 閘門（390×844 + live） | P1       | M      | 002–005, 007, 008 | §十六 / §十四.12 Gate | IN PROGRESS                                         |
-
+| [005](./005-epic4-multi-ia.md)              | Epic 4 Multi + IA         | P2       | M      | 001, 002          | E4 / L03,L05          | TODO                                                                           |
+| [006](./006-api-semantics-v2.md)            | API 語意 v2 加法遷移      | P2       | M      | 001               | §二十一               | DONE                                                                           |
+| [007](./007-cf-security-headers.md)         | CF Worker 可維護性        | P2       | M      | —                 | Release gate          | DONE                                                                           |
+| [008](./008-zeabur-deployment.md)           | Zeabur 部署與 race 防護   | P2       | M      | —                 | §3.5 / Release        | AUDIT DONE                                                                     |
+| [010](./010-qa-gate.md)                     | QA 閘門（390×844 + live） | P1       | M      | 002–005, 007, 008 | §十六 / §十四.12 Gate | IN PROGRESS                                                                    |
 
 Status 值：`TODO` | `IN PROGRESS` | `DONE` | `BLOCKED` | `REJECTED`
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -6,18 +6,21 @@
 
 ## 建議執行順序與狀態
 
-| Plan                                        | 標題                      | Priority | Effort | Depends on        | Spec Epic             | Status                        |
-| ------------------------------------------- | ------------------------- | -------- | ------ | ----------------- | --------------------- | ----------------------------- |
-| [001](./001-experiment-branch-bootstrap.md) | 實驗分支 bootstrap        | P1       | S      | —                 | §十四.12              | DONE                          |
-| [009](./009-agent-orchestration.md)         | Agent 編排與 gh playbook  | P1       | M      | 001               | §三                   | IN PROGRESS                   |
-| [002](./002-epic1-hero-trust.md)            | Epic 1 Hero + Trust       | P1       | L      | 001, 009          | E1 / L01,L06,L14      | DONE                          |
-| [003](./003-epic2-settings-ssot.md)         | Epic 2 Settings SSOT      | P1       | M      | 001               | E2 / L12,L15          | TODO                          |
-| [004](./004-epic3-content-distill.md)       | Epic 3 Content Distill    | P1       | M      | 001               | E3 / L09,L13          | IN PROGRESS（L09 Step1 DONE） |
-| [005](./005-epic4-multi-ia.md)              | Epic 4 Multi + IA         | P2       | M      | 001, 002          | E4 / L03,L05          | TODO                          |
-| [006](./006-api-semantics-v2.md)            | API 語意 v2 加法遷移      | P2       | M      | 001               | §二十一               | DONE                          |
-| [007](./007-cf-security-headers.md)         | CF Worker 可維護性        | P2       | M      | —                 | Release gate          | DONE                          |
-| [008](./008-zeabur-deployment.md)           | Zeabur 部署與 race 防護   | P2       | M      | —                 | §3.5 / Release        | AUDIT DONE                    |
-| [010](./010-qa-gate.md)                     | QA 閘門（390×844 + live） | P1       | M      | 002–005, 007, 008 | §十六 / §十四.12 Gate | IN PROGRESS                   |
+**追蹤**：Epic 1 已於 2026-06-27 以 PR [#464](https://github.com/haotool/app/pull/464) squash 併入 `experiment/ratewise-ux-2026`（`dbcadb05`）。
+
+| Plan                                        | 標題                      | Priority | Effort | Depends on        | Spec Epic             | Status                                              |
+| ------------------------------------------- | ------------------------- | -------- | ------ | ----------------- | --------------------- | --------------------------------------------------- |
+| [001](./001-experiment-branch-bootstrap.md) | 實驗分支 bootstrap        | P1       | S      | —                 | §十四.12              | DONE                                                |
+| [009](./009-agent-orchestration.md)         | Agent 編排與 gh playbook  | P1       | M      | 001               | §三                   | IN PROGRESS                                         |
+| [002](./002-epic1-hero-trust.md)            | Epic 1 Hero + Trust       | P1       | L      | 001, 009          | E1 / L01,L06,L14      | DONE（PR #464 merged）                              |
+| [003](./003-epic2-settings-ssot.md)         | Epic 2 Settings SSOT      | P1       | M      | 001, 002          | E2 / L12,L15          | IN PROGRESS（[#466](https://github.com/haotool/app/pull/466)） |
+| [004](./004-epic3-content-distill.md)       | Epic 3 Content Distill    | P1       | M      | 001               | E3 / L09,L13          | IN PROGRESS（Steps 2–5 DONE，[#469](https://github.com/haotool/app/pull/469)） |
+| [005](./005-epic4-multi-ia.md)              | Epic 4 Multi + IA         | P2       | M      | 001, 002          | E4 / L03,L05          | TODO                                                |
+| [006](./006-api-semantics-v2.md)            | API 語意 v2 加法遷移      | P2       | M      | 001               | §二十一               | DONE                                                |
+| [007](./007-cf-security-headers.md)         | CF Worker 可維護性        | P2       | M      | —                 | Release gate          | DONE                                                |
+| [008](./008-zeabur-deployment.md)           | Zeabur 部署與 race 防護   | P2       | M      | —                 | §3.5 / Release        | AUDIT DONE                                          |
+| [010](./010-qa-gate.md)                     | QA 閘門（390×844 + live） | P1       | M      | 002–005, 007, 008 | §十六 / §十四.12 Gate | IN PROGRESS                                         |
+
 
 Status 值：`TODO` | `IN PROGRESS` | `DONE` | `BLOCKED` | `REJECTED`
 


### PR DESCRIPTION
## Summary

- **E3-T2**：`CurrencyLandingPage` ATF read-only rate strip（`landing-rate-strip`）+ 長文 accordion 預設折疊
- **E3-T3**：`HomepageSEOSection` 瘦身為 1 段 intro + 熱門幣對連結
- **E3-T4**：`FAQ_PAGE_CATEGORIES` 四類分組（21 題）；FAQPage schema 仍僅 `/faq/`
- **E3-T5**：`buildAmountAnswerCapsule()` 金額化 capsule（`/usd-twd/500/`）

## 驗證

- `pnpm --filter @app/ratewise test -- seo-ssot template-bleed` → 132 pass
- `pnpm build:ratewise` → exit 0
- `rg -c '賣出價|中間價' dist/usd-twd/index.html` → **1**
- `rg -c '賣出價|中間價' dist/usd-twd/500/index.html` → **1**
- pre-push：typecheck + full test + build:ratewise pass

## Spec / Plan

- spec §六 L04/L13 → `done`
- plans/004 Steps 2–5 done（Step 6 PR 本 PR）

## Test plan

- [x] seo-ssot + template-bleed
- [x] build dist thesis ≤1
- [x] FAQPage 僅 /faq/（schema-truthfulness）
- [ ] Maintainer merge 至 `experiment/ratewise-ux-2026`（非 main）


Made with [Cursor](https://cursor.com)