### PR TITLE
fix(security): 更新 ratewise 基底映像修復 libssh2 CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,10 +92,12 @@ RUN test -f /app/apps/ratewise/dist/sitemap.xml && \
 FROM nginx:stable
 
 # [fix:2026-04-10] 安裝安全更新以修復 CVE-2026-4775 (libtiff) 等漏洞
-# 參考: https://security-tracker.debian.org/tracker/CVE-2026-4775
+# [fix:2026-06-28] 明確升級 libssh2-1t64 以修復 DSA-6365-1（CVE-2026-55200 等）
+# 參考: https://security-tracker.debian.org/tracker/DSA-6365-1
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends wget && \
+    apt-get install -y --only-upgrade libssh2-1t64 && \
     rm -rf /var/lib/apt/lists/*
 
 # [fix:2025-12-13] 新架構：haotool 作為根路徑首頁

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+81
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+82
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-28
+- ID：reward-docker-libssh2-dsa-6365
+- 原因：Trivy 掃描 ratewise Docker 映像（nginx:stable / Debian trixie）偵測 libssh2-1t64@1.11.1-1 含 DSA-6365-1 未修補 CVE
+- 解法：production stage 於 apt upgrade 後明確 `--only-upgrade libssh2-1t64` 拉取 1.11.1-1+deb13u1
 
 - 日期：2026-06-28
 - ID：reward-viewport-qa-layout-hotfix


### PR DESCRIPTION
## Summary

- Trivy image scan（`library/ratewise:1`）在 production stage 的 `nginx:stable`（Debian trixie）偵測到 `libssh2-1t64@1.11.1-1` 未修補
- 於 Dockerfile production stage 的既有 `apt-get upgrade` 後，新增 `apt-get install -y --only-upgrade libssh2-1t64` 拉取 DSA-6365-1 修補版（`1.11.1-1+deb13u1`）

## Root cause

`nginx:stable` 基底映像內建 Debian trixie 的 `libssh2-1t64@1.11.1-1`，含 DSA-6365-1 所列 CVE（CVE-2025-15661、CVE-2026-55199、CVE-2026-55200、CVE-2026-7598）。既有 `apt-get upgrade -y` 未明確確保 libssh2 安全更新被套用。

## Trivy alerts addressed

| Alert | Severity | Package | Status |
|-------|----------|---------|--------|
| #81 | Critical | libssh2 OOB write (CVE-2026-55200) | ✅ 本 PR |
| #82 | High | libssh2 DoS/overflow | ✅ 本 PR |
| #83 | Medium | libssh2 SFTP | ✅ 本 PR |
| #84 | High | libssh2 | ✅ 本 PR |
| #80 | Medium | react-router open redirect (pnpm-lock) | ⏭️ 留待 npm overrides PR 處理，避免重複 |

## Test plan

- [ ] CI `Security Scan` job Trivy image scan 通過（libssh2 alerts 消失）
- [ ] Docker build 成功且 `dpkg -l libssh2-1t64` 顯示 `1.11.1-1+deb13u1`

## References

- https://security-tracker.debian.org/tracker/DSA-6365-1
- https://security-tracker.debian.org/tracker/CVE-2026-55200

Made with [Cursor](https://cursor.com)