### PR TITLE
fix(ci): MoneyBox workflow 補 checkout api-semantics-v2

### DIFF
--- a/.github/workflows/update-moneybox-rates.yml
+++ b/.github/workflows/update-moneybox-rates.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           git fetch origin main
           git checkout origin/main -- scripts/fetch-moneybox-rates.js
+          git checkout origin/main -- apps/ratewise/src/config/api-semantics-v2.ts
           git checkout origin/main -- public/rates/ 2>/dev/null || mkdir -p public/rates
 
       - name: Setup Node.js

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -644,6 +644,9 @@ describe('ratewise build scripts', () => {
     expect(workflowSource).toContain('branches:\n      - main');
     expect(workflowSource).toContain('git fetch origin main');
     expect(workflowSource).toContain('git checkout origin/main -- scripts/fetch-moneybox-rates.js');
+    expect(workflowSource).toContain(
+      'git checkout origin/main -- apps/ratewise/src/config/api-semantics-v2.ts',
+    );
     expect(workflowSource).not.toContain('SOURCE_REF="${GITHUB_REF_NAME:-main}"');
     expect(workflowSource).not.toContain(
       'git checkout FETCH_HEAD -- scripts/fetch-moneybox-rates.js',

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+68
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+69
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-moneybox-workflow-api-semantics-checkout
+- 原因：data branch workflow 只 checkout fetch 腳本，缺 api-semantics-v2.ts 導致 enrich 失敗且 CDN 無 v2
+- 解法：update-moneybox-rates.yml sync 步驟補 checkout SSOT 並加 build-scripts 守門
 
 - 日期：2026-06-27
 - ID：reward-api-semantics-v2-moneybox-provider


### PR DESCRIPTION
## Summary

- `update-moneybox-rates.yml` 在 data branch sync 步驟補 `git checkout origin/main -- apps/ratewise/src/config/api-semantics-v2.ts`，讓 `fetch-moneybox-rates.js` 的 `enrichExchangeShopRatesPayload` 可在 CI 解析。
- `build-scripts.test.ts` 新增 workflow 字串守門，避免再次漏 checkout。
- 更新 `docs/dev/002_development_reward_penalty_log.md`（累計總分 +69）。

## 合併後操作

合併至 main 後請手動觸發一次排程 workflow（勿 force push `data`）：

```bash
gh workflow run update-moneybox-rates.yml
```

待 run 成功後，確認 jsDelivr CDN 上的 MoneyBox `latest.json` 含 v2 語意欄位。

## Test plan

- [x] `pnpm --filter @app/ratewise test -- src/config/__tests__/build-scripts.test.ts -t "persist MoneyBox"`
- [x] pre-commit（lint-staged、typecheck、format、commitlint）通過

Made with [Cursor](https://cursor.com)