### PR TITLE
fix(ratewise): 修復 PWA 冷啟動 HTTPS 連線不安全

### DIFF
--- a/.changeset/pwa-https-cold-start-hotfix.md
+++ b/.changeset/pwa-https-cold-start-hotfix.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復 PWA 冷啟動時 Chrome 顯示「此連結並不安全」警告：manifest 改為絕對 HTTPS scope，且 Service Worker 不再快取舊版 manifest。

--- a/apps/ratewise/public/manifest.webmanifest
+++ b/apps/ratewise/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "theme_color": "#8B5CF6",
   "background_color": "#E8ECF4",
   "display": "standalone",
-  "scope": "/ratewise/",
+  "scope": "https://app.haotool.org/ratewise/",
   "start_url": "https://app.haotool.org/ratewise/",
   "id": "/ratewise/",
   "orientation": "portrait-primary",

--- a/apps/ratewise/scripts/generate-manifest.mjs
+++ b/apps/ratewise/scripts/generate-manifest.mjs
@@ -24,9 +24,9 @@ const manifest = {
   theme_color: '#8B5CF6',
   background_color: '#E8ECF4',
   display: 'standalone',
-  scope: '/ratewise/',
-  // 絕對 HTTPS start_url：避免獨立 PWA partition + Chrome HTTPS-First 在啟動時以 http 語意解析。
-  // id/scope 維持相對（id 變更會被視為新 PWA 身分，破壞既有安裝更新連續性）。
+  // 絕對 HTTPS scope/start_url：避免獨立 PWA partition + Chrome HTTPS-First 在啟動時以 http 語意解析。
+  // id 維持相對（id 變更會被視為新 PWA 身分，破壞既有安裝更新連續性）。
+  scope: APP_INFO.siteUrl,
   start_url: APP_INFO.siteUrl,
   id: '/ratewise/',
   orientation: 'portrait-primary',

--- a/apps/ratewise/src/__tests__/sw.test.ts
+++ b/apps/ratewise/src/__tests__/sw.test.ts
@@ -242,6 +242,17 @@ describe('Service Worker Cache Strategies', () => {
     expect(sourceCode).toContain('new NetworkOnly(');
   });
 
+  it('should fetch manifest.webmanifest with NetworkOnly to avoid stale relative start_url', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+
+    const swPath = path.resolve(__dirname, '../sw.ts');
+    const sourceCode = await fs.readFile(swPath, 'utf-8');
+
+    expect(sourceCode).toContain("url.pathname.endsWith('.webmanifest')");
+    expect(sourceCode).not.toContain('.(webmanifest|txt|xml)$');
+  });
+
   // 🔴 RED: JS/CSS 應使用 CacheFirst（Vite hash-based filenames 是 immutable）
   it('should use CacheFirst for JS/CSS static resources (hash-based filenames are immutable)', async () => {
     const fs = await import('node:fs/promises');

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -260,6 +260,21 @@ describe('ratewise build scripts', () => {
     expect(manifestGenerator).not.toContain("name: 'HaoRate 匯率好工具'");
   });
 
+  it('should keep PWA manifest scope and start_url on absolute HTTPS SSOT', async () => {
+    const manifestGenerator = await readManifestGenerator();
+    const manifestPath = path.resolve(__dirname, '../../../public/manifest.webmanifest');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
+      scope: string;
+      start_url: string;
+    };
+
+    expect(manifestGenerator).toContain('scope: APP_INFO.siteUrl');
+    expect(manifestGenerator).toContain('start_url: APP_INFO.siteUrl');
+    expect(manifest.scope).toMatch(/^https:\/\//);
+    expect(manifest.start_url).toMatch(/^https:\/\//);
+    expect(manifest.scope).toBe(manifest.start_url);
+  });
+
   it('should not force React ecosystem packages into manual chunks', async () => {
     const viteConfig = await readViteConfig();
     expect(viteConfig).not.toContain(

--- a/apps/ratewise/src/sw.ts
+++ b/apps/ratewise/src/sw.ts
@@ -457,9 +457,12 @@ registerRoute(
   }),
 );
 
-// manifest / SEO 文字檔案：StaleWhileRevalidate，7 天。
+// manifest 必須 NetworkOnly：SWR 快取會回傳舊版相對 start_url，觸發冷啟動 HTTPS-First 警告。
+registerRoute(({ url }: { url: URL }) => url.pathname.endsWith('.webmanifest'), new NetworkOnly());
+
+// SEO 文字/XML：StaleWhileRevalidate，7 天。
 registerRoute(
-  ({ url }: { url: URL }) => /\.(webmanifest|txt|xml)$/.test(url.pathname),
+  ({ url }: { url: URL }) => /\.(txt|xml)$/.test(url.pathname),
   new StaleWhileRevalidate({
     cacheName: 'seo-files-cache',
     plugins: [

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+79
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+80
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-28
+- ID：reward-pwa-https-cold-start-manifest-regression
+- 原因：#447 已改絕對 HTTPS start_url，但 SW seo-files-cache 以 SWR 快取舊 manifest（相對 start_url），冷啟動仍觸發 HTTPS-First 警告
+- 解法：manifest.webmanifest 改 NetworkOnly、scope 同步絕對 HTTPS SSOT，並補防回歸測試
 
 - 日期：2026-06-28
 - ID：reward-threads-barcelona-inapp-ua


### PR DESCRIPTION
## Summary

- `manifest.webmanifest` 改 **NetworkOnly**，避免 `seo-files-cache` SWR 鎖定 #447 前舊版相對 `start_url`
- `scope` 同步為絕對 HTTPS SSOT（與 #447 `start_url` 對齊）
- 補 SW / build-scripts 防回歸測試 + patch changeset

## Root cause

**#447** 已將 `start_url` 改為絕對 HTTPS，但 SW 仍以 StaleWhileRevalidate 快取 `.webmanifest`。已安裝 PWA 冷啟動時可能讀到舊 manifest（相對 `start_url`），在 Chrome standalone + HTTPS-First 下觸發「此連結並不安全」。

另：`scope` 仍為相對路徑 `/ratewise/`，與絕對 HTTPS `start_url` 不一致。

## Changed files

- `apps/ratewise/src/sw.ts`
- `apps/ratewise/scripts/generate-manifest.mjs`
- `apps/ratewise/public/manifest.webmanifest`
- `apps/ratewise/src/__tests__/sw.test.ts`
- `apps/ratewise/src/config/__tests__/build-scripts.test.ts`
- `.changeset/pwa-https-cold-start-hotfix.md`
- `docs/dev/002_development_reward_penalty_log.md`

## Test plan

- [x] `pnpm --filter @app/ratewise test -- sw.test build-scripts.test`（87 passed）
- [x] pre-push：`typecheck` + `test` + `build:ratewise`
- [ ] CI green
- [ ] Production：已安裝 PWA 線上冷啟動一次，新 SW 生效並丟棄舊 manifest 快取

## QA verification matrix

| # | 項目 | 預期 |
|---|------|------|
| Q1 | Production curl headers | 200 HTTPS、HSTS |
| Q2 | manifest `start_url` / `scope` / `id` | 絕對 https，`scope` = `start_url` |
| Q3 | `sw.js` precache URLs | 0 個 `http://` |
| Q4 | manifest fetch | NetworkOnly，無 SWR 7 天快取 |
| Q5 | `dist/index.html` mixed content | 無 http 資源 |

## #456 navigation timeout 決策（刻意不納入本 PR）

**結論：保留 case 3 的 8s bounded timeout，不另開 follow-up 移除。**

| 情境 | 行為 | 說明 |
|------|------|------|
| case 1 暖快取 | SWR 立即回傳 | 無 timeout |
| case 2 冷快取 + precache hit | precache index.html 立即回傳 | 無 timeout（#456 舊 3s 全域 timeout 根因已在此消除） |
| case 3 precache miss | `Promise.race` 8s 後 fallback offline.html | 防止 hung network 無限白屏 |

#456 要移除的是**舊版 3s 全域 navigation timeout**（iOS eviction 時誤判離線），已在 hybrid SWR + precache-first 重構中移除。現行 8s 僅限 case 3，且有 `sw.test.ts` 行為測試覆蓋；移除會讓 precache 被驅逐且網路掛住時無限白屏。

**reinstall banner**：依 KISS 原則不納入；manifest NetworkOnly + 一次線上冷啟動即可讓新 SW 生效。

## Notes

- 請勿合併 #433
- #490 / #491（Threads Barcelona）已合併/關閉
- bump：**patch**
- 合併後：已安裝用戶需一次線上冷啟動（或清除站點資料）讓新 SW 生效
- 窄視窗佈局 QA 修復見 #494（獨立 PR，避免 scope 混雜）