### PR TITLE
fix(ratewise): PR 467 審查 hotfix — 金額頁 thesis 去重

### DIFF
--- a/.changeset/pr467-pair-amount-thesis-dedupe.md
+++ b/.changeset/pr467-pair-amount-thesis-dedupe.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+幣別金額頁 SEO 標題與描述收斂，與 landing 頁 thesis 去重規則一致。

--- a/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
+++ b/apps/ratewise/src/config/__tests__/seo-ssot.test.ts
@@ -457,6 +457,15 @@ describe('SEO SSOT', () => {
       expect(content.heroIntro).not.toMatch(CURRENCY_LANDING_THESIS_KEYWORD);
     });
 
+    it('金額頁 SEO 僅 description 含 canonical thesis，title 避開 thesis keyword', () => {
+      const forward = buildPairAmountSeo(100, 'USD', '美金', 'to-twd');
+      const reverse = buildPairAmountSeo(30000, 'USD', '美金', 'twd-to-foreign');
+      expect(forward.description).toContain(CANONICAL_BANK_SELL_THESIS);
+      expect(reverse.description).toContain(CANONICAL_BANK_SELL_THESIS);
+      expect(forward.title).not.toMatch(CURRENCY_LANDING_THESIS_KEYWORD);
+      expect(reverse.title).not.toMatch(CURRENCY_LANDING_THESIS_KEYWORD);
+    });
+
     it.each(CURRENCY_CODES)('%s 正文 SSOT 不得含 thesis keyword（賣出價|中間價）', (code) => {
       const content = getCurrencyLandingPageContent(code);
       expect(collectCurrencyLandingBodyText(content)).not.toMatch(CURRENCY_LANDING_THESIS_KEYWORD);

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -2517,14 +2517,14 @@ export function buildPairAmountSeo(
 
   if (direction === 'twd-to-foreign') {
     return {
-      title: `${formatted} 台幣換${currencyName}（TWD/${currencyCode}）— 台銀實際賣出價 | ${APP_INFO.shortName}`,
-      description: `${formatted} 台幣今日可換多少${currencyName}？${APP_INFO.shortName} 直接顯示台銀牌告現金賣出價（非中間價），資料每 5 分鐘自動更新，幫你出國換匯前精確估算可兌換的外幣金額，避免被中間價誤導。`,
+      title: `${formatted} 台幣換${currencyName}（TWD/${currencyCode}）| ${APP_INFO.shortName}`,
+      description: `${formatted} 台幣今日可換多少${currencyName}？${APP_INFO.shortName} 出國換匯前可查看台銀${currencyName}${CANONICAL_BANK_SELL_THESIS}，資料每 5 分鐘自動更新，幫你精確估算可兌換的外幣金額。`,
     };
   }
 
   return {
-    title: `買 ${formatted} ${currencyName}要多少新台幣（${currencyCode}/TWD）— 台銀實際賣出價 | ${APP_INFO.shortName}`,
-    description: `買 ${formatted} ${currencyName}今日要多少新台幣？${APP_INFO.shortName} 直接顯示台銀牌告現金賣出價（非中間價），資料每 5 分鐘自動更新，幫你出國換匯前精確估算所需台幣金額，避免被中間價誤導。`,
+    title: `買 ${formatted} ${currencyName}要多少新台幣（${currencyCode}/TWD）| ${APP_INFO.shortName}`,
+    description: `買 ${formatted} ${currencyName}今日要多少新台幣？${APP_INFO.shortName} 即時顯示台銀${currencyName}${CANONICAL_BANK_SELL_THESIS}，資料每 5 分鐘自動更新，幫你換匯前精確估算所需台幣金額。`,
   };
 }
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+67
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+68
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-pr467-pair-amount-seo-thesis
+- 原因：PR 467 收斂 landing thesis 但未同步 buildPairAmountSeo，金額頁 title/description 仍含賣出價/中間價
+- 解法：金額頁 SEO 對齊 CANONICAL_BANK_SELL_THESIS SSOT 並補 L09 測試
 
 - 日期：2026-06-27
 - ID：reward-ux2026-epic2-settings-ssot


### PR DESCRIPTION
## 審查背景

- 審查目標：已合併 PR 467（L09 內容 distill 與 thesis 去重）
- 合併分支：`experiment/ratewise-ux-2026`（非 `main`）
- Base 說明：PR 467 尚未進入 `main`，故本 PR 以 `experiment/ratewise-ux-2026` 為 base

## 發現清單

| 嚴重度 | 檔案 | 根因 |
| ------ | ---- | ---- |
| **P1** | `apps/ratewise/src/config/seo-metadata.ts` `buildPairAmountSeo`（約 2518–2528 行） | PR 467 已收斂 landing `title`/`description` 與 `heroIntro`/`precisionThesis`，但遺漏索引金額頁 SEO；`title` 仍含「台銀實際賣出價」，`description` 仍含「現金賣出價（非中間價）」與「中間價誤導」，與 L09 SSOT 不一致 |
| **P2（技術債，未修）** | `SEOHelmet` + `buildSiteJsonLd()` | 幣別頁 head JSON-LD 仍注入 `DEFAULT_DESCRIPTION`（含買入賣出價/中間價），與 meta canonical thesis 重複；為 PR 467 前既有行為，超出本次最小 hotfix 範圍 |
| **P2（測試缺口，已部分補）** | `seo-ssot.test.ts` L09 | 原僅覆蓋 forward/reverse 正文 SSOT，未覆蓋 `buildPairAmountSeo` |

### 未發現問題（已驗證）

- template-bleed：130+ 測試通過
- 正文 SSOT `collectCurrencyLandingBodyText`：17 幣 forward/reverse 不含 `賣出價|中間價`
- capsule↔FAQ 逐字重複：forward 17 幣通過
- 硬編碼 SEO 繞過 `seo-metadata.ts`：未發現

## 改動摘要

- `buildPairAmountSeo`：`title` 移除 thesis keyword；`description` 改用 `CANONICAL_BANK_SELL_THESIS` SSOT
- 新增 L09 金額頁 thesis 回歸測試（131 tests）
- changeset patch

## Gate 證據

```text
pnpm typecheck → 全 workspace Done
pnpm test → 2511 passed, 2 skipped（ratewise 149 files）+ lighthouse 6 passed
pnpm lint → 0 errors（2 warnings 為既有 UpdatePrompt hooks）
pnpm build:ratewise → exit 0
```

Build 後 thesis 計數（`rg -o` 全檔出現次數）：

- `dist/usd-twd/index.html`：12（主要來自 head 全域 JSON-LD，非本次範圍）
- `dist/usd-twd/500/index.html`：修復前 18 → 修復後 12（移除金額頁 title/description 重複 thesis）

## Test plan

- [x] `pnpm --filter @app/ratewise test -- seo-ssot`（131 passed）
- [x] 全 gate 通過（見上）


Made with [Cursor](https://cursor.com)