### PR TITLE
fix(release): 修復 js-yaml 4 override 破壞 changesets release

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
       "shell-quote@>=1.1.0 <=1.8.3": "1.8.4",
       "form-data@>=4.0.0 <4.0.6": "4.0.6",
       "js-yaml@<=4.1.1": "4.2.0",
+      "read-yaml-file@<2": "^2.1.0",
       "launch-editor@<=2.14.0": "2.14.1",
       "@babel/core@<=7.29.0": "7.29.6",
       "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": "7.29.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   shell-quote@>=1.1.0 <=1.8.3: 1.8.4
   form-data@>=4.0.0 <4.0.6: 4.0.6
   js-yaml@<=4.1.1: 4.2.0
+  read-yaml-file@<2: ^2.1.0
   launch-editor@<=2.14.0: 2.14.1
   '@babel/core@<=7.29.0': 7.29.6
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': 7.29.4
@@ -7462,10 +7463,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -7841,9 +7838,9 @@ packages:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
 
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -8388,9 +8385,9 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
 
   strip-comments@2.0.1:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
@@ -11252,7 +11249,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 2.1.0
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
@@ -17245,8 +17242,6 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pify@4.0.1: {}
-
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -17608,12 +17603,10 @@ snapshots:
       parse-json: 5.2.0
       type-fest: 0.6.0
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@2.1.0:
     dependencies:
-      graceful-fs: 4.2.11
       js-yaml: 4.2.0
-      pify: 4.0.1
-      strip-bom: 3.0.0
+      strip-bom: 4.0.0
 
   readable-stream@3.6.2:
     dependencies:
@@ -18326,7 +18319,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-bom@3.0.0: {}
+  strip-bom@4.0.0: {}
 
   strip-comments@2.0.1: {}
 


### PR DESCRIPTION
## 問題

合併 #502 後 **Release workflow 失敗**，版本無法 bump、release PR 無法建立：

```
🦋 error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead.
   at read-yaml-file@1.1.0 ... during `pnpm changeset:version`
```

## 根因

安全修復 PR #501 的 override `js-yaml@<=4.1.1 → 4.2.0` 將 js-yaml 強制升到 4.x（移除 `safeLoad`）。
但 changesets 的傳遞相依 `@changesets/cli → @manypkg/get-packages@1.1.3 → read-yaml-file@1.1.0` 仍呼叫已移除的 `yaml.safeLoad` → `changeset version` 崩潰，阻塞所有發版。

## 修法（KISS，保留 js-yaml 安全版本）

新增 pnpm override，將過舊的 `read-yaml-file` 升到 js-yaml 4 相容的 v2：

```json
"read-yaml-file@<2": "^2.1.0"
```

`read-yaml-file@2.1.0` 改用 `yaml.load`，API 對 `@manypkg/get-packages` 相容；js-yaml 維持 4.2.0 不動。

## 驗證

- `pnpm changeset status` 正常輸出 `@app/ratewise` patch（原 safeLoad 錯誤消除）
- `pnpm changeset:version` 端到端成功（bump 2.25.9→2.25.10、CHANGELOG、release metadata、markdown mirrors、live rates restore 全數完成，exit 0；本地已還原不入此 PR）
- `read-yaml-file` 解析版本由 1.1.0 → 2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)