### PR TITLE
fix(ratewise): manifest 網域改由 VITE_SITE_URL 環境驅動

### DIFF
--- a/.changeset/manifest-site-url-env.md
+++ b/.changeset/manifest-site-url-env.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+staging 等替代網域安裝 PWA 時 manifest scope 不再指向正式站：scope/start_url 改由 VITE_SITE_URL 環境變數驅動（含 trailing-slash 正規化），未設定時輸出與正式站完全相同。

--- a/apps/ratewise/scripts/generate-manifest.mjs
+++ b/apps/ratewise/scripts/generate-manifest.mjs
@@ -30,6 +30,16 @@ const currencyCount = [...constantsContent.matchAll(/^\s+([A-Z]{3}):\s*\{/gm)].l
 
 const versioned = (path) => `${path}?v=${VERSION_TOKEN}`;
 
+// scope/start_url 以 VITE_SITE_URL 環境變數驅動（與 seo-metadata canonical 同一 SSOT），
+// 未設定時回退正式站 APP_INFO.siteUrl；staging 等替代網域部署設定該變數即可，禁止硬編網域。
+// 正規化行為對齊 seo-paths.ts 的 normalizeSiteUrl（trim＋補尾斜線）；無法直接 import 複用：
+// seo-paths.ts 內部以無副檔名路徑 import './app-info'，Node Type Stripping 不解析副檔名。
+function normalizeSiteUrl(value) {
+  const trimmed = value.trim();
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+const siteUrl = normalizeSiteUrl(process.env.VITE_SITE_URL || APP_INFO.siteUrl);
+
 const manifest = {
   name: APP_INFO.name,
   short_name: APP_MANIFEST.shortName,
@@ -39,8 +49,8 @@ const manifest = {
   display: 'standalone',
   // 絕對 HTTPS scope/start_url：避免獨立 PWA partition + Chrome HTTPS-First 在啟動時以 http 語意解析。
   // id 維持相對（id 變更會被視為新 PWA 身分，破壞既有安裝更新連續性）。
-  scope: APP_INFO.siteUrl,
-  start_url: APP_INFO.siteUrl,
+  scope: siteUrl,
+  start_url: siteUrl,
   id: '/ratewise/',
   orientation: 'portrait-primary',
   categories: ['finance', 'utilities', 'productivity'],

--- a/apps/ratewise/src/config/__tests__/build-scripts.test.ts
+++ b/apps/ratewise/src/config/__tests__/build-scripts.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { APP_INFO } from '../app-info';
 
 async function readPackageJson() {
   const packageJsonPath = path.resolve(__dirname, '../../../package.json');
@@ -270,11 +271,19 @@ describe('ratewise build scripts', () => {
       start_url: string;
     };
 
-    expect(manifestGenerator).toContain('scope: APP_INFO.siteUrl');
-    expect(manifestGenerator).toContain('start_url: APP_INFO.siteUrl');
+    // scope/start_url 由 VITE_SITE_URL 環境變數驅動（staging 等替代網域），未設定時回退正式站 SSOT，
+    // 正規化必須複用 seo-paths 的 normalizeSiteUrl 避免行為分歧。
+    expect(manifestGenerator).toContain(
+      'normalizeSiteUrl(process.env.VITE_SITE_URL || APP_INFO.siteUrl)',
+    );
+    expect(manifestGenerator).toContain('scope: siteUrl');
+    expect(manifestGenerator).toContain('start_url: siteUrl');
     expect(manifest.scope).toMatch(/^https:\/\//);
     expect(manifest.start_url).toMatch(/^https:\/\//);
     expect(manifest.scope).toBe(manifest.start_url);
+    // committed manifest 必為正式站：堵住 env 污染下（VITE_SITE_URL 指向 staging）
+    // 重新生成並誤 commit staging URL 仍全綠的缺口。
+    expect(manifest.scope).toBe(APP_INFO.siteUrl);
   });
 
   it('should not force React ecosystem packages into manual chunks', async () => {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+2（reward 2、penalty 0、neutral 1）｜累計總分：+149
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+150
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-06
+- ID：reward-rw-602-manifest-site-url-env
+- 原因：generate-manifest 的 scope/start_url 硬編 APP_INFO.siteUrl（app.haotool.org），staging 等替代網域部署時 manifest scope 跨網域、PWA 安裝行為異常（#602；字體 @font-face 被 Beasties 修剪部分經 PM 裁決移交 #616 處理）
+- 解法：scope/start_url 改由 VITE_SITE_URL 環境變數驅動＋normalizeSiteUrl 正規化（行為對齊 seo-paths；直接 import 因該檔無副檔名 import 在 Node Type Stripping 下 ERR_MODULE_NOT_FOUND，以註解標明），未設定時回退正式站；committed manifest 補「必為正式站」JSON 斷言堵 env 污染誤 commit，generate:deterministic 冪等零 diff 實證
 
 - 日期：2026-07-06
 - ID：reward-rw-600-anchor-scroll-mt-safe-area


### PR DESCRIPTION
Closes #602

> PM 二次裁決收斂：safe-area 主修由 #605 處理（已併入 base `89394045`）、字體 @font-face 被 Beasties 修剪部分移交 **#616**（@font-face 歸位 index.css＋`inlineFonts:true` 方案）。本 PR 最終範圍只保留 **manifest 的 VITE_SITE_URL 環境驅動**。

## Summary

`generate-manifest.mjs` 的 `scope`／`start_url` 改由 `VITE_SITE_URL` 環境變數驅動（與 `seo-metadata` canonical 同一 SSOT），含 trailing-slash 正規化；未設定時回退 `APP_INFO.siteUrl`——**預設輸出與 committed manifest 零 diff（已實證，見下）**。staging 部署只需設 `VITE_SITE_URL=https://ratewise-staging.zeabur.app/ratewise/`，不硬編任何 staging 網域；`id` 維持 `/ratewise/` 不破壞既有安裝更新連續性。

## 根因 vet（file:line）

- `apps/ratewise/scripts/generate-manifest.mjs:42-43`（修改前）：`scope`/`start_url` 硬編 `APP_INFO.siteUrl`（`https://app.haotool.org/ratewise/`），staging 網域安裝 PWA 時 manifest scope 跨網域、安裝行為異常。

## 驗證證據

- **冪等＋零 diff**：`pnpm --filter @app/ratewise generate:deterministic` 連跑兩次，`git diff apps/ratewise/public/manifest.webmanifest` 均為 0 行（無 env 時輸出不變的宣稱已實證）
- **env 驅動＋正規化**：`VITE_SITE_URL=https://ratewise-staging.zeabur.app/ratewise`（刻意不帶 trailing slash）→ 輸出 `scope`/`start_url` 均為 `https://ratewise-staging.zeabur.app/ratewise/`
- **verify:artifacts**：通過（31 images across 6 apps）

## 閘門

- `pnpm vitest run`：176 檔 3323 passed（含 build-scripts manifest SSOT 斷言更新）
- `pnpm typecheck`：全 workspace 通過
- `pnpm build:ratewise`：成功

## Test plan

- [x] manifest 預設輸出零 diff（generate:deterministic 冪等連跑兩次）
- [x] env 驅動生效＋trailing-slash 正規化
- [x] verify:artifacts／vitest／typecheck／build 全綠
- [ ] staging 部署更新後實機複驗：manifest scope 同域、PWA 可正常安裝