### PR TITLE
fix(split-meow): PR 445 審查修復舊支出幣別 fallback

### DIFF
--- a/.changeset/review-445-legacy-expense-currency-twd.md
+++ b/.changeset/review-445-legacy-expense-currency-twd.md
@@ -1,0 +1,5 @@
+---
+'@app/split-meow': patch
+---
+
+修正 KRW 上線前、localStorage 舊支出缺 currency 欄位時，切換全域幣別後歷史金額仍誤顯示為韓元；舊帳目改固定以台幣解析。

--- a/apps/split-meow/src/components/__tests__/HomeAndHistorySmoke.test.tsx
+++ b/apps/split-meow/src/components/__tests__/HomeAndHistorySmoke.test.tsx
@@ -195,11 +195,17 @@ describe('HistoryTab', () => {
     }
   });
 
-  it('幣別為 KRW 時以 ₩ 顯示金額', () => {
+  it('有 currency 快照的 KRW 支出以 ₩ 顯示金額', () => {
+    useStore.setState({ expenses: [{ ...EXPENSE_1, currency: 'KRW' }], currency: 'KRW' });
+    renderWith(<HistoryTab />);
+    expect(document.body.textContent).toContain('₩');
+  });
+
+  it('缺 currency 的舊支出在全域 KRW 時仍顯示 NT$', () => {
     useStore.setState({ expenses: [EXPENSE_1], currency: 'KRW' });
     renderWith(<HistoryTab />);
-    // 總金額與費用列表均應顯示 ₩
-    expect(document.body.textContent).toContain('₩');
+    expect(document.body.textContent).toContain('NT$');
+    expect(document.body.textContent).not.toContain('₩');
   });
 
   it('多筆消費顯示 settlement 區塊', () => {

--- a/apps/split-meow/src/config/__tests__/currencies.test.ts
+++ b/apps/split-meow/src/config/__tests__/currencies.test.ts
@@ -112,9 +112,15 @@ describe('trip currency helpers', () => {
     ).toEqual({ a: 50, b: -50 });
   });
 
-  it('resolveExpenseCurrency 舊資料 fallback 行程幣別', () => {
-    expect(resolveExpenseCurrency({}, 'KRW')).toBe('KRW');
+  it('resolveExpenseCurrency 舊資料 fallback TWD', () => {
+    expect(resolveExpenseCurrency({}, 'KRW')).toBe('TWD');
     expect(resolveExpenseCurrency({ currency: 'TWD' }, 'KRW')).toBe('TWD');
+    expect(resolveExpenseCurrency({ currency: 'KRW' }, 'TWD')).toBe('KRW');
+  });
+
+  it('resolveTripCurrency 舊資料 fallback TWD，空行程 fallback 全域幣別', () => {
+    expect(resolveTripCurrency([{}], 'KRW')).toBe('TWD');
+    expect(resolveTripCurrency([], 'KRW')).toBe('KRW');
   });
 
   it('wouldCreateMixedCurrencyTrip 僅在單幣行程將混幣時為 true', () => {

--- a/apps/split-meow/src/config/currencies.ts
+++ b/apps/split-meow/src/config/currencies.ts
@@ -1,5 +1,8 @@
 export type CurrencyCode = 'TWD' | 'KRW';
 
+/** KRW 上線前 localStorage 舊帳目皆為 TWD；缺 currency 欄位時不可跟著全域幣別漂移。 */
+const LEGACY_DEFAULT_CURRENCY: CurrencyCode = 'TWD';
+
 export interface CurrencyInfo {
   code: CurrencyCode;
   symbol: string;
@@ -37,20 +40,22 @@ export function getCurrencySymbol(currency: CurrencyCode): string {
   return CURRENCIES[currency].symbol;
 }
 
-/** 單筆費用的顯示幣別；舊資料缺欄位時 fallback 至行程主導幣別。 */
+/** 單筆費用的顯示幣別；舊資料缺欄位時視為 TWD。 */
 export function resolveExpenseCurrency(
   expense: { currency?: CurrencyCode },
-  tripCurrency: CurrencyCode,
+  _tripCurrency: CurrencyCode,
 ): CurrencyCode {
-  return expense.currency ?? tripCurrency;
+  return expense.currency ?? LEGACY_DEFAULT_CURRENCY;
 }
 
-/** 行程主導幣別：最舊一筆記帳的幣別快照，舊資料 fallback 全域幣別。 */
+/** 行程主導幣別：最舊一筆記帳的幣別快照；舊資料 fallback TWD，空行程 fallback 全域幣別。 */
 export function resolveTripCurrency(
   expenses: { currency?: CurrencyCode }[],
   globalCurrency: CurrencyCode,
 ): CurrencyCode {
-  return expenses[expenses.length - 1]?.currency ?? globalCurrency;
+  const oldest = expenses[expenses.length - 1];
+  if (!oldest) return globalCurrency;
+  return oldest.currency ?? LEGACY_DEFAULT_CURRENCY;
 }
 
 /** 行程是否混用多種幣別；混幣時不可加總或結算。 */

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+71
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+72
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-split-meow-legacy-expense-currency-twd
+- 原因：PR 445 審查發現缺 currency 的舊支出 fallback 至全域幣別，KRW 上線前 TWD 帳目切換幣別後仍誤顯示 ₩
+- 解法：resolveExpenseCurrency 與 resolveTripCurrency 舊資料固定 fallback TWD，補 currencies 單元測試
 
 - 日期：2026-06-27
 - ID：reward-pw-version-unify-1611


### PR DESCRIPTION
## Summary

- 深度審查已合併 PR #455（clean）與 #445（發現 legacy 缺陷）
- #445：`resolveExpenseCurrency` / `resolveTripCurrency` 對缺 `currency` 的舊支出誤跟全域 KRW，NT$ 帳目切換幣別後仍顯示 ₩
- 修正：舊資料固定 fallback TWD，對齊 `ExpenseRecord` JSDoc 與 KRW 上線前僅有 TWD 的事實

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（split-meow 190 tests + 全 workspace）
- [x] `pnpm lint`


Made with [Cursor](https://cursor.com)