### PR TITLE
fix(ratewise): API Semantics v2 MoneyBox provider 語意層

### DIFF
--- a/.changeset/ratewise-api-semantics-v2-moneybox.md
+++ b/.changeset/ratewise-api-semantics-v2-moneybox.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+開放資料 API：MoneyBox 換錢所 JSON 與 Open Data 頁面新增 v2 語意欄位（quoteUnit、semanticFieldMapping），澄清與台銀 sell 報價方向差異。

--- a/apps/ratewise/public/api/latest.json
+++ b/apps/ratewise/public/api/latest.json
@@ -1,6 +1,49 @@
 {
   "name": "HaoRate Exchange Rate API",
   "version": "2.25.3",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "description": "臺灣銀行牌告匯率靜態 API — 資料每 5 分鐘自動同步，並提供 App 匯率模式欄位對照",
   "source": "臺灣銀行牌告匯率",
   "sourceUrl": "https://rate.bot.com.tw/xrt",
@@ -122,7 +165,48 @@
       "currentEndpoint": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",
       "historyEndpoint": "https://raw.githubusercontent.com/haotool/app/data/public/rates/history/{YYYY-MM-DD}.json",
       "cdnCurrentEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/latest.json",
-      "cdnHistoryEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/history/{YYYY-MM-DD}.json"
+      "cdnHistoryEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/history/{YYYY-MM-DD}.json",
+      "semanticFieldMapping": {
+        "schemaVersion": "2.0",
+        "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+        "providerKind": "bank",
+        "quoteUnit": "TWD_PER_FOREIGN",
+        "asOfSourceField": "timestamp | updateTime",
+        "fields": {
+          "customerBuyForeignRate": {
+            "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+            "description": "客戶用 TWD 買外幣（銀行賣出）",
+            "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+          },
+          "customerSellForeignRate": {
+            "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+            "description": "客戶用外幣賣回 TWD（銀行買入）",
+            "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+          },
+          "midMarketRate": {
+            "legacyPath": "(buy + sell) / 2",
+            "description": "參考中間價"
+          },
+          "bankSellTwdPerUnit": {
+            "legacyPath": "1 / sell",
+            "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+          }
+        },
+        "examples": {
+          "USD": {
+            "cash": {
+              "customerBuyForeignRate": "details.USD.cash.sell",
+              "customerSellForeignRate": "details.USD.cash.buy"
+            }
+          }
+        },
+        "bankComparison": {
+          "botQuoteUnit": "TWD_PER_FOREIGN",
+          "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+          "moneyboxQuoteUnit": "KRW_PER_TWD",
+          "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+        }
+      }
     },
     {
       "providerId": "moneybox",
@@ -138,7 +222,47 @@
       "currentEndpoint": "https://raw.githubusercontent.com/haotool/app/data/public/rates/providers/moneybox/latest.json",
       "historyEndpoint": "https://raw.githubusercontent.com/haotool/app/data/public/rates/providers/moneybox/history/{YYYY-MM-DD}.json",
       "cdnCurrentEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/providers/moneybox/latest.json",
-      "cdnHistoryEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/providers/moneybox/history/{YYYY-MM-DD}.json"
+      "cdnHistoryEndpoint": "https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/providers/moneybox/history/{YYYY-MM-DD}.json",
+      "semanticFieldMapping": {
+        "schemaVersion": "2.0",
+        "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+        "providerKind": "exchange-shop",
+        "providerId": "moneybox",
+        "quoteUnit": "KRW_PER_TWD",
+        "asOfSourceField": "timestamp | updateTime",
+        "fields": {
+          "customerBuyForeignRate": {
+            "legacyPath": "rates.TWD.sell",
+            "description": "客戶用 TWD 買外幣（換錢所賣出）；KRW/TWD 直接乘算",
+            "twdToForeignFormula": "amount * rates.TWD.sell"
+          },
+          "customerSellForeignRate": {
+            "legacyPath": "rates.TWD.buy",
+            "description": "客戶用外幣賣回 TWD（換錢所買入）"
+          },
+          "midMarketRate": {
+            "legacyPath": "(buy + sell) / 2",
+            "description": "參考中間價"
+          },
+          "quotePerBaseUnit": {
+            "legacyPath": "rates.TWD.sell",
+            "description": "每 1 TWD 可換的 KRW（直接報價）"
+          }
+        },
+        "examples": {
+          "TWD": {
+            "customerBuyForeignRate": "rates.TWD.sell",
+            "customerSellForeignRate": "rates.TWD.buy",
+            "twdToKrw": "1000 * rates.TWD.sell"
+          }
+        },
+        "bankComparison": {
+          "botQuoteUnit": "TWD_PER_FOREIGN",
+          "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+          "moneyboxQuoteUnit": "KRW_PER_TWD",
+          "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+        }
+      }
     }
   ],
   "rateTypeDescriptions": {

--- a/apps/ratewise/public/api/pairs/aud-twd.json
+++ b/apps/ratewise/public/api/pairs/aud-twd.json
@@ -2,6 +2,49 @@
   "pair": "AUD/TWD",
   "from": "AUD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "aud-twd",
   "pageUrl": "https://app.haotool.org/ratewise/aud-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/cad-twd.json
+++ b/apps/ratewise/public/api/pairs/cad-twd.json
@@ -2,6 +2,49 @@
   "pair": "CAD/TWD",
   "from": "CAD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "cad-twd",
   "pageUrl": "https://app.haotool.org/ratewise/cad-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/chf-twd.json
+++ b/apps/ratewise/public/api/pairs/chf-twd.json
@@ -2,6 +2,49 @@
   "pair": "CHF/TWD",
   "from": "CHF",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "chf-twd",
   "pageUrl": "https://app.haotool.org/ratewise/chf-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/cny-twd.json
+++ b/apps/ratewise/public/api/pairs/cny-twd.json
@@ -2,6 +2,49 @@
   "pair": "CNY/TWD",
   "from": "CNY",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "cny-twd",
   "pageUrl": "https://app.haotool.org/ratewise/cny-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/eur-twd.json
+++ b/apps/ratewise/public/api/pairs/eur-twd.json
@@ -2,6 +2,49 @@
   "pair": "EUR/TWD",
   "from": "EUR",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "eur-twd",
   "pageUrl": "https://app.haotool.org/ratewise/eur-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/gbp-twd.json
+++ b/apps/ratewise/public/api/pairs/gbp-twd.json
@@ -2,6 +2,49 @@
   "pair": "GBP/TWD",
   "from": "GBP",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "gbp-twd",
   "pageUrl": "https://app.haotool.org/ratewise/gbp-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/hkd-twd.json
+++ b/apps/ratewise/public/api/pairs/hkd-twd.json
@@ -2,6 +2,49 @@
   "pair": "HKD/TWD",
   "from": "HKD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "hkd-twd",
   "pageUrl": "https://app.haotool.org/ratewise/hkd-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/idr-twd.json
+++ b/apps/ratewise/public/api/pairs/idr-twd.json
@@ -2,6 +2,49 @@
   "pair": "IDR/TWD",
   "from": "IDR",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "idr-twd",
   "pageUrl": "https://app.haotool.org/ratewise/idr-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/jpy-twd.json
+++ b/apps/ratewise/public/api/pairs/jpy-twd.json
@@ -2,6 +2,49 @@
   "pair": "JPY/TWD",
   "from": "JPY",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "jpy-twd",
   "pageUrl": "https://app.haotool.org/ratewise/jpy-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/krw-twd.json
+++ b/apps/ratewise/public/api/pairs/krw-twd.json
@@ -2,6 +2,49 @@
   "pair": "KRW/TWD",
   "from": "KRW",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "krw-twd",
   "pageUrl": "https://app.haotool.org/ratewise/krw-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/myr-twd.json
+++ b/apps/ratewise/public/api/pairs/myr-twd.json
@@ -2,6 +2,49 @@
   "pair": "MYR/TWD",
   "from": "MYR",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "myr-twd",
   "pageUrl": "https://app.haotool.org/ratewise/myr-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/nzd-twd.json
+++ b/apps/ratewise/public/api/pairs/nzd-twd.json
@@ -2,6 +2,49 @@
   "pair": "NZD/TWD",
   "from": "NZD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "nzd-twd",
   "pageUrl": "https://app.haotool.org/ratewise/nzd-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/php-twd.json
+++ b/apps/ratewise/public/api/pairs/php-twd.json
@@ -2,6 +2,49 @@
   "pair": "PHP/TWD",
   "from": "PHP",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "php-twd",
   "pageUrl": "https://app.haotool.org/ratewise/php-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/sgd-twd.json
+++ b/apps/ratewise/public/api/pairs/sgd-twd.json
@@ -2,6 +2,49 @@
   "pair": "SGD/TWD",
   "from": "SGD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "sgd-twd",
   "pageUrl": "https://app.haotool.org/ratewise/sgd-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/thb-twd.json
+++ b/apps/ratewise/public/api/pairs/thb-twd.json
@@ -2,6 +2,49 @@
   "pair": "THB/TWD",
   "from": "THB",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "thb-twd",
   "pageUrl": "https://app.haotool.org/ratewise/thb-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/usd-twd.json
+++ b/apps/ratewise/public/api/pairs/usd-twd.json
@@ -2,6 +2,49 @@
   "pair": "USD/TWD",
   "from": "USD",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "usd-twd",
   "pageUrl": "https://app.haotool.org/ratewise/usd-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/api/pairs/vnd-twd.json
+++ b/apps/ratewise/public/api/pairs/vnd-twd.json
@@ -2,6 +2,49 @@
   "pair": "VND/TWD",
   "from": "VND",
   "to": "TWD",
+  "schemaVersion": "2.0",
+  "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+  "semanticFieldMapping": {
+    "schemaVersion": "2.0",
+    "semanticsDoc": "https://app.haotool.org/ratewise/open-data/",
+    "providerKind": "bank",
+    "quoteUnit": "TWD_PER_FOREIGN",
+    "asOfSourceField": "timestamp | updateTime",
+    "fields": {
+      "customerBuyForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.sell",
+        "description": "客戶用 TWD 買外幣（銀行賣出）",
+        "twdToForeignFormula": "amount / details.{TO}.{rateType}.sell"
+      },
+      "customerSellForeignRate": {
+        "legacyPath": "details.{CURRENCY}.{rateType}.buy",
+        "description": "客戶用外幣賣回 TWD（銀行買入）",
+        "foreignToTwdFormula": "amount * details.{FROM}.{rateType}.buy"
+      },
+      "midMarketRate": {
+        "legacyPath": "(buy + sell) / 2",
+        "description": "參考中間價"
+      },
+      "bankSellTwdPerUnit": {
+        "legacyPath": "1 / sell",
+        "description": "每 1 單位外幣的 TWD 賣價（外幣計價時）"
+      }
+    },
+    "examples": {
+      "USD": {
+        "cash": {
+          "customerBuyForeignRate": "details.USD.cash.sell",
+          "customerSellForeignRate": "details.USD.cash.buy"
+        }
+      }
+    },
+    "bankComparison": {
+      "botQuoteUnit": "TWD_PER_FOREIGN",
+      "botTwdToForeign": "amount / details.{CCY}.cash.sell",
+      "moneyboxQuoteUnit": "KRW_PER_TWD",
+      "moneyboxTwdToKrw": "amount * rates.TWD.sell"
+    }
+  },
   "slug": "vnd-twd",
   "pageUrl": "https://app.haotool.org/ratewise/vnd-twd/",
   "liveRateUrl": "https://raw.githubusercontent.com/haotool/app/data/public/rates/latest.json",

--- a/apps/ratewise/public/llms.txt
+++ b/apps/ratewise/public/llms.txt
@@ -156,9 +156,11 @@ Contact: haotool.org@gmail.com
 
 ### 即時匯率資料（真實數據，每 5 分鐘更新）
 - 即時匯率 JSON（CDN）: https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/latest.json
-  - 欄位：timestamp, updateTime, source, rates{USD/JPY/EUR/...}, details{貨幣:{spot:{buy,sell}, cash:{buy,sell}}}
-  - 匯率類型：cash_buy=現金買入, cash_sell=現金賣出, spot_buy=即期買入, spot_sell=即期賣出
-  - 說明：賣出（sell）= 銀行賣給你外幣的價格 = 你拿台幣換外幣看此價；買入（buy）= 銀行收你外幣的價格 = 你拿外幣換台幣看此價
+  - 欄位：schemaVersion (2.0), semanticFieldMapping, timestamp, updateTime, source, details{貨幣:{spot/cash + v2 customerBuyForeignRate 等}}
+  - v2 語意：customerBuyForeignRate = 客戶用 TWD 買外幣（台銀對應 sell）；詳見 https://app.haotool.org/ratewise/open-data/
+- MoneyBox 換錢所 JSON（KRW 現金）: https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/providers/moneybox/latest.json
+  - quoteUnit: KRW_PER_TWD；TWD→KRW 用 amount * rates.TWD.sell（與台銀除法語意相反）
+  - 欄位：schemaVersion, semanticFieldMapping, rates.TWD.{buy,sell,customerBuyForeignRate,quotePerBaseUnit}
 
 ### 幣對靜態 JSON 端點（Per-Pair API，供 AI agent / 搜尋系統）
 - 格式：https://app.haotool.org/ratewise/api/pairs/{pair}.json (例如: https://app.haotool.org/ratewise/api/pairs/usd-twd.json)

--- a/apps/ratewise/public/openapi.json
+++ b/apps/ratewise/public/openapi.json
@@ -3,7 +3,7 @@
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "info": {
     "title": "HaoRate 匯率 API",
-    "version": "1.3.0",
+    "version": "2.1.0",
     "description": "臺灣銀行牌告匯率靜態 JSON API，每 5 分鐘由 GitHub Actions 自動同步。\n\n**匯率類型說明：**\n- `cash_buy`（現金買入）：銀行以此價收購外幣現鈔（你拿外幣換台幣）\n- `cash_sell`（現金賣出）：銀行以此價賣出外幣現鈔（你拿台幣換外幣現金）\n- `spot_buy`（即期買入）：電匯/帳戶轉入匯率（你匯款回台灣）\n- `spot_sell`（即期賣出）：電匯/帳戶轉出匯率（你從台灣匯款出去）\n\n**重要提示：** 賣出（sell）= 銀行賣給你外幣的價格 = 你拿台幣換外幣看此價；\n買入（buy）= 銀行收你外幣的價格 = 你拿外幣換台幣看此價。\n\n**App 匯率模式對應：**\n- `auto`：來源外幣用 `{rateType}.buy`，目標外幣用 `{rateType}.sell`；TWD 視為 1。\n- `sell`：來源與目標皆用 `{rateType}.sell`。\n- `mid`：來源與目標皆用 `({rateType}.buy + {rateType}.sell) / 2`。\n\n匯率僅供參考，實際交易請以金融機構公告為準。",
     "contact": {
       "name": "haotool",
@@ -135,9 +135,21 @@
     ],
     "x-webapp": "https://app.haotool.org/ratewise/",
     "x-documentation": "https://app.haotool.org/ratewise/open-data/",
-    "x-app-version": "2.25.3"
+    "x-app-version": "2.25.3",
+    "x-schema-version": "2.0",
+    "x-semantics-doc": "https://app.haotool.org/ratewise/open-data/"
   },
   "x-changelog": {
+    "2.1.0": {
+      "date": "2026-06-27",
+      "summary": "換錢所 provider JSON 新增 schemaVersion、quoteUnit、semanticFieldMapping 與 ExchangeShopRateV2 語意欄位。",
+      "app-version": "2.25.3"
+    },
+    "2.0.0": {
+      "date": "2026-06-27",
+      "summary": "新增 customer-centric v2 語意欄位（customerBuyForeignRate 等）與 schemaVersion；legacy buy/sell 保留。",
+      "app-version": "2.25.3"
+    },
     "1.2.0": {
       "date": "2026-05-09",
       "summary": "新增 MoneyBox 換錢所 current/history 端點與 provider metadata 合約。",
@@ -585,13 +597,42 @@
             "properties": {
               "buy": {
                 "type": "number",
-                "description": "即期買入匯率：銀行以此價收購外幣（你匯款回台灣時適用）",
+                "description": "@deprecated 2026-12-31 — 即期買入匯率（銀行視角）；請改用 customerSellForeignRate",
                 "example": 32.015
               },
               "sell": {
                 "type": "number",
-                "description": "即期賣出匯率：銀行以此價賣出外幣（你從台灣匯款出去時適用）",
+                "description": "@deprecated 2026-12-31 — 即期賣出匯率（銀行視角）；請改用 customerBuyForeignRate",
                 "example": 32.085
+              },
+              "customerBuyForeignRate": {
+                "type": "number",
+                "description": "客戶用 TWD 買外幣（即期）；對應 legacy sell",
+                "example": 32.085
+              },
+              "customerSellForeignRate": {
+                "type": "number",
+                "description": "客戶用外幣賣回 TWD（即期）；對應 legacy buy",
+                "example": 32.015
+              },
+              "midMarketRate": {
+                "type": "number",
+                "example": 32.05
+              },
+              "bankSellTwdPerUnit": {
+                "type": "number",
+                "example": 0.03117
+              },
+              "rateType": {
+                "type": "string",
+                "enum": [
+                  "spot"
+                ],
+                "example": "spot"
+              },
+              "currency": {
+                "type": "string",
+                "example": "USD"
               }
             },
             "required": [
@@ -605,13 +646,42 @@
             "properties": {
               "buy": {
                 "type": "number",
-                "description": "現金買入匯率：銀行以此價收購外幣現鈔（你拿外幣現鈔換台幣時適用）",
+                "description": "@deprecated 2026-12-31 — 現金買入匯率（銀行視角）；請改用 customerSellForeignRate",
                 "example": 31.73
               },
               "sell": {
                 "type": "number",
-                "description": "現金賣出匯率：銀行以此價賣出外幣現鈔（你拿台幣換外幣現鈔時適用）",
+                "description": "@deprecated 2026-12-31 — 現金賣出匯率（銀行視角）；請改用 customerBuyForeignRate",
                 "example": 32.385
+              },
+              "customerBuyForeignRate": {
+                "type": "number",
+                "description": "客戶用 TWD 買外幣（現金）；對應 legacy sell",
+                "example": 32.385
+              },
+              "customerSellForeignRate": {
+                "type": "number",
+                "description": "客戶用外幣賣回 TWD（現金）；對應 legacy buy",
+                "example": 31.73
+              },
+              "midMarketRate": {
+                "type": "number",
+                "example": 32.0575
+              },
+              "bankSellTwdPerUnit": {
+                "type": "number",
+                "example": 0.03087
+              },
+              "rateType": {
+                "type": "string",
+                "enum": [
+                  "cash"
+                ],
+                "example": "cash"
+              },
+              "currency": {
+                "type": "string",
+                "example": "USD"
               }
             },
             "required": [
@@ -625,10 +695,371 @@
           "cash"
         ]
       },
+      "CurrencyRateV2": {
+        "type": "object",
+        "description": "v2 語意化匯率物件（customer-centric additive 欄位；spec §二十一）。legacy buy/sell 仍保留至 2026-12-31 文件 sunset。",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "美金"
+          },
+          "spot": {
+            "type": "object",
+            "description": "v2 語意化匯率區塊（additive；legacy buy/sell 仍保留）",
+            "properties": {
+              "buy": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "@deprecated 2026-12-31 — 銀行視角買入價；請改用 customerSellForeignRate（客戶賣外幣回 TWD）",
+                "example": 32.015
+              },
+              "sell": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "@deprecated 2026-12-31 — 銀行視角賣出價；請改用 customerBuyForeignRate（客戶用 TWD 買外幣）",
+                "example": 32.085
+              },
+              "customerBuyForeignRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "客戶用 TWD 買外幣（銀行賣出）；對應 legacy sell",
+                "example": 32.085
+              },
+              "customerSellForeignRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "客戶用外幣賣回 TWD（銀行買入）；對應 legacy buy",
+                "example": 32.015
+              },
+              "midMarketRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "參考中間價：(buy + sell) / 2",
+                "example": 32.05
+              },
+              "bankSellTwdPerUnit": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "每 1 單位外幣的 TWD 賣價（1 / sell）",
+                "example": 0.03117
+              },
+              "rateType": {
+                "type": "string",
+                "enum": [
+                  "cash",
+                  "spot"
+                ],
+                "example": "cash"
+              },
+              "currency": {
+                "type": "string",
+                "description": "ISO 4217 幣別代碼",
+                "example": "USD"
+              }
+            },
+            "required": [
+              "buy",
+              "sell",
+              "customerBuyForeignRate",
+              "customerSellForeignRate",
+              "midMarketRate",
+              "rateType",
+              "currency"
+            ]
+          },
+          "cash": {
+            "type": "object",
+            "description": "v2 語意化匯率區塊（additive；legacy buy/sell 仍保留）",
+            "properties": {
+              "buy": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "@deprecated 2026-12-31 — 銀行視角買入價；請改用 customerSellForeignRate（客戶賣外幣回 TWD）",
+                "example": 32.015
+              },
+              "sell": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "@deprecated 2026-12-31 — 銀行視角賣出價；請改用 customerBuyForeignRate（客戶用 TWD 買外幣）",
+                "example": 32.085
+              },
+              "customerBuyForeignRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "客戶用 TWD 買外幣（銀行賣出）；對應 legacy sell",
+                "example": 32.085
+              },
+              "customerSellForeignRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "客戶用外幣賣回 TWD（銀行買入）；對應 legacy buy",
+                "example": 32.015
+              },
+              "midMarketRate": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "參考中間價：(buy + sell) / 2",
+                "example": 32.05
+              },
+              "bankSellTwdPerUnit": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "每 1 單位外幣的 TWD 賣價（1 / sell）",
+                "example": 0.03117
+              },
+              "rateType": {
+                "type": "string",
+                "enum": [
+                  "cash",
+                  "spot"
+                ],
+                "example": "cash"
+              },
+              "currency": {
+                "type": "string",
+                "description": "ISO 4217 幣別代碼",
+                "example": "USD"
+              }
+            },
+            "required": [
+              "buy",
+              "sell",
+              "customerBuyForeignRate",
+              "customerSellForeignRate",
+              "midMarketRate",
+              "rateType",
+              "currency"
+            ]
+          }
+        },
+        "required": [
+          "spot",
+          "cash"
+        ]
+      },
+      "SemanticRateTypeBlock": {
+        "type": "object",
+        "description": "v2 語意化匯率區塊（additive；legacy buy/sell 仍保留）",
+        "properties": {
+          "buy": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "@deprecated 2026-12-31 — 銀行視角買入價；請改用 customerSellForeignRate（客戶賣外幣回 TWD）",
+            "example": 32.015
+          },
+          "sell": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "@deprecated 2026-12-31 — 銀行視角賣出價；請改用 customerBuyForeignRate（客戶用 TWD 買外幣）",
+            "example": 32.085
+          },
+          "customerBuyForeignRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "客戶用 TWD 買外幣（銀行賣出）；對應 legacy sell",
+            "example": 32.085
+          },
+          "customerSellForeignRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "客戶用外幣賣回 TWD（銀行買入）；對應 legacy buy",
+            "example": 32.015
+          },
+          "midMarketRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "參考中間價：(buy + sell) / 2",
+            "example": 32.05
+          },
+          "bankSellTwdPerUnit": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "每 1 單位外幣的 TWD 賣價（1 / sell）",
+            "example": 0.03117
+          },
+          "rateType": {
+            "type": "string",
+            "enum": [
+              "cash",
+              "spot"
+            ],
+            "example": "cash"
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 幣別代碼",
+            "example": "USD"
+          }
+        },
+        "required": [
+          "buy",
+          "sell",
+          "customerBuyForeignRate",
+          "customerSellForeignRate",
+          "midMarketRate",
+          "rateType",
+          "currency"
+        ]
+      },
+      "ExchangeShopRateV2": {
+        "type": "object",
+        "description": "換錢所單一幣別報價（legacy + v2 additive）",
+        "properties": {
+          "currency": {
+            "type": "string",
+            "example": "TWD"
+          },
+          "base": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "example": 44.9
+          },
+          "buy": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "@deprecated 2026-12-31 — 換錢所買入價；請改用 customerSellForeignRate",
+            "example": 45.1
+          },
+          "sell": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "@deprecated 2026-12-31 — 換錢所賣出價；請改用 customerBuyForeignRate",
+            "example": 44.9
+          },
+          "spbuy": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "example": 45.2
+          },
+          "spsell": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "example": 44.8
+          },
+          "customerBuyForeignRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "客戶用 TWD 買外幣（換錢所賣出）；MoneyBox TWD 對應 rates.TWD.sell（KRW/TWD）",
+            "example": 46.5
+          },
+          "customerSellForeignRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "客戶用外幣賣回 TWD（換錢所買入）；對應 legacy buy",
+            "example": 46
+          },
+          "midMarketRate": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "參考中間價：(buy + sell) / 2",
+            "example": 46.25
+          },
+          "quoteUnit": {
+            "type": "string",
+            "enum": [
+              "TWD_PER_FOREIGN",
+              "KRW_PER_TWD"
+            ],
+            "description": "報價單位；MoneyBox TWD 為 KRW_PER_TWD（與台銀 TWD_PER_FOREIGN 相反）",
+            "example": "KRW_PER_TWD"
+          },
+          "quotePerBaseUnit": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "每 1 TWD 可換 KRW（KRW_PER_TWD 時等同 sell；台銀語意為 1/sell）",
+            "example": 46.5
+          }
+        },
+        "required": [
+          "currency",
+          "base",
+          "buy",
+          "sell",
+          "spbuy",
+          "spsell"
+        ]
+      },
       "ExchangeShopRatesResponse": {
         "type": "object",
-        "description": "換錢所匯率資料回應。目前 MoneyBox 以 KRW 為基準，TWD rate 表示 1 TWD 可換多少 KRW。",
+        "description": "換錢所匯率資料回應。MoneyBox 以 KRW 為基準；TWD rate 表示 1 TWD 可換多少 KRW（sell 直接乘算）。",
         "properties": {
+          "schemaVersion": {
+            "type": "string",
+            "description": "API 語意版本（有別於 App semver）",
+            "example": "2.0"
+          },
+          "asOf": {
+            "type": "string",
+            "format": "date-time",
+            "description": "資料生效時間（通常對應 timestamp）",
+            "example": "2026-06-27T04:00:00.000Z"
+          },
+          "semanticFieldMapping": {
+            "type": "object",
+            "description": "v2 語意欄位對照（見 open-data / latest.json metadata）"
+          },
+          "quoteUnit": {
+            "type": "string",
+            "enum": [
+              "KRW_PER_TWD"
+            ],
+            "description": "MoneyBox TWD 報價單位（與台銀 details 語意不同）",
+            "example": "KRW_PER_TWD"
+          },
           "timestamp": {
             "type": "string",
             "format": "date-time",
@@ -656,56 +1087,7 @@
           "rates": {
             "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "currency": {
-                  "type": "string",
-                  "example": "TWD"
-                },
-                "base": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 44.9
-                },
-                "buy": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 45.1
-                },
-                "sell": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 44.9
-                },
-                "spbuy": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 45.2
-                },
-                "spsell": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 44.8
-                }
-              },
-              "required": [
-                "currency",
-                "base",
-                "buy",
-                "sell",
-                "spbuy",
-                "spsell"
-              ]
+              "$ref": "#/components/schemas/ExchangeShopRateV2"
             }
           }
         },
@@ -722,6 +1104,17 @@
         "type": "object",
         "description": "匯率資料回應（每 5 分鐘由 GitHub Actions 自動同步）",
         "properties": {
+          "schemaVersion": {
+            "type": "string",
+            "description": "API 語意版本（有別於 App semver）",
+            "example": "2.0"
+          },
+          "asOf": {
+            "type": "string",
+            "format": "date-time",
+            "description": "牌告生效時間（通常對應 timestamp 或 updateTime）",
+            "example": "2026-06-27T04:00:00.000Z"
+          },
           "timestamp": {
             "type": "string",
             "format": "date-time",
@@ -753,9 +1146,9 @@
           },
           "details": {
             "type": "object",
-            "description": "各幣別完整四種報價資料（以幣別代碼為 key）",
+            "description": "各幣別完整四種報價資料（以幣別代碼為 key）；v2 欄位見 CurrencyRateV2 / CurrencyRateDetail",
             "additionalProperties": {
-              "$ref": "#/components/schemas/CurrencyRateDetail"
+              "$ref": "#/components/schemas/CurrencyRateV2"
             },
             "example": {
               "USD": {

--- a/apps/ratewise/scripts/generate-api-json.mjs
+++ b/apps/ratewise/scripts/generate-api-json.mjs
@@ -11,6 +11,12 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SITE_CONFIG, RAW_DATA_BASE, CDN_DATA_BASE } from '../seo-paths.config.mjs';
 import { APP_INFO } from '../src/config/app-info.ts';
+import {
+  API_SEMANTICS_DOC,
+  API_SEMANTICS_SCHEMA_VERSION,
+  buildProviderSemanticFieldMapping,
+  buildSemanticFieldMapping,
+} from '../src/config/api-semantics-v2.ts';
 import { buildPublicRateProviderMetadata } from '../src/config/rateProviderPublicMetadata.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -42,6 +48,9 @@ const exchangeShopProvider = providerMetadata.providers.find(
 const latestJson = {
   name: `${APP_INFO.shortName} Exchange Rate API`,
   version: pkg.version,
+  schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+  semanticsDoc: API_SEMANTICS_DOC.publicUrl,
+  semanticFieldMapping: buildSemanticFieldMapping(),
   description: '臺灣銀行牌告匯率靜態 API — 資料每 5 分鐘自動同步，並提供 App 匯率模式欄位對照',
   source: '臺灣銀行牌告匯率',
   sourceUrl: 'https://rate.bot.com.tw/xrt',
@@ -64,7 +73,13 @@ const latestJson = {
     moneyboxHistory: exchangeShopProvider?.cdnHistoryEndpoint,
   },
   providerSelection,
-  providers,
+  providers: providers.map((provider) => ({
+    ...provider,
+    semanticFieldMapping: buildProviderSemanticFieldMapping(provider.sourceKind, {
+      providerId: provider.providerId,
+      ...(provider.sourceKind === 'exchange-shop' ? { quoteUnit: 'KRW_PER_TWD' } : {}),
+    }),
+  })),
   rateTypeDescriptions: {
     cash_buy: '現金買入：銀行以此價收購外幣現鈔（你拿外幣換台幣）',
     cash_sell: '現金賣出：銀行以此價賣出外幣現鈔（你拿台幣換外幣現金）',

--- a/apps/ratewise/scripts/generate-llms-txt.mjs
+++ b/apps/ratewise/scripts/generate-llms-txt.mjs
@@ -207,9 +207,11 @@ Contact: ${pkg.author?.email || 'haotool.org@gmail.com'}
 
 ### 即時匯率資料（真實數據，每 5 分鐘更新）
 - 即時匯率 JSON（CDN）: https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/latest.json
-  - 欄位：timestamp, updateTime, source, rates{USD/JPY/EUR/...}, details{貨幣:{spot:{buy,sell}, cash:{buy,sell}}}
-  - 匯率類型：cash_buy=現金買入, cash_sell=現金賣出, spot_buy=即期買入, spot_sell=即期賣出
-  - 說明：賣出（sell）= 銀行賣給你外幣的價格 = 你拿台幣換外幣看此價；買入（buy）= 銀行收你外幣的價格 = 你拿外幣換台幣看此價
+  - 欄位：schemaVersion (2.0), semanticFieldMapping, timestamp, updateTime, source, details{貨幣:{spot/cash + v2 customerBuyForeignRate 等}}
+  - v2 語意：customerBuyForeignRate = 客戶用 TWD 買外幣（台銀對應 sell）；詳見 ${BASE_URL}open-data/
+- MoneyBox 換錢所 JSON（KRW 現金）: https://cdn.jsdelivr.net/gh/haotool/app@data/public/rates/providers/moneybox/latest.json
+  - quoteUnit: KRW_PER_TWD；TWD→KRW 用 amount * rates.TWD.sell（與台銀除法語意相反）
+  - 欄位：schemaVersion, semanticFieldMapping, rates.TWD.{buy,sell,customerBuyForeignRate,quotePerBaseUnit}
 
 ### 幣對靜態 JSON 端點（Per-Pair API，供 AI agent / 搜尋系統）
 - 格式：${BASE_URL}api/pairs/{pair}.json (例如: ${BASE_URL}api/pairs/usd-twd.json)

--- a/apps/ratewise/scripts/generate-openapi.mjs
+++ b/apps/ratewise/scripts/generate-openapi.mjs
@@ -3,6 +3,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SITE_CONFIG, RAW_DATA_BASE, CDN_DATA_BASE } from '../seo-paths.config.mjs';
 import { APP_INFO } from '../src/config/app-info.ts';
+import { API_SEMANTICS_DOC, API_SEMANTICS_SCHEMA_VERSION } from '../src/config/api-semantics-v2.ts';
 import { PROVIDER_RATES_PATH } from '../src/config/api-endpoints.ts';
 import { buildPublicRateProviderMetadata } from '../src/config/rateProviderPublicMetadata.ts';
 
@@ -12,7 +13,7 @@ const ROOT = resolve(__dirname, '..');
 const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8'));
 const APP_VERSION = pkg.version;
 
-const API_VERSION = '1.3.0';
+const API_VERSION = '2.1.0';
 
 const constantsPath = resolve(ROOT, 'src/features/ratewise/constants.ts');
 const constantsContent = readFileSync(constantsPath, 'utf-8');
@@ -112,6 +113,64 @@ const response429 = {
   },
 };
 
+const semanticRateTypeBlockSchema = {
+  type: 'object',
+  description: 'v2 語意化匯率區塊（additive；legacy buy/sell 仍保留）',
+  properties: {
+    buy: {
+      type: ['number', 'null'],
+      description:
+        '@deprecated 2026-12-31 — 銀行視角買入價；請改用 customerSellForeignRate（客戶賣外幣回 TWD）',
+      example: 32.015,
+    },
+    sell: {
+      type: ['number', 'null'],
+      description:
+        '@deprecated 2026-12-31 — 銀行視角賣出價；請改用 customerBuyForeignRate（客戶用 TWD 買外幣）',
+      example: 32.085,
+    },
+    customerBuyForeignRate: {
+      type: ['number', 'null'],
+      description: '客戶用 TWD 買外幣（銀行賣出）；對應 legacy sell',
+      example: 32.085,
+    },
+    customerSellForeignRate: {
+      type: ['number', 'null'],
+      description: '客戶用外幣賣回 TWD（銀行買入）；對應 legacy buy',
+      example: 32.015,
+    },
+    midMarketRate: {
+      type: ['number', 'null'],
+      description: '參考中間價：(buy + sell) / 2',
+      example: 32.05,
+    },
+    bankSellTwdPerUnit: {
+      type: ['number', 'null'],
+      description: '每 1 單位外幣的 TWD 賣價（1 / sell）',
+      example: 0.03117,
+    },
+    rateType: {
+      type: 'string',
+      enum: ['cash', 'spot'],
+      example: 'cash',
+    },
+    currency: {
+      type: 'string',
+      description: 'ISO 4217 幣別代碼',
+      example: 'USD',
+    },
+  },
+  required: [
+    'buy',
+    'sell',
+    'customerBuyForeignRate',
+    'customerSellForeignRate',
+    'midMarketRate',
+    'rateType',
+    'currency',
+  ],
+};
+
 const currencyRateDetailSchema = {
   type: 'object',
   description: '單一幣別的完整四種報價（即期與現金的買入/賣出）',
@@ -122,14 +181,30 @@ const currencyRateDetailSchema = {
       properties: {
         buy: {
           type: 'number',
-          description: '即期買入匯率：銀行以此價收購外幣（你匯款回台灣時適用）',
+          description:
+            '@deprecated 2026-12-31 — 即期買入匯率（銀行視角）；請改用 customerSellForeignRate',
           example: 32.015,
         },
         sell: {
           type: 'number',
-          description: '即期賣出匯率：銀行以此價賣出外幣（你從台灣匯款出去時適用）',
+          description:
+            '@deprecated 2026-12-31 — 即期賣出匯率（銀行視角）；請改用 customerBuyForeignRate',
           example: 32.085,
         },
+        customerBuyForeignRate: {
+          type: 'number',
+          description: '客戶用 TWD 買外幣（即期）；對應 legacy sell',
+          example: 32.085,
+        },
+        customerSellForeignRate: {
+          type: 'number',
+          description: '客戶用外幣賣回 TWD（即期）；對應 legacy buy',
+          example: 32.015,
+        },
+        midMarketRate: { type: 'number', example: 32.05 },
+        bankSellTwdPerUnit: { type: 'number', example: 0.03117 },
+        rateType: { type: 'string', enum: ['spot'], example: 'spot' },
+        currency: { type: 'string', example: 'USD' },
       },
       required: ['buy', 'sell'],
     },
@@ -139,17 +214,45 @@ const currencyRateDetailSchema = {
       properties: {
         buy: {
           type: 'number',
-          description: '現金買入匯率：銀行以此價收購外幣現鈔（你拿外幣現鈔換台幣時適用）',
+          description:
+            '@deprecated 2026-12-31 — 現金買入匯率（銀行視角）；請改用 customerSellForeignRate',
           example: 31.73,
         },
         sell: {
           type: 'number',
-          description: '現金賣出匯率：銀行以此價賣出外幣現鈔（你拿台幣換外幣現鈔時適用）',
+          description:
+            '@deprecated 2026-12-31 — 現金賣出匯率（銀行視角）；請改用 customerBuyForeignRate',
           example: 32.385,
         },
+        customerBuyForeignRate: {
+          type: 'number',
+          description: '客戶用 TWD 買外幣（現金）；對應 legacy sell',
+          example: 32.385,
+        },
+        customerSellForeignRate: {
+          type: 'number',
+          description: '客戶用外幣賣回 TWD（現金）；對應 legacy buy',
+          example: 31.73,
+        },
+        midMarketRate: { type: 'number', example: 32.0575 },
+        bankSellTwdPerUnit: { type: 'number', example: 0.03087 },
+        rateType: { type: 'string', enum: ['cash'], example: 'cash' },
+        currency: { type: 'string', example: 'USD' },
       },
       required: ['buy', 'sell'],
     },
+  },
+  required: ['spot', 'cash'],
+};
+
+const currencyRateV2Schema = {
+  type: 'object',
+  description:
+    'v2 語意化匯率物件（customer-centric additive 欄位；spec §二十一）。legacy buy/sell 仍保留至 2026-12-31 文件 sunset。',
+  properties: {
+    name: { type: 'string', example: '美金' },
+    spot: semanticRateTypeBlockSchema,
+    cash: semanticRateTypeBlockSchema,
   },
   required: ['spot', 'cash'],
 };
@@ -158,6 +261,17 @@ const ratesResponseSchema = {
   type: 'object',
   description: '匯率資料回應（每 5 分鐘由 GitHub Actions 自動同步）',
   properties: {
+    schemaVersion: {
+      type: 'string',
+      description: 'API 語意版本（有別於 App semver）',
+      example: API_SEMANTICS_SCHEMA_VERSION,
+    },
+    asOf: {
+      type: 'string',
+      format: 'date-time',
+      description: '牌告生效時間（通常對應 timestamp 或 updateTime）',
+      example: '2026-06-27T04:00:00.000Z',
+    },
     timestamp: {
       type: 'string',
       format: 'date-time',
@@ -186,8 +300,9 @@ const ratesResponseSchema = {
     },
     details: {
       type: 'object',
-      description: '各幣別完整四種報價資料（以幣別代碼為 key）',
-      additionalProperties: { $ref: '#/components/schemas/CurrencyRateDetail' },
+      description:
+        '各幣別完整四種報價資料（以幣別代碼為 key）；v2 欄位見 CurrencyRateV2 / CurrencyRateDetail',
+      additionalProperties: { $ref: '#/components/schemas/CurrencyRateV2' },
       example: {
         USD: { spot: { buy: 32.015, sell: 32.085 }, cash: { buy: 31.73, sell: 32.385 } },
         JPY: { spot: { buy: 0.2078, sell: 0.2088 }, cash: { buy: 0.2041, sell: 0.2119 } },
@@ -197,11 +312,80 @@ const ratesResponseSchema = {
   required: ['timestamp', 'updateTime', 'source', 'rates', 'details'],
 };
 
+const exchangeShopRateBlockSchema = {
+  type: 'object',
+  description: '換錢所單一幣別報價（legacy + v2 additive）',
+  properties: {
+    currency: { type: 'string', example: 'TWD' },
+    base: { type: ['number', 'null'], example: 44.9 },
+    buy: {
+      type: ['number', 'null'],
+      description: '@deprecated 2026-12-31 — 換錢所買入價；請改用 customerSellForeignRate',
+      example: 45.1,
+    },
+    sell: {
+      type: ['number', 'null'],
+      description: '@deprecated 2026-12-31 — 換錢所賣出價；請改用 customerBuyForeignRate',
+      example: 44.9,
+    },
+    spbuy: { type: ['number', 'null'], example: 45.2 },
+    spsell: { type: ['number', 'null'], example: 44.8 },
+    customerBuyForeignRate: {
+      type: ['number', 'null'],
+      description: '客戶用 TWD 買外幣（換錢所賣出）；MoneyBox TWD 對應 rates.TWD.sell（KRW/TWD）',
+      example: 46.5,
+    },
+    customerSellForeignRate: {
+      type: ['number', 'null'],
+      description: '客戶用外幣賣回 TWD（換錢所買入）；對應 legacy buy',
+      example: 46.0,
+    },
+    midMarketRate: {
+      type: ['number', 'null'],
+      description: '參考中間價：(buy + sell) / 2',
+      example: 46.25,
+    },
+    quoteUnit: {
+      type: 'string',
+      enum: ['TWD_PER_FOREIGN', 'KRW_PER_TWD'],
+      description: '報價單位；MoneyBox TWD 為 KRW_PER_TWD（與台銀 TWD_PER_FOREIGN 相反）',
+      example: 'KRW_PER_TWD',
+    },
+    quotePerBaseUnit: {
+      type: ['number', 'null'],
+      description: '每 1 TWD 可換 KRW（KRW_PER_TWD 時等同 sell；台銀語意為 1/sell）',
+      example: 46.5,
+    },
+  },
+  required: ['currency', 'base', 'buy', 'sell', 'spbuy', 'spsell'],
+};
+
 const exchangeShopRatesResponseSchema = {
   type: 'object',
   description:
-    '換錢所匯率資料回應。目前 MoneyBox 以 KRW 為基準，TWD rate 表示 1 TWD 可換多少 KRW。',
+    '換錢所匯率資料回應。MoneyBox 以 KRW 為基準；TWD rate 表示 1 TWD 可換多少 KRW（sell 直接乘算）。',
   properties: {
+    schemaVersion: {
+      type: 'string',
+      description: 'API 語意版本（有別於 App semver）',
+      example: API_SEMANTICS_SCHEMA_VERSION,
+    },
+    asOf: {
+      type: 'string',
+      format: 'date-time',
+      description: '資料生效時間（通常對應 timestamp）',
+      example: '2026-06-27T04:00:00.000Z',
+    },
+    semanticFieldMapping: {
+      type: 'object',
+      description: 'v2 語意欄位對照（見 open-data / latest.json metadata）',
+    },
+    quoteUnit: {
+      type: 'string',
+      enum: ['KRW_PER_TWD'],
+      description: 'MoneyBox TWD 報價單位（與台銀 details 語意不同）',
+      example: 'KRW_PER_TWD',
+    },
     timestamp: {
       type: 'string',
       format: 'date-time',
@@ -229,16 +413,7 @@ const exchangeShopRatesResponseSchema = {
     rates: {
       type: 'object',
       additionalProperties: {
-        type: 'object',
-        properties: {
-          currency: { type: 'string', example: 'TWD' },
-          base: { type: ['number', 'null'], example: 44.9 },
-          buy: { type: ['number', 'null'], example: 45.1 },
-          sell: { type: ['number', 'null'], example: 44.9 },
-          spbuy: { type: ['number', 'null'], example: 45.2 },
-          spsell: { type: ['number', 'null'], example: 44.8 },
-        },
-        required: ['currency', 'base', 'buy', 'sell', 'spbuy', 'spsell'],
+        $ref: '#/components/schemas/ExchangeShopRateV2',
       },
     },
   },
@@ -363,8 +538,22 @@ const openApiSpec = {
     'x-webapp': SITE_CONFIG.url,
     'x-documentation': `${SITE_CONFIG.url}open-data/`,
     'x-app-version': APP_VERSION,
+    'x-schema-version': API_SEMANTICS_SCHEMA_VERSION,
+    'x-semantics-doc': API_SEMANTICS_DOC.publicUrl,
   },
   'x-changelog': {
+    '2.1.0': {
+      date: '2026-06-27',
+      summary:
+        '換錢所 provider JSON 新增 schemaVersion、quoteUnit、semanticFieldMapping 與 ExchangeShopRateV2 語意欄位。',
+      'app-version': APP_VERSION,
+    },
+    '2.0.0': {
+      date: '2026-06-27',
+      summary:
+        '新增 customer-centric v2 語意欄位（customerBuyForeignRate 等）與 schemaVersion；legacy buy/sell 保留。',
+      'app-version': APP_VERSION,
+    },
     '1.2.0': {
       date: '2026-05-09',
       summary: '新增 MoneyBox 換錢所 current/history 端點與 provider metadata 合約。',
@@ -619,6 +808,9 @@ const openApiSpec = {
   components: {
     schemas: {
       CurrencyRateDetail: currencyRateDetailSchema,
+      CurrencyRateV2: currencyRateV2Schema,
+      SemanticRateTypeBlock: semanticRateTypeBlockSchema,
+      ExchangeShopRateV2: exchangeShopRateBlockSchema,
       ExchangeShopRatesResponse: exchangeShopRatesResponseSchema,
       RatesResponse: ratesResponseSchema,
       PairInfo: pairInfoSchema,

--- a/apps/ratewise/scripts/generate-pair-json.mjs
+++ b/apps/ratewise/scripts/generate-pair-json.mjs
@@ -14,6 +14,11 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CURRENCY_SEO_PATHS, SITE_CONFIG, RAW_DATA_BASE } from '../seo-paths.config.mjs';
+import {
+  API_SEMANTICS_DOC,
+  API_SEMANTICS_SCHEMA_VERSION,
+  buildSemanticFieldMapping,
+} from '../src/config/api-semantics-v2.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -47,6 +52,9 @@ for (const path of CURRENCY_SEO_PATHS) {
     pair: `${fromCode}/${toCode}`,
     from: fromCode,
     to: toCode,
+    schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+    semanticsDoc: API_SEMANTICS_DOC.publicUrl,
+    semanticFieldMapping: buildSemanticFieldMapping(),
     slug,
     pageUrl: `${SITE_CONFIG.url}${slug}/`,
     liveRateUrl: `${CDN_BASE_URL}/latest.json`,

--- a/apps/ratewise/src/config/__tests__/api-semantics-v2.test.ts
+++ b/apps/ratewise/src/config/__tests__/api-semantics-v2.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  API_SEMANTICS_SCHEMA_VERSION,
+  buildProviderSemanticFieldMapping,
+  buildSemanticFieldMapping,
+  enrichCurrencyDetail,
+  enrichExchangeShopRatesPayload,
+  enrichRatesPayload,
+} from '../api-semantics-v2';
+
+const buildTimeRatesPath = resolve(__dirname, '../generated/build-time-rates.json');
+const buildTimeRates = JSON.parse(readFileSync(buildTimeRatesPath, 'utf-8')) as {
+  timestamp: string;
+  updateTime: string;
+  details: Record<
+    string,
+    { spot: { buy: number; sell: number }; cash: { buy: number; sell: number } }
+  >;
+};
+
+const usdRates = buildTimeRates.details['USD']!;
+const jpyRates = buildTimeRates.details['JPY']!;
+
+describe('api-semantics-v2', () => {
+  it('maps USD cash customerBuyForeignRate to legacy sell (spec §21.3)', () => {
+    const enriched = enrichCurrencyDetail('USD', usdRates);
+
+    expect(enriched.cash.customerBuyForeignRate).toBe(usdRates.cash.sell);
+    expect(enriched.cash.customerSellForeignRate).toBe(usdRates.cash.buy);
+    expect(enriched.cash.midMarketRate).toBe(
+      Number(((usdRates.cash.buy + usdRates.cash.sell) / 2).toFixed(6)),
+    );
+  });
+
+  it('maps USD spot fields with rateType=cash|spot', () => {
+    const enriched = enrichCurrencyDetail('USD', usdRates);
+
+    expect(enriched.spot.rateType).toBe('spot');
+    expect(enriched.cash.rateType).toBe('cash');
+    expect(enriched.spot.currency).toBe('USD');
+    expect(enriched.spot.customerBuyForeignRate).toBe(usdRates.spot.sell);
+  });
+
+  it('enriches full payload with schemaVersion and asOf', () => {
+    const enriched = enrichRatesPayload(buildTimeRates);
+
+    expect(enriched.schemaVersion).toBe(API_SEMANTICS_SCHEMA_VERSION);
+    expect(enriched.asOf).toBeTruthy();
+    expect(enriched.details?.['USD']?.cash.customerBuyForeignRate).toBe(usdRates.cash.sell);
+  });
+
+  it('preserves legacy buy/sell on enriched blocks', () => {
+    const enriched = enrichCurrencyDetail('JPY', jpyRates);
+
+    expect(enriched.cash.buy).toBe(jpyRates.cash.buy);
+    expect(enriched.cash.sell).toBe(jpyRates.cash.sell);
+  });
+
+  it('exports semantic field mapping metadata', () => {
+    const mapping = buildSemanticFieldMapping();
+
+    expect(mapping.schemaVersion).toBe('2.0');
+    expect(mapping.fields.customerBuyForeignRate.legacyPath).toContain('.sell');
+    expect(mapping.fields.customerSellForeignRate.legacyPath).toContain('.buy');
+  });
+
+  it('maps MoneyBox TWD sell to customerBuyForeignRate with KRW_PER_TWD (spec §21.2)', () => {
+    const payload = enrichExchangeShopRatesPayload({
+      timestamp: '2026-06-27T04:00:00.000Z',
+      updateTime: '2026/06/27 13:00:00',
+      base: 'KRW',
+      rates: {
+        TWD: {
+          currency: 'TWD',
+          base: 46.2,
+          buy: 46.0,
+          sell: 46.5,
+          spbuy: 46.1,
+          spsell: 46.4,
+        },
+      },
+    });
+
+    const twd = payload.rates['TWD'];
+    expect(twd).toBeDefined();
+    if (!twd) return;
+
+    expect(payload.schemaVersion).toBe(API_SEMANTICS_SCHEMA_VERSION);
+    expect(payload.quoteUnit).toBe('KRW_PER_TWD');
+    expect(twd.customerBuyForeignRate).toBe(46.5);
+    expect(twd.customerSellForeignRate).toBe(46.0);
+    expect(twd.quoteUnit).toBe('KRW_PER_TWD');
+    expect(twd.quotePerBaseUnit).toBe(46.5);
+    expect(twd.sell).toBe(46.5);
+    expect(payload.semanticFieldMapping.providerKind).toBe('exchange-shop');
+    expect(payload.semanticFieldMapping.fields.customerBuyForeignRate.twdToForeignFormula).toBe(
+      'amount * rates.TWD.sell',
+    );
+  });
+
+  it('buildProviderSemanticFieldMapping distinguishes bank vs exchange-shop quote units', () => {
+    const bank = buildProviderSemanticFieldMapping('bank');
+    const shop = buildProviderSemanticFieldMapping('exchange-shop', {
+      providerId: 'moneybox',
+      quoteUnit: 'KRW_PER_TWD',
+    });
+
+    expect(bank.quoteUnit).toBe('TWD_PER_FOREIGN');
+    expect(shop.quoteUnit).toBe('KRW_PER_TWD');
+    expect(shop.bankComparison.moneyboxTwdToKrw).toBe('amount * rates.TWD.sell');
+    expect(bank.bankComparison.botTwdToForeign).toContain('details');
+  });
+});

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -949,7 +949,8 @@ describe('ratewise build scripts', () => {
     expect(typeof fixture.updateTime).toBe('string');
     expect(fixture.details).not.toHaveProperty('TWD');
 
-    expect(openApiGenerator).toContain("const API_VERSION = '1.3.0'");
+    expect(openApiGenerator).toContain("const API_VERSION = '2.1.0'");
+    expect(openApiGenerator).toContain('ExchangeShopRateV2');
     expect(openApiGenerator).toContain("timestamp: {\n      type: 'string'");
     expect(openApiGenerator).not.toContain("description: 'Unix 時間戳（毫秒）'");
     expect(openApiGenerator).not.toContain(

--- a/apps/ratewise/src/config/api-semantics-v2.ts
+++ b/apps/ratewise/src/config/api-semantics-v2.ts
@@ -1,0 +1,335 @@
+/**
+ * API Semantics v2 SSOT（spec §二十一）。
+ * legacy buy/sell 保留；v2 欄位為 additive customer-centric 語意層。
+ */
+
+export const API_SEMANTICS_SCHEMA_VERSION = '2.0' as const;
+
+export const API_SEMANTICS_DOC = {
+  specPath: 'docs/superpowers/specs/2026-06-26-ratewise-2026-product-ux-spec.md',
+  section: '二十一',
+  publicUrl: 'https://app.haotool.org/ratewise/open-data/',
+} as const;
+
+export type ApiSemanticRateType = 'cash' | 'spot';
+
+/** 台銀：sell = TWD/外幣單位；MoneyBox TWD：sell = KRW/TWD。 */
+export type QuoteUnit = 'TWD_PER_FOREIGN' | 'KRW_PER_TWD';
+
+export interface LegacyRateTypeBlock {
+  buy: number | null;
+  sell: number | null;
+}
+
+export interface SemanticRateTypeBlock extends LegacyRateTypeBlock {
+  customerBuyForeignRate: number | null;
+  customerSellForeignRate: number | null;
+  midMarketRate: number | null;
+  bankSellTwdPerUnit: number | null;
+  rateType: ApiSemanticRateType;
+  currency: string;
+  quoteUnit: QuoteUnit;
+}
+
+export interface LegacyCurrencyDetail {
+  name?: string;
+  spot: LegacyRateTypeBlock;
+  cash: LegacyRateTypeBlock;
+}
+
+export interface SemanticCurrencyDetail {
+  name?: string;
+  spot: SemanticRateTypeBlock;
+  cash: SemanticRateTypeBlock;
+}
+
+export interface LegacyExchangeShopRate {
+  currency: string;
+  base: number | null;
+  buy: number | null;
+  sell: number | null;
+  spbuy: number | null;
+  spsell: number | null;
+}
+
+export interface SemanticExchangeShopRate extends LegacyExchangeShopRate {
+  customerBuyForeignRate: number | null;
+  customerSellForeignRate: number | null;
+  midMarketRate: number | null;
+  quoteUnit: QuoteUnit;
+  quotePerBaseUnit: number | null;
+}
+
+export type ProviderSemanticKind = 'bank' | 'exchange-shop';
+
+export function computeMidMarketRate(
+  buy: number | null | undefined,
+  sell: number | null | undefined,
+): number | null {
+  if (buy == null || sell == null || !Number.isFinite(buy) || !Number.isFinite(sell)) {
+    return null;
+  }
+  return Number(((buy + sell) / 2).toFixed(6));
+}
+
+export function computeBankSellTwdPerUnit(sell: number | null | undefined): number | null {
+  if (sell == null || !Number.isFinite(sell) || sell === 0) {
+    return null;
+  }
+  return Number((1 / sell).toFixed(8));
+}
+
+export function resolveQuoteUnitForExchangeShopCurrency(
+  currency: string,
+  baseCurrency: string,
+): QuoteUnit {
+  if (currency === 'TWD' && baseCurrency === 'KRW') {
+    return 'KRW_PER_TWD';
+  }
+  return 'TWD_PER_FOREIGN';
+}
+
+export function computeQuotePerBaseUnit(
+  sell: number | null | undefined,
+  quoteUnit: QuoteUnit,
+): number | null {
+  if (sell == null || !Number.isFinite(sell)) {
+    return null;
+  }
+  if (quoteUnit === 'KRW_PER_TWD') {
+    return sell;
+  }
+  return computeBankSellTwdPerUnit(sell);
+}
+
+export function enrichRateTypeBlock(
+  block: LegacyRateTypeBlock,
+  currency: string,
+  rateType: ApiSemanticRateType,
+  quoteUnit: QuoteUnit = 'TWD_PER_FOREIGN',
+): SemanticRateTypeBlock {
+  const buy = block.buy ?? null;
+  const sell = block.sell ?? null;
+
+  return {
+    buy,
+    sell,
+    customerBuyForeignRate: sell,
+    customerSellForeignRate: buy,
+    midMarketRate: computeMidMarketRate(buy, sell),
+    bankSellTwdPerUnit: computeBankSellTwdPerUnit(sell),
+    rateType,
+    currency,
+    quoteUnit,
+  };
+}
+
+export function enrichCurrencyDetail(
+  currency: string,
+  detail: LegacyCurrencyDetail,
+): SemanticCurrencyDetail {
+  return {
+    ...(detail.name !== undefined ? { name: detail.name } : {}),
+    spot: enrichRateTypeBlock(detail.spot, currency, 'spot', 'TWD_PER_FOREIGN'),
+    cash: enrichRateTypeBlock(detail.cash, currency, 'cash', 'TWD_PER_FOREIGN'),
+  };
+}
+
+export function enrichExchangeShopRate(
+  block: LegacyExchangeShopRate,
+  quoteUnit: QuoteUnit,
+): SemanticExchangeShopRate {
+  const buy = block.buy ?? null;
+  const sell = block.sell ?? null;
+
+  return {
+    ...block,
+    customerBuyForeignRate: sell,
+    customerSellForeignRate: buy,
+    midMarketRate: computeMidMarketRate(buy, sell),
+    quoteUnit,
+    quotePerBaseUnit: computeQuotePerBaseUnit(sell, quoteUnit),
+  };
+}
+
+export function resolveAsOf(payload: { timestamp?: string; updateTime?: string }): string | null {
+  if (typeof payload.timestamp === 'string' && payload.timestamp.trim().length > 0) {
+    const parsed = Date.parse(payload.timestamp);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+
+  if (typeof payload.updateTime === 'string' && payload.updateTime.trim().length > 0) {
+    return payload.updateTime;
+  }
+
+  return null;
+}
+
+export function enrichRatesPayload<T extends { details?: Record<string, LegacyCurrencyDetail> }>(
+  payload: T,
+): T & {
+  schemaVersion: typeof API_SEMANTICS_SCHEMA_VERSION;
+  asOf: string | null;
+  details?: Record<string, SemanticCurrencyDetail>;
+} {
+  const enrichedDetails = payload.details
+    ? Object.fromEntries(
+        Object.entries(payload.details).map(([currency, detail]) => [
+          currency,
+          enrichCurrencyDetail(currency, detail),
+        ]),
+      )
+    : undefined;
+
+  return {
+    ...payload,
+    schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+    asOf: resolveAsOf(payload as { timestamp?: string; updateTime?: string }),
+    ...(enrichedDetails ? { details: enrichedDetails } : {}),
+  };
+}
+
+export interface ExchangeShopRatesPayload {
+  timestamp?: string;
+  updateTime?: string;
+  source?: string;
+  sourceUrl?: string;
+  apiUrl?: string;
+  base?: string;
+  rates: Record<string, LegacyExchangeShopRate>;
+}
+
+export function enrichExchangeShopRatesPayload<T extends ExchangeShopRatesPayload>(
+  payload: T,
+): Omit<T, 'rates'> & {
+  schemaVersion: typeof API_SEMANTICS_SCHEMA_VERSION;
+  asOf: string | null;
+  semanticFieldMapping: ReturnType<typeof buildProviderSemanticFieldMapping>;
+  quoteUnit: QuoteUnit;
+  rates: Record<string, SemanticExchangeShopRate>;
+} {
+  const baseCurrency = payload.base ?? 'KRW';
+  const quoteUnit = resolveQuoteUnitForExchangeShopCurrency('TWD', baseCurrency);
+
+  const enrichedRates = Object.fromEntries(
+    Object.entries(payload.rates).map(([code, rate]) => [
+      code,
+      enrichExchangeShopRate(rate, resolveQuoteUnitForExchangeShopCurrency(code, baseCurrency)),
+    ]),
+  );
+
+  return {
+    ...payload,
+    schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+    asOf: resolveAsOf(payload),
+    semanticFieldMapping: buildProviderSemanticFieldMapping('exchange-shop', {
+      providerId: 'moneybox',
+      quoteUnit,
+    }),
+    quoteUnit,
+    rates: enrichedRates,
+  };
+}
+
+export function buildSemanticFieldMapping() {
+  return buildProviderSemanticFieldMapping('bank');
+}
+
+export function buildProviderSemanticFieldMapping(
+  providerKind: ProviderSemanticKind,
+  options?: { providerId?: string; quoteUnit?: QuoteUnit },
+) {
+  if (providerKind === 'exchange-shop') {
+    const quoteUnit = options?.quoteUnit ?? 'KRW_PER_TWD';
+    const providerId = options?.providerId ?? 'moneybox';
+
+    return {
+      schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+      semanticsDoc: API_SEMANTICS_DOC.publicUrl,
+      providerKind,
+      providerId,
+      quoteUnit,
+      asOfSourceField: 'timestamp | updateTime',
+      fields: {
+        customerBuyForeignRate: {
+          legacyPath: `rates.TWD.sell`,
+          description: '客戶用 TWD 買外幣（換錢所賣出）；KRW/TWD 直接乘算',
+          twdToForeignFormula:
+            quoteUnit === 'KRW_PER_TWD' ? 'amount * rates.TWD.sell' : 'amount / rates.{CCY}.sell',
+        },
+        customerSellForeignRate: {
+          legacyPath: `rates.TWD.buy`,
+          description: '客戶用外幣賣回 TWD（換錢所買入）',
+        },
+        midMarketRate: {
+          legacyPath: '(buy + sell) / 2',
+          description: '參考中間價',
+        },
+        quotePerBaseUnit: {
+          legacyPath: quoteUnit === 'KRW_PER_TWD' ? 'rates.TWD.sell' : '1 / sell',
+          description:
+            quoteUnit === 'KRW_PER_TWD'
+              ? '每 1 TWD 可換的 KRW（直接報價）'
+              : '每 1 單位外幣的基準幣報價',
+        },
+      },
+      examples: {
+        TWD: {
+          customerBuyForeignRate: 'rates.TWD.sell',
+          customerSellForeignRate: 'rates.TWD.buy',
+          twdToKrw: '1000 * rates.TWD.sell',
+        },
+      },
+      bankComparison: {
+        botQuoteUnit: 'TWD_PER_FOREIGN',
+        botTwdToForeign: 'amount / details.{CCY}.cash.sell',
+        moneyboxQuoteUnit: quoteUnit,
+        moneyboxTwdToKrw: 'amount * rates.TWD.sell',
+      },
+    } as const;
+  }
+
+  return {
+    schemaVersion: API_SEMANTICS_SCHEMA_VERSION,
+    semanticsDoc: API_SEMANTICS_DOC.publicUrl,
+    providerKind,
+    quoteUnit: 'TWD_PER_FOREIGN' as QuoteUnit,
+    asOfSourceField: 'timestamp | updateTime',
+    fields: {
+      customerBuyForeignRate: {
+        legacyPath: 'details.{CURRENCY}.{rateType}.sell',
+        description: '客戶用 TWD 買外幣（銀行賣出）',
+        twdToForeignFormula: 'amount / details.{TO}.{rateType}.sell',
+      },
+      customerSellForeignRate: {
+        legacyPath: 'details.{CURRENCY}.{rateType}.buy',
+        description: '客戶用外幣賣回 TWD（銀行買入）',
+        foreignToTwdFormula: 'amount * details.{FROM}.{rateType}.buy',
+      },
+      midMarketRate: {
+        legacyPath: '(buy + sell) / 2',
+        description: '參考中間價',
+      },
+      bankSellTwdPerUnit: {
+        legacyPath: '1 / sell',
+        description: '每 1 單位外幣的 TWD 賣價（外幣計價時）',
+      },
+    },
+    examples: {
+      USD: {
+        cash: {
+          customerBuyForeignRate: 'details.USD.cash.sell',
+          customerSellForeignRate: 'details.USD.cash.buy',
+        },
+      },
+    },
+    bankComparison: {
+      botQuoteUnit: 'TWD_PER_FOREIGN',
+      botTwdToForeign: 'amount / details.{CCY}.cash.sell',
+      moneyboxQuoteUnit: 'KRW_PER_TWD',
+      moneyboxTwdToKrw: 'amount * rates.TWD.sell',
+    },
+  } as const;
+}

--- a/apps/ratewise/src/config/exchangeShopProviders.ts
+++ b/apps/ratewise/src/config/exchangeShopProviders.ts
@@ -1,6 +1,7 @@
 import type { CurrencyCode } from '../features/ratewise/types';
 import { CDN_DATA_BASE, PROVIDER_RATES_PATH, RAW_DATA_BASE } from './api-endpoints.ts';
 
+/** 換錢所 provider 匯率；v2 語意見 api-semantics-v2（quoteUnit KRW_PER_TWD）。 */
 export interface ExchangeShopConfig {
   providerName: string;
   providerNameEn: string;

--- a/apps/ratewise/src/pages/OpenData.tsx
+++ b/apps/ratewise/src/pages/OpenData.tsx
@@ -13,6 +13,10 @@ import {
   RATES_API,
   RAW_DATA_BASE,
 } from '../config/api-endpoints';
+import {
+  buildProviderSemanticFieldMapping,
+  buildSemanticFieldMapping,
+} from '../config/api-semantics-v2';
 import { buildPublicRateProviderMetadata } from '../config/rateProviderPublicMetadata';
 import { SITE_CONFIG } from '../config/seo-paths';
 import rateModeStrategies from '../config/rate-mode-strategies.json';
@@ -180,6 +184,67 @@ print(history["details"]["USD"]["spot"]["sell"])`,
 ] as const;
 
 // ─── 資料欄位說明 ──────────────────────────────────────────────────────────────
+
+const BANK_SEMANTIC_MAPPING = buildSemanticFieldMapping();
+const MONEYBOX_SEMANTIC_MAPPING = buildProviderSemanticFieldMapping('exchange-shop', {
+  providerId: 'moneybox',
+  quoteUnit: 'KRW_PER_TWD',
+});
+
+const QUOTE_UNIT_COMPARISON_ROWS = [
+  {
+    source: '臺灣銀行（details）',
+    quoteUnit: BANK_SEMANTIC_MAPPING.quoteUnit,
+    sellMeaning: '每 1 單位外幣的 TWD 賣價（例 USD cash.sell ≈ 32）',
+    twdToForeign: BANK_SEMANTIC_MAPPING.bankComparison.botTwdToForeign,
+    v2Field: 'customerBuyForeignRate ← sell',
+  },
+  {
+    source: 'MoneyBox（rates.TWD）',
+    quoteUnit: MONEYBOX_SEMANTIC_MAPPING.quoteUnit,
+    sellMeaning: '每 1 TWD 可換的 KRW（例 sell ≈ 46.5 KRW/TWD）',
+    twdToForeign: MONEYBOX_SEMANTIC_MAPPING.bankComparison.moneyboxTwdToKrw,
+    v2Field: 'customerBuyForeignRate ← sell（直接乘算）',
+  },
+] as const;
+
+const V2_SCHEMA_FIELDS = [
+  {
+    field: 'schemaVersion',
+    type: 'string',
+    description: 'API 語意版本（2.0）；有別於頂層 version（App semver）',
+  },
+  {
+    field: 'semanticFieldMapping',
+    type: 'object',
+    description: 'v2 欄位對照與換算公式；latest.json metadata 與換錢所 provider JSON 皆可引用',
+  },
+  {
+    field: 'customerBuyForeignRate',
+    type: 'number | null',
+    description: '客戶用 TWD 買外幣；台銀對應 details.{CCY}.{rateType}.sell',
+  },
+  {
+    field: 'customerSellForeignRate',
+    type: 'number | null',
+    description: '客戶用外幣賣回 TWD；台銀對應 details.{CCY}.{rateType}.buy',
+  },
+  {
+    field: 'midMarketRate',
+    type: 'number | null',
+    description: '參考中間價：(buy + sell) / 2',
+  },
+  {
+    field: 'quoteUnit',
+    type: 'TWD_PER_FOREIGN | KRW_PER_TWD',
+    description: '報價方向；台銀與 MoneyBox 皆叫 sell 但 quote 方向相反，換算前必須確認',
+  },
+  {
+    field: 'quotePerBaseUnit',
+    type: 'number | null',
+    description: '換錢所：KRW_PER_TWD 時等同 sell；台銀外幣計價時為 1/sell',
+  },
+] as const;
 
 const SCHEMA_FIELDS = [
   { field: 'timestamp', type: 'string (ISO 8601)', description: '資料抓取時間（UTC）' },
@@ -774,7 +839,61 @@ const OpenData = () => {
             </p>
 
             <div className="mb-6 max-w-full overflow-x-auto rounded-xl border border-surface-border">
-              <table className="min-w-[44rem] text-sm" aria-label="資料格式欄位說明">
+              <table className="min-w-[52rem] text-sm" aria-label="台銀與 MoneyBox quote 語意對照">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-elevated">
+                    <th className="px-4 py-3 text-left font-semibold text-text">來源</th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">quoteUnit</th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">
+                      legacy sell 意義
+                    </th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">TWD→外幣/KRW</th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">v2 對照</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-surface-border bg-surface">
+                  {QUOTE_UNIT_COMPARISON_ROWS.map((row) => (
+                    <tr key={row.source}>
+                      <td className="px-4 py-3 break-words text-text">{row.source}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-primary">{row.quoteUnit}</td>
+                      <td className="px-4 py-3 break-words text-text-muted">{row.sellMeaning}</td>
+                      <td className="px-4 py-3 break-all font-mono text-xs text-text-muted">
+                        {row.twdToForeign}
+                      </td>
+                      <td className="px-4 py-3 break-words text-text">{row.v2Field}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mb-6 max-w-full overflow-x-auto rounded-xl border border-surface-border">
+              <table className="min-w-[44rem] text-sm" aria-label="API Semantics v2 欄位說明">
+                <thead>
+                  <tr className="border-b border-surface-border bg-surface-elevated">
+                    <th className="px-4 py-3 text-left font-semibold text-text">v2 欄位</th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">型別</th>
+                    <th className="px-4 py-3 text-left font-semibold text-text">說明</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-surface-border bg-surface">
+                  {V2_SCHEMA_FIELDS.map((f) => (
+                    <tr key={f.field}>
+                      <td className="px-4 py-3 break-all font-mono text-xs text-primary">
+                        {f.field}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-xs text-text-muted">
+                        {f.type}
+                      </td>
+                      <td className="px-4 py-3 break-words text-text">{f.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mb-6 max-w-full overflow-x-auto rounded-xl border border-surface-border">
+              <table className="min-w-[44rem] text-sm" aria-label="台銀 latest.json 欄位說明">
                 <thead>
                   <tr className="border-b border-surface-border bg-surface-elevated">
                     <th className="px-4 py-3 text-left font-semibold text-text">欄位</th>

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0）｜累計總分：+69
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+68
 
 ## 新增模板（4 行）
 
@@ -13,40 +13,65 @@
 
 ## 條目（新→舊）
 
-- 日期：2026-06-26
-- ID：reward-split-meow-expense-currency-rate-snapshot
-- 原因：split-meow 的 ExpenseRecord 只存裸數字、未保存記帳當下幣別；使用者先以 TWD 記帳後切換 KRW（或韓國時區自動偵測）時，歷史金額會被當前全域幣別重新格式化，NT$1,000 被誤顯示為 ₩1,000。
-- 解法：ExpenseRecord 增加 currency 與 exchangeRateKrwPerTwd 快照欄位，記帳時保存；HistoryTab 個別金額改用各筆快照幣別、KRW 副標即時換算 TWD、彙總/結算採 trip 主導幣別 fallback；補 store/currencies 單元測試與 Playwright 瀏覽器驗收（切回 TWD 後 KRW 記錄仍正確）。
+- 日期：2026-06-27
+- ID：reward-api-semantics-v2-moneybox-provider
+- 原因：MoneyBox provider JSON 缺 v2 語意層，sell 與台銀 quote 方向相反易誤用
+- 解法：enrichExchangeShopRatesPayload、provider semanticFieldMapping、OpenData 對照表與 OpenAPI ExchangeShopRateV2
 
-- 日期：2026-06-26
-- ID：reward-pr426-sw-bounded-nav-case3-002-audit
-- 原因：PR 426 review P1 指出 SW case-3 有界網路 fallback 與測試 lint 修改的 commit 未含 002 稽核軌跡；該功能已隨 #433 生產治理進 main，但稽核條目隨被取代的 #411 分支遺失。
-- 解法：補本條目搶救稽核軌跡；SW case-3 setCatchHandler 有界 fallback 本體已於 #433 收斂進 main。
+- 日期：2026-06-27
+- ID：neutral-plan010-e2e-mobile-smoke
+- 原因：Plan 010 Gate G4 缺 mobile-pwa/hero-y/touch-44/console Playwright 390x844 自動化
+- 解法：新增 mobile-pwa-smoke、touch-targets-44、console-hydration spec 與 chromium-mobile-390 project
 
-- 日期：2026-06-26
-- ID：reward-ci-playwright-cache-v6
-- 原因：setup-playwright composite action 仍用 actions/cache@v4，在 Node 24 CI 觸發 Node 20 deprecation warning
-- 解法：升級 actions/cache@v6 並補 patch changeset
+- 日期：2026-06-27
+- ID：reward-ux2026-epic2-settings-ssot
+- 原因：Settings 缺 PWA 安裝入口、PWA 1.8s 自動弹出、Favorites 無匯率列且觸控未達 44px
+- 解法：Epic 2 實作 conversion-success nudge、Settings install 區塊、Favorites 匯率列與 segmentedSwitch min-h-11
 
-- 日期：2026-06-26
-- ID：reward-pr435-code-reviewer-hardening
-- 原因：Codex 配額用盡無法 review PR 435，改派 code-reviewer 代理把關，發現 i18n 探測在 removeItem 丟錯時會誤判 localStorage 不可寫（可寫性結論不應依賴清除步驟），且 smoke 測試 BASE_STATE 仍缺部分 test-mutable 欄位。
-- 解法：i18n 探測改用 finally 清除 probe key、可寫性僅依 setItem 結果；BASE_STATE 補 expenseCategory/settledPayments/catPlayMode；img-src 收窄列為 follow-up issue #437。
+- 日期：2026-06-27
+- ID：neutral-epic4-multi-ia-plan005
+- 原因：Multi 18 列全展開與 nav 8px/scroll-padding 不足（L03/L05 UX-INC-004/007）
+- 解法：≤8 progressive disclosure、全列表套用文案、nav 10px+scroll-padding 57px、冷啟動禁 redirect /multi
 
-- 日期：2026-06-26
-- ID：reward-ratewise-i18n-localstorage-writable-probe
-- 原因：PR 404 review 指出 canUseBrowserLanguageStorage 只檢查 window 與非 test 模式，未實際偵測 localStorage 可寫；私密模式 / 嵌入式瀏覽器中 window 存在但 setItem 丟錯，i18next caches:['localStorage'] 寫入失敗導致語系切換不持久。
-- 解法：改用 try setItem/removeItem 實際探測可寫性，不可寫時 detection 回退 ['htmlTag','navigator'] 且 caches:[]，避免寫入失敗中斷語系切換。
+- 日期：2026-06-27
+- ID：neutral-epic1-settings-hero-toggle
+- 原因：plan 002 §二十 要求 Settings heroLayoutVariant toggle 與 spec L01/L06/L14 done 證據同步
+- 解法：Settings 新增 legacy/hero-v2 切換、i18n 四語系、SingleConverter DOM helper 重排、spec §六 Status=done
 
-- 日期：2026-06-26
-- ID：reward-worker-split-meow-img-src-https-restore
-- 原因：PR 414 review 指出 split-meow 專屬 CSP profile 未帶 fallback 的 img-src https:，Split Meow 成員 legacy 遠端頭像會在正式站被 CSP 擋下。
-- 解法：SPLIT_MEOW_HTML_PROFILE 補回 imgSources:['https:']，並 bump SECURITY_POLICY_VERSION 5.4→5.5 與變更記錄。
+- 日期：2026-06-27
+- ID：reward-epic1-hero-v2-layout
+- 原因：首屏 answer-first 倒置（金額列優先於 hero 匯率）違反 spec §十一 E1
+- 解法：新增 hero-v2 feature flag、display-md token、DOM 重排與 freshness chip；預設 legacy
 
-- 日期：2026-06-26
-- ID：reward-split-meow-smoke-test-currency-reset
-- 原因：PR 415 review 指出 HomeAndHistorySmoke 的 BASE_STATE 未重置 currency / krwPerTwd，設定 KRW 的測試會洩漏污染後續測試。
-- 解法：BASE_STATE 補上 currency:'TWD'、currencyManuallySet:false、krwPerTwd:null、rateUpdatedAt:null，確保測試隔離。
+- 日期：2026-06-27
+- ID：reward-release-yml-worker-order-minify
+- 原因：release.yml Worker deploy 在 Zeabur wait 之前且 CI 未用 --minify，違反 AGENTS.md 邊緣順序 SOP
+- 解法：調整為 Wait → Worker deploy --minify → purge，並同步 DEPLOY.md 與 security-headers package.json
+
+- 日期：2026-06-27
+- ID：neutral-epic3-collect-body-text-ssot
+- 原因：L09 dedupe 測試內嵌 collectBodyText 與 seo-metadata SSOT 重複
+- 解法：seo-ssot.test 改 import collectCurrencyLandingBodyText 共用 SSOT
+
+- 日期：2026-06-27
+- ID：neutral-epic3-l09-plan-spec-sync
+- 原因：L09 Step1 完成需同步 plan 004 與 UX spec 狀態證據
+- 解法：更新 plans/README、004 done criteria 與 spec L09 status（build dist thesis curl 1）
+
+- 日期：2026-06-27
+- ID：reward-epic3-canonical-sell-thesis
+- 原因：幣別頁 curl 賣出價/中間價 keyword 重複（L09 thesis >1）
+- 解法：seo-metadata 新增 CANONICAL_BANK_SELL_THESIS SSOT 並收斂 AnswerCapsule/FAQ 交叉引用
+
+- 日期：2026-06-27
+- ID：reward-ratewise-api-semantics-v2-m1-m3
+- 原因：public API 仍用銀行視角 buy/sell，整合方易反解 customer action；spec §二十一 要求 additive v2 語意層。
+- 解法：新增 api-semantics-v2 SSOT、schemaVersion 2.0 metadata、OpenAPI CurrencyRateV2 與 vitest 映射測試；legacy 欄位保留。
+
+- 日期：2026-06-27
+- ID：neutral-ux2026-stream0-bootstrap
+- 原因：UX 2026 平行 stream 0 需確認 experiment 分支與 worktree SSOT 並同步 plans/spec 追蹤
+- 解法：驗證 origin/experiment/ratewise-ux-2026、補 cf worktree、更新 plans/README 001 DONE 與 002/004/006/007 IN PROGRESS
 
 - 日期：2026-06-26
 - ID：neutral-retrigger-prod-deploy-2252

--- a/scripts/fetch-moneybox-rates.js
+++ b/scripts/fetch-moneybox-rates.js
@@ -7,6 +7,7 @@
 import { writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { dirname, isAbsolute, join } from 'path';
 import { fileURLToPath } from 'url';
+import { enrichExchangeShopRatesPayload } from '../apps/ratewise/src/config/api-semantics-v2.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -263,10 +264,11 @@ async function main() {
     // 確保目錄存在
     mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
 
-    // 寫入檔案
-    writeFileSync(OUTPUT_FILE, JSON.stringify(ratesData, null, 2), 'utf8');
+    const enrichedRatesData = enrichExchangeShopRatesPayload(ratesData);
 
-    const twdRate = ratesData.rates.TWD;
+    writeFileSync(OUTPUT_FILE, JSON.stringify(enrichedRatesData, null, 2), 'utf8');
+
+    const twdRate = enrichedRatesData.rates.TWD;
     console.log('✅ Successfully saved new rates');
     console.log('===============================================');
     console.log(`📁 Output: ${OUTPUT_FILE}`);


### PR DESCRIPTION
## Summary

- 擴充 `api-semantics-v2.ts`：`enrichExchangeShopRatesPayload`、`quoteUnit`（`KRW_PER_TWD` vs `TWD_PER_FOREIGN`）、`buildProviderSemanticFieldMapping`
- `fetch-moneybox-rates.js` 輸出 `schemaVersion`、`semanticFieldMapping`、v2 匯率欄位（additive，legacy buy/sell 保留）
- OpenData 頁新增台銀 vs MoneyBox quote 對照表與 v2 欄位說明；OpenAPI `ExchangeShopRateV2`（API v2.1.0）
- `latest.json` provider metadata、`llms.txt` 同步 v2 羽翼

## Test plan

- [x] `pnpm --filter @app/ratewise test -- api-semantics`（7 passed）
- [x] `pnpm --filter @app/ratewise test -- build-scripts`（46 passed）
- [x] `pnpm --filter @app/ratewise typecheck`
- [x] `pnpm --filter @app/ratewise verify:artifacts`
- [x] pre-push：typecheck + test + build:ratewise

## 10 工作流 checklist

- [x] W1 現況稽核（評估矩陣見 PR 討論）
- [x] W2 v2 Schema 設計（quoteUnit + additive 欄位）
- [x] W3 SSOT 實作 + vitest
- [x] W4 生成腳本（fetch-moneybox + generate-api-json）
- [x] W5 OpenAPI ExchangeShopRateV2
- [x] W6 OpenData 頁面更新
- [x] W7 llms.txt / latest.json metadata
- [x] W8 App 內部最小 JSDoc（exchangeShopProviders）
- [x] W9 hotfix PR + changeset patch + 002
- [x] W10 驗證通過


Made with [Cursor](https://cursor.com)