### PR TITLE
fix(ratewise): PR#472 收斂 OpenAPI 契約與 Dataset JSON-LD

### DIFF
--- a/.changeset/ratewise-pr472-openapi-dataset-hotfix.md
+++ b/.changeset/ratewise-pr472-openapi-dataset-hotfix.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+開放資料 API 說明與結構化資料對齊 v2 語意：OpenAPI 台銀 details 契約改回與現行 JSON 一致，Dataset 納入 MoneyBox 換錢所端點。

--- a/apps/ratewise/public/openapi.json
+++ b/apps/ratewise/public/openapi.json
@@ -1148,7 +1148,7 @@
             "type": "object",
             "description": "各幣別完整四種報價資料（以幣別代碼為 key）；v2 欄位見 CurrencyRateV2 / CurrencyRateDetail",
             "additionalProperties": {
-              "$ref": "#/components/schemas/CurrencyRateV2"
+              "$ref": "#/components/schemas/CurrencyRateDetail"
             },
             "example": {
               "USD": {

--- a/apps/ratewise/scripts/generate-openapi.mjs
+++ b/apps/ratewise/scripts/generate-openapi.mjs
@@ -302,7 +302,7 @@ const ratesResponseSchema = {
       type: 'object',
       description:
         '各幣別完整四種報價資料（以幣別代碼為 key）；v2 欄位見 CurrencyRateV2 / CurrencyRateDetail',
-      additionalProperties: { $ref: '#/components/schemas/CurrencyRateV2' },
+      additionalProperties: { $ref: '#/components/schemas/CurrencyRateDetail' },
       example: {
         USD: { spot: { buy: 32.015, sell: 32.085 }, cash: { buy: 31.73, sell: 32.385 } },
         JPY: { spot: { buy: 0.2078, sell: 0.2088 }, cash: { buy: 0.2041, sell: 0.2119 } },

--- a/apps/ratewise/src/config/seo-metadata.ts
+++ b/apps/ratewise/src/config/seo-metadata.ts
@@ -557,8 +557,8 @@ export function buildOpenDataDatasetJsonLd(): JsonLdBlock {
   return {
     '@context': 'https://schema.org',
     '@type': 'Dataset',
-    name: `${APP_INFO.shortName} 台灣銀行牌告匯率開放資料`,
-    description: `${APP_INFO.shortName} 提供臺灣銀行牌告匯率的開放 JSON 資料集，包含 ${SUPPORTED_CURRENCY_COUNT} 種貨幣的現金與即期買入賣出四種報價，並提供最新匯率、歷史匯率與 OpenAPI 規格。`,
+    name: `${APP_INFO.shortName} 匯率開放資料`,
+    description: `${APP_INFO.shortName} 提供臺灣銀行牌告匯率與 MoneyBox 換錢所（KRW/TWD）的開放 JSON 資料集，包含 ${SUPPORTED_CURRENCY_COUNT} 種台銀外幣的現金與即期四種報價，以及 v2 語意欄位（customerBuyForeignRate、quoteUnit）對照；並提供最新匯率、歷史匯率與 OpenAPI 規格。`,
     url: buildCanonicalUrl('/open-data/'),
     sameAs: 'https://rate.bot.com.tw/xrt',
     isBasedOn: {
@@ -609,6 +609,12 @@ export function buildOpenDataDatasetJsonLd(): JsonLdBlock {
         '@type': 'DataDownload',
         name: 'OpenAPI 3.1 規格',
         contentUrl: `${SITE_BASE_URL}openapi.json`,
+        encodingFormat: 'application/json',
+      },
+      {
+        '@type': 'DataDownload',
+        name: 'MoneyBox 換錢所最新匯率 JSON',
+        contentUrl: RATES_API.moneyboxCdn,
         encodingFormat: 'application/json',
       },
     ],

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+72
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+73
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-pr472-openapi-dataset-hotfix
+- 原因：PR472 後 OpenAPI details 誤用 CurrencyRateV2 必填 v2 欄位，與台銀 live JSON 不符；Dataset JSON-LD 未納入 MoneyBox
+- 解法：RatesResponse details 改 ref CurrencyRateDetail；buildOpenDataDatasetJsonLd 補 MoneyBox distribution 與描述
 
 - 日期：2026-06-27
 - ID：reward-split-meow-legacy-expense-currency-twd


### PR DESCRIPTION
## 審查發現

1. **OpenAPI 契約不符（高）**：PR #472 將 `RatesResponse.details` 的 `additionalProperties` 改為 `CurrencyRateV2`，其 `SemanticRateTypeBlock` 必填 `customerBuyForeignRate` 等 v2 欄位；但台銀 `latest.json` / `build-time-rates.json` 的 `details.*.{cash,spot}` 仍只有 legacy `buy`/`sell`（`fetch-taiwan-bank-rates.js` 未套用 `enrichRatesPayload`）。消費者依 OpenAPI 驗證 live 資料會誤判不合規。
2. **Dataset JSON-LD 落後（中）**：Open Data 頁已新增 MoneyBox quote 對照與 v2 欄位說明，但 `buildOpenDataDatasetJsonLd()` 仍只描述台銀、distribution 未含 MoneyBox CDN 端點，結構化資料與頁面/API 文檔不一致。
3. **其餘項目 clean**：MoneyBox `enrichExchangeShopRatesPayload` 映射正確；Open Data 頁無 FAQPage JSON-LD 重複；`dateModified` 仍用 `BUILD_TIME`；無 template-bleed；ExchangeShopRateV2 OpenAPI 對 enriched MoneyBox JSON 一致。

## 修法

- `generate-openapi.mjs`：`RatesResponse.details` 改回 `$ref: CurrencyRateDetail`（v2 欄位仍文件化為 optional/additive；`CurrencyRateV2` 保留供 enriched 回應參考）。
- `seo-metadata.ts`：`buildOpenDataDatasetJsonLd()` 更新描述、名稱，並在 `distribution` 新增 `RATES_API.moneyboxCdn`。
- 重新生成 `public/openapi.json`。

## gate 證據

```
pnpm typecheck  → exit 0
pnpm test       → exit 0（ratewise 2457 passed；root lighthouse 6 passed）
pnpm lint       → exit 0
pnpm build:ratewise → exit 0
```


Made with [Cursor](https://cursor.com)