### PR TITLE
fix(ci): 修正 E2E 多 reporter CLI 語法讓 blob 報告產出

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,9 +325,7 @@ jobs:
             --project=chromium-desktop \
             --project=chromium-mobile \
             --shard=${{ matrix.shard }}/2 \
-            --reporter=blob \
-            --reporter=github \
-            --reporter=list
+            --reporter=blob,github,list
 
       - name: Stop preview server
         if: always()


### PR DESCRIPTION
## 根因（接續 #482）
#482 修了 merge 下載路徑，但 main CI 仍紅。深入發現真正根因：

E2E 測試步驟用**三個分開的 `--reporter=` flag**（`--reporter=blob --reporter=github --reporter=list`）。Playwright CLI 的 `--reporter` 多 reporter **必須逗號分隔**；重複 flag 只有最後的 `list` 生效，**`blob` 從未產出** → `apps/ratewise/blob-report` 為空 → upload 無檔（僅 warn）→ download 抓不到 → merge-reports 報「Directory does not exist」失敗。

## 修法
依 Playwright 官方文檔改為單一逗號語法 `--reporter=blob,github,list`，blob/github/list 三者同時生效。

## 依據
context7 / Playwright 官方 sharding 文檔：`--reporter` 支援逗號分隔多 reporter。

## 驗證
合併後 main push 的 E2E Full 將產出 blob-report-1/2 artifact，E2E Merge Reports 由 fail 轉 pass。