### PR TITLE
fix(ratewise): 修復冷啟動 multi 還原 hydration 未觸發

### DIFF
--- a/.changeset/cold-start-multi-hydration-fallback.md
+++ b/.changeset/cold-start-multi-hydration-fallback.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復冷啟動時多幣別換算模式無法還原的問題（生產環境 persist 已同步但 hydration 回呼未觸發）。

--- a/apps/ratewise/src/features/ratewise/components/RememberedHomeRoute.tsx
+++ b/apps/ratewise/src/features/ratewise/components/RememberedHomeRoute.tsx
@@ -6,6 +6,7 @@ import {
   markRestoreAttempted,
   shouldRestoreToMulti,
   isPersistedMultiPendingStoreSync,
+  readPersistedLastConverterView,
 } from './coldStartRestore';
 
 /**
@@ -20,14 +21,46 @@ export function RememberedHomeRoute() {
   const [hydrated, setHydrated] = useState(isTestEnv);
 
   useEffect(() => {
+    let active = true;
+    const markHydrated = () => {
+      if (active) {
+        setHydrated(true);
+      }
+    };
+
+    const isStoreSyncedWithPersist = (): boolean => {
+      const persisted = readPersistedLastConverterView();
+      if (persisted === null) return true;
+      return useConverterStore.getState().lastConverterView === persisted;
+    };
+
     if (useConverterStore.persist.hasHydrated()) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- persist hydration marker
-      setHydrated(true);
-      return undefined;
+      markHydrated();
+      return () => {
+        active = false;
+      };
     }
-    return useConverterStore.persist.onFinishHydration(() => {
-      setHydrated(true);
+
+    const unsubFinish = useConverterStore.persist.onFinishHydration(markHydrated);
+
+    // SSG/CSR：store 可能已 merge persist，但 onFinishHydration 未觸發。
+    queueMicrotask(() => {
+      if (isStoreSyncedWithPersist()) {
+        markHydrated();
+      }
     });
+
+    const unsubStore = useConverterStore.subscribe((state, prevState) => {
+      if (state.lastConverterView !== prevState.lastConverterView && isStoreSyncedWithPersist()) {
+        markHydrated();
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubFinish();
+      unsubStore();
+    };
   }, []);
 
   const hasDeepLink =

--- a/apps/ratewise/src/features/ratewise/components/__tests__/RememberedHomeRoute.test.tsx
+++ b/apps/ratewise/src/features/ratewise/components/__tests__/RememberedHomeRoute.test.tsx
@@ -131,4 +131,18 @@ describe('RememberedHomeRoute', () => {
     expect(await screen.findByTestId('ratewise-single')).toBeInTheDocument();
     expect(screen.queryByTestId('multi-page')).not.toBeInTheDocument();
   });
+
+  it('production MODE：store 已同步 multi 但 hasHydrated=false 時仍導向 /multi', async () => {
+    vi.stubEnv('MODE', 'production');
+    localStorage.setItem(CONVERTER_STORE_KEY, multiPersistPayload);
+    useConverterStore.setState({ lastConverterView: 'multi' });
+    vi.spyOn(useConverterStore.persist, 'hasHydrated').mockReturnValue(false);
+
+    renderHome('/');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('multi-page')).toBeInTheDocument();
+    });
+    vi.unstubAllEnvs();
+  });
 });

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+77
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+78
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-27
+- ID：reward-cold-start-multi-hydration-fallback
+- 原因：RememberedHomeRoute 僅依 hasHydrated/onFinishHydration 設 hydrated，SSG/CSR 生產環境 store 已 merge persist 但回呼未觸發，multi 冷啟動無法還原
+- 解法：hydration effect 補 queueMicrotask 與 store subscribe fallback，store 與 localStorage 同步即標記 hydrated
 
 - 日期：2026-06-27
 - ID：reward-applayout-logo-vitest-teardown-flake


### PR DESCRIPTION
## Summary

- 修復 SSG/CSR 生產環境下 `RememberedHomeRoute` 因 `hasHydrated()` / `onFinishHydration` 未觸發而永遠卡在 `hydrated=false`，導致 multi 冷啟動無法還原的問題
- hydration effect 新增 `queueMicrotask` 與 `useConverterStore.subscribe` fallback：當 store 已與 localStorage persist 同步時即標記 hydrated
- 新增 production MODE 回歸測試（`hasHydrated=false` 但 store 已有 `lastConverterView=multi`）
- patch changeset：`@app/ratewise`

## Root cause

`#487` 已修復 persist/store 同步時序競態，但生產環境仍存在 zustand persist 資料已 merge、hydration callback 卻從未觸發的路徑，使 restore gate 永遠關閉。

## Test plan

- [x] `RememberedHomeRoute.test.tsx` + `coldStartRestore.test.ts`（11 項）
- [x] `pnpm --filter @app/ratewise test`（2469 項通過）
- [ ] CI checks green
- [ ] 手動：PWA 冷啟動 / 上次停留 multi → 應導向 `/multi`

## Notes

- 未包含 `offline.html` 漂移
- 不 merge #433


Made with [Cursor](https://cursor.com)