### PR TITLE
test(ratewise): 補離線靜態資源三層回退單元測試

### DIFF
--- a/apps/ratewise/src/utils/__tests__/pwaOfflineFallback.test.ts
+++ b/apps/ratewise/src/utils/__tests__/pwaOfflineFallback.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { APP_INFO } from '../../config/app-info';
-import { resolveOfflineDocumentFallback } from '../pwaOfflineFallback';
+import {
+  resolveOfflineDocumentFallback,
+  resolveOfflineStaticResourceFallback,
+} from '../pwaOfflineFallback';
 
 describe('pwaOfflineFallback', () => {
   it('should prefer cached index.html before offline fallbacks', async () => {
@@ -80,5 +83,75 @@ describe('pwaOfflineFallback', () => {
       'emergency-navigation-fallback',
     );
     expect(response.headers.get('X-RateWise-Offline-Fallback')).not.toBeNull();
+  });
+});
+
+describe('resolveOfflineStaticResourceFallback', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should return exact caches.match(request) hit without calling matchPrecacheFn', async () => {
+    const request = new Request('https://app.haotool.org/ratewise/assets/x.js');
+    const exactResponse = new Response('exact');
+    const cachesMatch = vi.fn().mockResolvedValue(exactResponse);
+    vi.stubGlobal('caches', { match: cachesMatch });
+    const matchPrecacheFn = vi.fn();
+
+    const response = await resolveOfflineStaticResourceFallback(request, matchPrecacheFn);
+
+    expect(response).toBe(exactResponse);
+    expect(cachesMatch).toHaveBeenCalledTimes(1);
+    expect(cachesMatch).toHaveBeenCalledWith(request);
+    expect(matchPrecacheFn).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to ignoreSearch match when exact match misses', async () => {
+    const request = new Request('https://app.haotool.org/ratewise/assets/x.js?__WB_REVISION__=abc');
+    const ignoreSearchResponse = new Response('ignore-search');
+    const cachesMatch = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(ignoreSearchResponse);
+    vi.stubGlobal('caches', { match: cachesMatch });
+    const matchPrecacheFn = vi.fn();
+
+    const response = await resolveOfflineStaticResourceFallback(request, matchPrecacheFn);
+
+    expect(response).toBe(ignoreSearchResponse);
+    expect(cachesMatch).toHaveBeenCalledTimes(2);
+    expect(cachesMatch).toHaveBeenNthCalledWith(1, request);
+    expect(cachesMatch).toHaveBeenNthCalledWith(2, 'https://app.haotool.org/ratewise/assets/x.js', {
+      ignoreSearch: true,
+    });
+    expect(matchPrecacheFn).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to matchPrecacheFn when caches layers miss', async () => {
+    const request = new Request('https://app.haotool.org/ratewise/assets/x.js');
+    const precacheResponse = new Response('precached');
+    const cachesMatch = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('caches', { match: cachesMatch });
+    const matchPrecacheFn = vi.fn((key: string) => (key === 'x.js' ? precacheResponse : null));
+
+    const response = await resolveOfflineStaticResourceFallback(request, matchPrecacheFn);
+
+    expect(response).toBe(precacheResponse);
+    expect(matchPrecacheFn.mock.calls.map(([key]) => key)).toEqual([
+      'ratewise/assets/x.js',
+      'assets/x.js',
+      'x.js',
+    ]);
+  });
+
+  it('should return Response.error() when all fallback layers miss', async () => {
+    const request = new Request('https://app.haotool.org/ratewise/assets/x.js');
+    const cachesMatch = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('caches', { match: cachesMatch });
+    const matchPrecacheFn = vi.fn().mockResolvedValue(null);
+
+    const response = await resolveOfflineStaticResourceFallback(request, matchPrecacheFn);
+
+    expect(response.type).toBe('error');
   });
 });

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+69
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+70
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-pwa-static-fallback-unit-tests
+- 原因：PR 452 未覆蓋 resolveOfflineStaticResourceFallback 三層離線回退路徑
+- 解法：補 exact、ignoreSearch、matchPrecache 與全 miss 四項單元測試
 
 - 日期：2026-06-27
 - ID：reward-moneybox-workflow-api-semantics-checkout


### PR DESCRIPTION
## Summary

- PR #452 已引入 `resolveOfflineStaticResourceFallback` 三層離線靜態資源回退，但 `pwaOfflineFallback.test.ts` 僅覆蓋 `resolveOfflineDocumentFallback`，離線 JS/CSS 關鍵路徑缺測（對比 PR #456 的 document fallback 測試完整性）。
- 本 PR 在既有測試檔新增 `describe(resolveOfflineStaticResourceFallback)`，以 `vi.stubGlobal('caches', ...)` mock 全域 Cache API，並以 `afterEach(vi.unstubAllGlobals)` 清理。

## 新增測試

1. **第一層 exact**：`caches.match(request)` 命中即回傳，且不呼叫 `matchPrecacheFn`。
2. **第二層 ignoreSearch**：exact miss 後以去掉 query 的 bareUrl 搭配 `{ ignoreSearch: true }` 命中。
3. **第三層 matchPrecache**：前兩層 miss 後依 pathname 產生的 key（`ratewise/assets/x.js`、`assets/x.js`、`x.js`）呼叫 `matchPrecacheFn` 並回傳命中 Response。
4. **全 miss**：三層皆 miss 時回傳 `Response.error()`（`response.type === 'error'`）。

## Test plan（本機 gate 證據）

- [x] `pnpm --filter @app/ratewise exec vitest run pwaOfflineFallback` — 9 passed
- [x] `pnpm --filter @app/ratewise typecheck` — 通過
- [x] `pnpm lint` — 通過

純測試新增，未修改 production code。

Made with [Cursor](https://cursor.com)