### PR TITLE
fix(ci): 修正 E2E Merge Reports 下載路徑導致 main CI 長期紅燈

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,8 @@ jobs:
       - name: Download blob reports
         uses: actions/download-artifact@v4
         with:
-          path: all-blob-reports
+          # 下載至 apps/ratewise 內，對齊 merge 指令的 cwd（pnpm --filter exec 以套件目錄為工作目錄）。
+          path: apps/ratewise/all-blob-reports
           pattern: blob-report-*
           merge-multiple: true
 


### PR DESCRIPTION
## 背景
main 的「CI」workflow 長期紅燈（#472/#446/#474/#478/#479 連續失敗），根因非程式碼。

## 根因
`E2E Full` 兩 shard 全綠並上傳 blob，但 `E2E Merge Reports` job：
- `download-artifact` 下載到 repo 根的 `all-blob-reports/`
- merge 指令 `pnpm --filter @app/ratewise exec playwright merge-reports ... ./all-blob-reports` 的 cwd 為 `apps/ratewise/`
- 故 `./all-blob-reports` 指向不存在的 `apps/ratewise/all-blob-reports` → merge 找不到報告 → job 失敗

## 修法（最小）
download-artifact `path` 改為 `apps/ratewise/all-blob-reports`，對齊 merge 指令 cwd 與輸出 `apps/ratewise/playwright-report`。

## 驗證
合併後 main push 的 `E2E Merge Reports` 應由 fail 轉 pass。