### PR TITLE
fix(ratewise): offline.html 自我修復打破 SW 死亡迴圈

### DIFF
--- a/.changeset/ratewise-offline-shell-self-heal.md
+++ b/.changeset/ratewise-offline-shell-self-heal.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+在線卻卡在離線頁時，offline.html 會自動嘗試修復 Service Worker 並導回主應用，避免無法進入主功能的死亡迴圈。

--- a/apps/ratewise/public/offline.html
+++ b/apps/ratewise/public/offline.html
@@ -193,7 +193,7 @@
       <h1>您目前處於離線狀態</h1>
       <p>請檢查您的網路連線，或稍後再試。HaoRate 會在連線恢復時自動更新。</p>
 
-      <button class="retry-btn" onclick="window.location.reload()">
+      <button class="retry-btn" id="retry-btn" type="button">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="20"
@@ -227,20 +227,157 @@
     </div>
 
     <script>
-      // 檢查是否有快取的匯率數據
-      try {
-        const cached = localStorage.getItem('exchangeRates');
-        if (cached) {
-          document.getElementById('cached-info').style.display = 'block';
-        }
-      } catch (e) {
-        // Ignore localStorage errors
-      }
+      (function () {
+        var HEAL_SESSION_KEY = 'rw-offline-shell-heal';
+        var LEGACY_PRECACHE_THRESHOLD = 150;
+        var SHELL_PROBE_TIMEOUT_MS = 2000;
+        var WAITING_SW_TIMEOUT_MS = 8000;
 
-      // 監聽網路狀態變化，自動重載
-      window.addEventListener('online', () => {
-        window.location.reload();
-      });
+        // 檢查是否有快取的匯率數據
+        try {
+          var cached = localStorage.getItem('exchangeRates');
+          if (cached) {
+            document.getElementById('cached-info').style.display = 'block';
+          }
+        } catch (e) {
+          // localStorage 不可用時略過
+        }
+
+        function hasHealBeenAttemptedThisSession() {
+          try {
+            return sessionStorage.getItem(HEAL_SESSION_KEY) === '1';
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function markHealAttemptedThisSession() {
+          try {
+            sessionStorage.setItem(HEAL_SESSION_KEY, '1');
+          } catch (e) {
+            // sessionStorage 不可用時仍允許單次修復
+          }
+        }
+
+        function navigateToAppShell() {
+          var healQuery = 'shell-heal=' + Date.now();
+          window.location.replace('./?' + healQuery);
+        }
+
+        function probeActiveSwShellBroken() {
+          if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+            return Promise.resolve(true);
+          }
+
+          return new Promise(function (resolve) {
+            var channel = new MessageChannel();
+            var timeoutId = setTimeout(function () {
+              resolve(true);
+            }, SHELL_PROBE_TIMEOUT_MS);
+
+            channel.port1.onmessage = function (event) {
+              clearTimeout(timeoutId);
+              var data = event.data || {};
+              var precacheEntryCount = Number(data.precacheEntryCount || 0);
+              var hasIndexShell = Boolean(data.hasIndexShell || data.healthy);
+              resolve(!hasIndexShell || precacheEntryCount > LEGACY_PRECACHE_THRESHOLD);
+            };
+
+            navigator.serviceWorker.controller.postMessage({ type: 'CHECK_SHELL_PRECACHE' }, [
+              channel.port2,
+            ]);
+          });
+        }
+
+        function waitForWaitingServiceWorker(registration) {
+          if (registration.waiting) {
+            return Promise.resolve(registration.waiting);
+          }
+
+          return new Promise(function (resolve) {
+            var timeoutId = setTimeout(function () {
+              registration.removeEventListener('updatefound', onUpdateFound);
+              resolve(registration.waiting);
+            }, WAITING_SW_TIMEOUT_MS);
+
+            function onUpdateFound() {
+              var installing = registration.installing;
+              if (!installing) {
+                return;
+              }
+
+              installing.addEventListener('statechange', function () {
+                if (installing.state === 'installed' && registration.waiting) {
+                  clearTimeout(timeoutId);
+                  registration.removeEventListener('updatefound', onUpdateFound);
+                  resolve(registration.waiting);
+                }
+              });
+            }
+
+            registration.addEventListener('updatefound', onUpdateFound);
+          });
+        }
+
+        function skipWaitingAndNavigateToShell(waitingWorker) {
+          return new Promise(function () {
+            navigator.serviceWorker.addEventListener(
+              'controllerchange',
+              function () {
+                navigateToAppShell();
+              },
+              { once: true },
+            );
+            waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+            setTimeout(navigateToAppShell, 1500);
+          });
+        }
+
+        // 在線卻載入 offline.html 時自我修復；swHealth 僅在 React 掛載後執行，無法打破死亡迴圈。
+        async function attemptOfflineShellSelfHeal(forceRetry) {
+          if (!navigator.onLine) {
+            return;
+          }
+          if (!forceRetry && hasHealBeenAttemptedThisSession()) {
+            return;
+          }
+          markHealAttemptedThisSession();
+
+          try {
+            if ('serviceWorker' in navigator) {
+              var registration = await navigator.serviceWorker.getRegistration();
+              if (registration) {
+                await registration.update();
+                var broken = await probeActiveSwShellBroken();
+                if (broken) {
+                  var waiting = await waitForWaitingServiceWorker(registration);
+                  if (waiting) {
+                    await skipWaitingAndNavigateToShell(waiting);
+                    return;
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            // 修復失敗時仍嘗試導向 app shell
+          }
+
+          navigateToAppShell();
+        }
+
+        var retryBtn = document.getElementById('retry-btn');
+        if (retryBtn) {
+          retryBtn.addEventListener('click', function () {
+            void attemptOfflineShellSelfHeal(true);
+          });
+        }
+
+        window.addEventListener('online', function () {
+          void attemptOfflineShellSelfHeal(true);
+        });
+
+        void attemptOfflineShellSelfHeal(false);
+      })();
     </script>
   </body>
 </html>

--- a/apps/ratewise/scripts/templates/offline.template.html
+++ b/apps/ratewise/scripts/templates/offline.template.html
@@ -193,7 +193,7 @@
       <h1>您目前處於離線狀態</h1>
       <p>請檢查您的網路連線，或稍後再試。__BRAND_SHORT__ 會在連線恢復時自動更新。</p>
 
-      <button class="retry-btn" onclick="window.location.reload()">
+      <button class="retry-btn" id="retry-btn" type="button">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="20"
@@ -227,20 +227,157 @@
     </div>
 
     <script>
-      // 檢查是否有快取的匯率數據
-      try {
-        const cached = localStorage.getItem('exchangeRates');
-        if (cached) {
-          document.getElementById('cached-info').style.display = 'block';
-        }
-      } catch (e) {
-        // Ignore localStorage errors
-      }
+      (function () {
+        var HEAL_SESSION_KEY = 'rw-offline-shell-heal';
+        var LEGACY_PRECACHE_THRESHOLD = 150;
+        var SHELL_PROBE_TIMEOUT_MS = 2000;
+        var WAITING_SW_TIMEOUT_MS = 8000;
 
-      // 監聽網路狀態變化，自動重載
-      window.addEventListener('online', () => {
-        window.location.reload();
-      });
+        // 檢查是否有快取的匯率數據
+        try {
+          var cached = localStorage.getItem('exchangeRates');
+          if (cached) {
+            document.getElementById('cached-info').style.display = 'block';
+          }
+        } catch (e) {
+          // localStorage 不可用時略過
+        }
+
+        function hasHealBeenAttemptedThisSession() {
+          try {
+            return sessionStorage.getItem(HEAL_SESSION_KEY) === '1';
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function markHealAttemptedThisSession() {
+          try {
+            sessionStorage.setItem(HEAL_SESSION_KEY, '1');
+          } catch (e) {
+            // sessionStorage 不可用時仍允許單次修復
+          }
+        }
+
+        function navigateToAppShell() {
+          var healQuery = 'shell-heal=' + Date.now();
+          window.location.replace('./?' + healQuery);
+        }
+
+        function probeActiveSwShellBroken() {
+          if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+            return Promise.resolve(true);
+          }
+
+          return new Promise(function (resolve) {
+            var channel = new MessageChannel();
+            var timeoutId = setTimeout(function () {
+              resolve(true);
+            }, SHELL_PROBE_TIMEOUT_MS);
+
+            channel.port1.onmessage = function (event) {
+              clearTimeout(timeoutId);
+              var data = event.data || {};
+              var precacheEntryCount = Number(data.precacheEntryCount || 0);
+              var hasIndexShell = Boolean(data.hasIndexShell || data.healthy);
+              resolve(!hasIndexShell || precacheEntryCount > LEGACY_PRECACHE_THRESHOLD);
+            };
+
+            navigator.serviceWorker.controller.postMessage({ type: 'CHECK_SHELL_PRECACHE' }, [
+              channel.port2,
+            ]);
+          });
+        }
+
+        function waitForWaitingServiceWorker(registration) {
+          if (registration.waiting) {
+            return Promise.resolve(registration.waiting);
+          }
+
+          return new Promise(function (resolve) {
+            var timeoutId = setTimeout(function () {
+              registration.removeEventListener('updatefound', onUpdateFound);
+              resolve(registration.waiting);
+            }, WAITING_SW_TIMEOUT_MS);
+
+            function onUpdateFound() {
+              var installing = registration.installing;
+              if (!installing) {
+                return;
+              }
+
+              installing.addEventListener('statechange', function () {
+                if (installing.state === 'installed' && registration.waiting) {
+                  clearTimeout(timeoutId);
+                  registration.removeEventListener('updatefound', onUpdateFound);
+                  resolve(registration.waiting);
+                }
+              });
+            }
+
+            registration.addEventListener('updatefound', onUpdateFound);
+          });
+        }
+
+        function skipWaitingAndNavigateToShell(waitingWorker) {
+          return new Promise(function () {
+            navigator.serviceWorker.addEventListener(
+              'controllerchange',
+              function () {
+                navigateToAppShell();
+              },
+              { once: true },
+            );
+            waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+            setTimeout(navigateToAppShell, 1500);
+          });
+        }
+
+        // 在線卻載入 offline.html 時自我修復；swHealth 僅在 React 掛載後執行，無法打破死亡迴圈。
+        async function attemptOfflineShellSelfHeal(forceRetry) {
+          if (!navigator.onLine) {
+            return;
+          }
+          if (!forceRetry && hasHealBeenAttemptedThisSession()) {
+            return;
+          }
+          markHealAttemptedThisSession();
+
+          try {
+            if ('serviceWorker' in navigator) {
+              var registration = await navigator.serviceWorker.getRegistration();
+              if (registration) {
+                await registration.update();
+                var broken = await probeActiveSwShellBroken();
+                if (broken) {
+                  var waiting = await waitForWaitingServiceWorker(registration);
+                  if (waiting) {
+                    await skipWaitingAndNavigateToShell(waiting);
+                    return;
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            // 修復失敗時仍嘗試導向 app shell
+          }
+
+          navigateToAppShell();
+        }
+
+        var retryBtn = document.getElementById('retry-btn');
+        if (retryBtn) {
+          retryBtn.addEventListener('click', function () {
+            void attemptOfflineShellSelfHeal(true);
+          });
+        }
+
+        window.addEventListener('online', function () {
+          void attemptOfflineShellSelfHeal(true);
+        });
+
+        void attemptOfflineShellSelfHeal(false);
+      })();
     </script>
   </body>
 </html>

--- a/apps/ratewise/src/pwa-offline.test.ts
+++ b/apps/ratewise/src/pwa-offline.test.ts
@@ -30,9 +30,21 @@ describe('PWA 離線功能測試', () => {
       const offlinePath = resolve(ROOT_PATH, 'public/offline.html');
       const content = readFileSync(offlinePath, 'utf-8');
 
-      // 應該有重試功能
-      expect(content).toContain('window.location.reload()');
+      // 重試按鈕應觸發 shell 自我修復，而非單純 reload（避免在線死亡迴圈）
+      expect(content).toContain('retry-btn');
+      expect(content).toContain('attemptOfflineShellSelfHeal');
       expect(content).toContain("window.addEventListener('online'");
+    });
+
+    it('should self-heal when online user lands on offline shell', () => {
+      const offlinePath = resolve(ROOT_PATH, 'public/offline.html');
+      const content = readFileSync(offlinePath, 'utf-8');
+
+      expect(content).toContain('rw-offline-shell-heal');
+      expect(content).toContain('CHECK_SHELL_PRECACHE');
+      expect(content).toContain("type: 'SKIP_WAITING'");
+      expect(content).toContain('navigateToAppShell');
+      expect(content).not.toContain('window.location.reload()');
     });
 
     it('should show cached data indicator', () => {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+84
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+85
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-06-28
+- ID：reward-offline-shell-self-heal-death-loop
+- 原因：在線用戶被壞 SW 誤服 offline.html 時 React/swHealth 未掛載，reload 仍回 offline.html 形成死亡迴圈
+- 解法：offline.html 內嵌 CHECK_SHELL_PRECACHE 探針 + SKIP_WAITING + 導向 app shell，打破無 React 的修復盲區
 
 - 日期：2026-06-28
 - ID：reward-sw-aggressive-propagation-broken-shell


### PR DESCRIPTION
## Summary

- **根因**：#505 的 `swHealth` 僅在 React `UpdatePrompt` 掛載後執行；在線用戶若被壞 SW 誤服 `offline.html`，永遠載入不了主 app → 修復邏輯無法觸發。既有 `reload()` / `online` 重載仍走同一 SW navigation → **死亡迴圈**。
- **正式站探測**（2026-06-28）：production SHA `c5f08b8`、API v2.25.10、live precache 全綠、`sw.js` 含 `CHECK_SHELL_PRECACHE` 與 `index.html` — 伺服器端正常，問題在 client 端舊/壞 SW 狀態。
- **修法**：在 `offline.html` 內嵌獨立自我修復腳本（無 React 依賴）：連網時 `CHECK_SHELL_PRECACHE` 探針 → 壞 SW 則 `update` + `SKIP_WAITING` → 導向 app shell；重試按鈕改為同一流程，移除 `reload()` 循環。

## Test plan

- [x] `vitest` pwa-offline / swHealth / sw.test（86 passed）
- [x] `pnpm typecheck`
- [x] `pnpm build:ratewise` — `dist/offline.html` 含自我修復腳本
- [ ] 合併發版後：手機在線開啟 `/ratewise/`，若曾卡離線頁應自動跳回主 app（或點「重新載入」一次即可）

## 手機驗證步驟（使用者）

1. 確認已更新至含此 PR 的版本（合併 release 後）
2. 在 Safari/Chrome 開啟 https://app.haotool.org/ratewise/
3. 若仍見「網路連線中斷 / 您目前處於離線狀態」但 Wi‑Fi/行動數據正常：
   - 等待 1–2 秒（自動修復）
   - 或點「重新載入」
4. 預期：跳轉至正常匯率首頁（非 offline.html）
5. 若仍失敗：設定 → 清除網站資料 → 重新開啟（最後手段）


Made with [Cursor](https://cursor.com)