### PR TITLE
fix(ratewise): MoneyBox schema 遷移觸發 commit 與 CDN fallback

### DIFF
--- a/.changeset/moneybox-schema-cdn-fallback.md
+++ b/.changeset/moneybox-schema-cdn-fallback.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+MoneyBox 換匯所在 jsDelivr CDN 落後 v2 schema 時，自動改從 GitHub Raw 取得最新資料，避免 Open Data 整合方讀到過期語意欄位。

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -727,6 +727,15 @@ describe('ratewise build scripts', () => {
     ]);
   });
 
+  it('should trigger MoneyBox update when schemaVersion migration is needed even if rates unchanged', async () => {
+    const scriptSource = await readMoneyBoxFetchScript();
+
+    expect(scriptSource).toContain('function needsSchemaMigration()');
+    expect(scriptSource).toContain('API_SEMANTICS_SCHEMA_VERSION');
+    expect(scriptSource).toContain('schemaMigrationNeeded');
+    expect(scriptSource).toContain('!hasChanges && !schemaMigrationNeeded');
+  });
+
   it('CurrencyLandingPage should import AnswerCapsule and accept answerCapsule prop (AEO/GEO readiness)', async () => {
     const source = await readCurrencyLandingPageSource();
 

--- a/apps/ratewise/src/services/__tests__/moneyboxRateService.test.ts
+++ b/apps/ratewise/src/services/__tests__/moneyboxRateService.test.ts
@@ -12,6 +12,7 @@ import { EXCHANGE_SHOP_PROVIDERS } from '../../config/exchangeShopProviders';
 import type { CurrencyCode } from '../../features/ratewise/types';
 
 const MOCK_MONEYBOX_JSON = {
+  schemaVersion: '2.0',
   timestamp: '2026-05-07T07:33:55.932Z',
   updateTime: '2026/05/07 16:33:55',
   source: 'MoneyBox (明洞換匯所聯盟)',
@@ -48,6 +49,35 @@ describe('fetchExchangeShopRate', () => {
     expect((result as ExchangeShopRate & { currency?: CurrencyCode })!.currency).toBe('KRW');
     expect(result!.providerName).toBe('明洞換匯所');
     expect(result!.source).toBe('MoneyBox');
+  });
+
+  it('falls back to raw GitHub URL when jsDelivr CDN returns stale schemaVersion', async () => {
+    const config = EXCHANGE_SHOP_PROVIDERS.KRW!;
+    const { schemaVersion: _ignored, ...legacyPayload } = MOCK_MONEYBOX_JSON;
+    const v2Payload = MOCK_MONEYBOX_JSON;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(legacyPayload),
+        headers: { get: () => '"etag-legacy"' },
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(v2Payload),
+        headers: { get: () => '"etag-v2"' },
+      } as unknown as Response);
+
+    const result = await fetchExchangeShopRate('KRW');
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(config.cdnUrl);
+    expect(vi.mocked(fetch).mock.calls[1]?.[0]).toBe(config.cdnUrlFallback);
+    expect(result).not.toBeNull();
+    expect(result!.sell).toBe(44.85);
+    expect(result!.isFallback).toBe(false);
   });
 
   it('returns cached data within 5 minutes without re-fetching', async () => {

--- a/apps/ratewise/src/services/moneyboxRateService.ts
+++ b/apps/ratewise/src/services/moneyboxRateService.ts
@@ -4,6 +4,7 @@ import {
   hasExchangeShopProvider,
   type ExchangeShopConfig,
 } from '../config/exchangeShopProviders';
+import { API_SEMANTICS_SCHEMA_VERSION } from '../config/api-semantics-v2';
 import { CDN_DATA_BASE, PROVIDER_RATES_PATH, RAW_DATA_BASE } from '../config/api-endpoints';
 import { buildPublicRateProviderMetadata } from '../config/rateProviderPublicMetadata';
 import { CURRENCY_DEFINITIONS } from '../features/ratewise/constants';
@@ -166,10 +167,16 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
   }
 }
 
+function isStaleMoneyboxPayload(raw: unknown): boolean {
+  const schemaVersion = (raw as { schemaVersion?: string } | null)?.schemaVersion;
+  return schemaVersion !== API_SEMANTICS_SCHEMA_VERSION;
+}
+
 async function fetchFromCDN(config: ExchangeShopConfig): Promise<{ raw: unknown; etag?: string }> {
   const urls = [config.cdnUrl, config.cdnUrlFallback];
 
-  for (const url of urls) {
+  for (const [index, url] of urls.entries()) {
+    const isLastUrl = index === urls.length - 1;
     try {
       const res = await fetchWithTimeout(url, { cache: 'no-cache' });
 
@@ -179,6 +186,14 @@ async function fetchFromCDN(config: ExchangeShopConfig): Promise<{ raw: unknown;
       }
 
       const raw: unknown = await res.json();
+      if (!isLastUrl && isStaleMoneyboxPayload(raw)) {
+        logger.warn('Exchange shop CDN payload schemaVersion stale, trying fallback URL', {
+          url,
+          schemaVersion: (raw as { schemaVersion?: string }).schemaVersion,
+        });
+        continue;
+      }
+
       const etag = res.headers.get('etag') ?? undefined;
       return { raw, etag };
     } catch (e) {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+73
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+74
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-moneybox-schema-migration-cdn-fallback
+- 原因：MoneyBox fetch 僅比對匯率數字，schema v2 遷移未觸發 data commit/purge；jsDelivr @data 分支快取最長 12h
+- 解法：needsSchemaMigration 補觸發寫入與 purge；runtime CDN stale schemaVersion 時 fallback Raw
 
 - 日期：2026-06-27
 - ID：reward-pr472-openapi-dataset-hotfix

--- a/scripts/fetch-moneybox-rates.js
+++ b/scripts/fetch-moneybox-rates.js
@@ -7,7 +7,10 @@
 import { writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { dirname, isAbsolute, join } from 'path';
 import { fileURLToPath } from 'url';
-import { enrichExchangeShopRatesPayload } from '../apps/ratewise/src/config/api-semantics-v2.ts';
+import {
+  API_SEMANTICS_SCHEMA_VERSION,
+  enrichExchangeShopRatesPayload,
+} from '../apps/ratewise/src/config/api-semantics-v2.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -205,6 +208,15 @@ function listRateChanges(oldRates = {}, newRates = {}) {
   );
 }
 
+function needsSchemaMigration() {
+  try {
+    const oldData = JSON.parse(readFileSync(OUTPUT_FILE, 'utf8'));
+    return oldData.schemaVersion !== API_SEMANTICS_SCHEMA_VERSION;
+  } catch {
+    return false;
+  }
+}
+
 function hasRateChanges(newData) {
   try {
     const oldData = JSON.parse(readFileSync(OUTPUT_FILE, 'utf8'));
@@ -252,13 +264,20 @@ async function main() {
     // 檢查是否有變化
     console.log('🔍 Checking for rate changes...');
     const hasChanges = hasRateChanges(ratesData);
+    const schemaMigrationNeeded = needsSchemaMigration();
 
-    if (!hasChanges) {
+    if (!hasChanges && !schemaMigrationNeeded) {
       console.log('ℹ️  No rate changes detected, skipping update');
       return;
     }
 
-    console.log('✨ Rate changes detected!');
+    if (schemaMigrationNeeded && !hasChanges) {
+      console.log(
+        `🔄 Schema migration needed: latest.json lacks schemaVersion ${API_SEMANTICS_SCHEMA_VERSION}`,
+      );
+    }
+
+    console.log('✨ Rate or schema changes detected!');
     console.log('');
 
     // 確保目錄存在
@@ -310,3 +329,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export { fetchMoneyBoxRates };
 export { listRateChanges };
+export { needsSchemaMigration };


### PR DESCRIPTION
## Summary

- **根因**：`fetch-moneybox-rates.js` 的 `hasRateChanges()` 只比對匯率數字；v2 schema 合併後若匯率未變，data 分支不 commit、不 purge，jsDelivr `@data` 最長快取 12h。
- **Workflow 修復**：新增 `needsSchemaMigration()`，缺 `schemaVersion 2.0` 時仍寫入 latest.json 並觸發 purge。
- **Runtime 防禦**：`moneyboxRateService.fetchFromCDN` 在 jsDelivr 回傳 stale schema 時 fallback Raw；最後 URL 仍接受 legacy（不 breaking 換算）。

## 調查結論（2026-06-27）

| 端點 | schemaVersion | etag | cache |
|------|---------------|------|-------|
| `@data` jsDelivr | 2.0 ✅ | W/"20c1-…" | s-maxage=43200 |
| `@fbc242ac…` jsDelivr | 2.0 ✅ | 同上 | immutable |
| Raw GitHub | 2.0 ✅ | sha256 | max-age=300 |

**已自然恢復** — 三端點一致，`updateTime: 2026/06/27 19:24:30`。

App 換算只讀 `rates.TWD.sell/buy`（legacy），CDN 舊版不影響 KRW 換算，只影響 Open Data / API 整合方。

## Test plan

- [x] `vitest run moneyboxRateService.test.ts`（17 項）
- [x] `vitest run build-scripts.test.ts`（schema migration 靜態檢查）
- [x] pre-push：typecheck + test + build:ratewise


Made with [Cursor](https://cursor.com)