### PR TITLE
fix(ratewise): 內容頁錨點 safe-area 連動與修復 @font-face 被 Beasties 剝除

### DIFF
--- a/.changeset/content-anchor-fontface.md
+++ b/.changeset/content-anchor-fontface.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復 PWA standalone 下內容頁頁內錨點跳轉（隱私頁目錄、使用指南步驟）被變高的返回列遮蔽的問題；修復品牌標準字體在正式站永遠未載入（全站 unused preload 警告、頁首 wordmark 回落系統字體）的問題。

--- a/apps/ratewise/index.html
+++ b/apps/ratewise/index.html
@@ -140,15 +140,8 @@
         line-height: 1.6;
         -webkit-text-size-adjust: 100%;
       }
-      /* 品牌標準字（showcase-twincoins SSOT）：Nunito 900 子集，僅含 HaoRate 六個字符。 */
-      @font-face {
-        font-family: 'Nunito Wordmark';
-        font-style: normal;
-        font-weight: 900;
-        font-display: swap;
-        src: url('__BASE_PATH__fonts/nunito-wordmark-900.woff2') format('woff2');
-        unicode-range: U+0048, U+0052, U+0061, U+0065, U+006F, U+0074;
-      }
+      /* 品牌標準字 @font-face 移至 src/index.css（與 .brand-wordmark 同 sheet）：
+         Beasties 逐 sheet 判定 critical fonts，內嵌 sheet 無使用者會整條剝除 @font-face。 */
       /* Theme-aware skeleton variables
        * Maps to user's selected theme for seamless loading experience
        * @see index.css - theme color definitions

--- a/apps/ratewise/src/components/content/ContentSections.tsx
+++ b/apps/ratewise/src/components/content/ContentSections.tsx
@@ -77,7 +77,7 @@ export function ContentSectionCard({
   return (
     <section
       id={id}
-      className="rounded-card border border-border/60 bg-surface shadow-card p-5 scroll-mt-20"
+      className="rounded-card border border-border/60 bg-surface shadow-card p-5 scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))]"
     >
       {title && <h2 className="mb-4 text-xl font-bold leading-tight text-text">{title}</h2>}
       {children}
@@ -175,7 +175,7 @@ function renderSection(section: ContentSection) {
       );
     case 'faq':
       return (
-        <section id={section.id} className="scroll-mt-20">
+        <section id={section.id} className="scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))]">
           {section.title && (
             <h2 className="mb-4 text-xl font-bold leading-tight text-text">{section.title}</h2>
           )}

--- a/apps/ratewise/src/components/content/__tests__/ContentPageLayout.test.tsx
+++ b/apps/ratewise/src/components/content/__tests__/ContentPageLayout.test.tsx
@@ -46,6 +46,20 @@ describe('ContentPageLayout', () => {
     const container = screen.getByTestId('content-page').firstElementChild;
     expect(container?.className).toContain('pb-24');
   });
+
+  // sticky 返回列 safe-area 適配由 PageNavHeader.safe-area.test.tsx（#605）守門；
+  // 此處守門錨點連動：sticky 列在 standalone 下變高，錨點目標 scroll-margin 必須同步吃 safe-area（#600）。
+  it('錨點 section 的 scroll-margin-top 疊加 safe-area-inset-top', () => {
+    render(
+      <BrowserRouter>
+        <ContentSections
+          sections={[{ kind: 'text', id: 'anchor-a', title: '錨點區', paragraphs: ['內容'] }]}
+        />
+      </BrowserRouter>,
+    );
+    const section = document.getElementById('anchor-a');
+    expect(section?.className).toContain('scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))]');
+  });
 });
 
 describe('ContentSections', () => {

--- a/apps/ratewise/src/index.css
+++ b/apps/ratewise/src/index.css
@@ -21,8 +21,19 @@
 /* ========================================
    品牌標準字 Wordmark（SSOT: scripts/source-images/brand/showcase-twincoins.html）
    Nunito 900、字距 -0.02em；「Rate」使用主題主色。
-   @font-face 定義於 index.html critical CSS（__BASE_PATH__ SSOT 替換）。
    ======================================== */
+/* 品牌標準字子集（Nunito 900，僅 wordmark 六字符，1.2KB）。
+   必須與 .brand-wordmark 同 sheet：Beasties 逐 sheet 判定 critical fonts，
+   放在 index.html 內嵌樣式會於 SSG 階段被整條剝除（unused preload 根因）。 */
+@font-face {
+  font-family: 'Nunito Wordmark';
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: url('/fonts/nunito-wordmark-900.woff2') format('woff2');
+  unicode-range: U+0048, U+0052, U+0061, U+0065, U+006F, U+0074;
+}
+
 .brand-wordmark {
   font-family:
     'Nunito Wordmark',

--- a/apps/ratewise/src/index.html.test.ts
+++ b/apps/ratewise/src/index.html.test.ts
@@ -120,11 +120,17 @@ describe('index.html - Static Template (SEOHelmet Architecture)', () => {
       expect(indexHtmlContent).toContain('<link rel="icon"');
     });
 
-    it('should preload and define the brand wordmark font subset with base path SSOT', () => {
-      // 品牌標準字（Nunito 900 子集）：preload + @font-face 均須走 __BASE_PATH__ 佔位符。
+    it('should preload the brand wordmark font subset with base path SSOT', () => {
+      // 品牌標準字（Nunito 900 子集）：preload 走 __BASE_PATH__ 佔位符。
+      // @font-face 必須在 src/index.css（與 .brand-wordmark 同 sheet），
+      // 否則 Beasties 逐 sheet 判定 critical fonts 時會整條剝除（unused preload 根因）。
       expect(indexHtmlContent).toContain('__BASE_PATH__fonts/nunito-wordmark-900.woff2');
-      expect(indexHtmlContent).toContain("font-family: 'Nunito Wordmark'");
-      expect(indexHtmlContent).toContain('font-display: swap');
+      expect(indexHtmlContent).not.toMatch(/@font-face\s*\{/);
+
+      const indexCssContent = readFileSync(resolve(__dirname, 'index.css'), 'utf-8');
+      expect(indexCssContent).toContain("font-family: 'Nunito Wordmark'");
+      expect(indexCssContent).toContain('font-display: swap');
+      expect(indexCssContent).toContain("url('/fonts/nunito-wordmark-900.woff2')");
     });
 
     it('should retain PWA manifest hints', () => {

--- a/apps/ratewise/src/pages/Guide.tsx
+++ b/apps/ratewise/src/pages/Guide.tsx
@@ -160,7 +160,7 @@ const Guide = () => {
               <section
                 key={step.position}
                 id={`step-${step.position}`}
-                className="scroll-mt-20 rounded-card border border-border/60 bg-surface p-5 shadow-card"
+                className="scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))] rounded-card border border-border/60 bg-surface p-5 shadow-card"
               >
                 <div className="flex items-start gap-4">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-strong text-lg font-bold text-white">

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -503,6 +503,13 @@ export default defineConfig(({ mode }) => {
       script: 'async',
       formatting: 'beautify',
       dirStyle: 'nested',
+      // Beasties 預設 inlineFonts:false 會剝除 index.html inline @font-face 並注入重複
+      // font preload，導致品牌字體永遠未被使用（unused preload console warning）。
+      // inlineFonts:true 保留 @font-face；preloadFonts:false 交由 index.html 靜態 preload SSOT。
+      beastiesOptions: {
+        inlineFonts: true,
+        preloadFonts: false,
+      },
       // vite-react-ssg + Beasties may read freshly rendered nested amount pages during
       // writeout. Serial rendering avoids intermittent ENOENT on CI/pre-push.
       concurrency: 1,

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+147
+> 本次分數變化：+2（reward 2、penalty 0、neutral 1）｜累計總分：+149
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,21 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-06
+- ID：reward-rw-600-anchor-scroll-mt-safe-area
+- 原因：#605 修了 sticky 返回列 safe-area 但錨點目標 `scroll-mt-20` 固定 80px 未連動，standalone 下 sticky 列變高（+59px）後隱私目錄與 Guide 步驟跳轉被遮蔽（#600 連動項）
+- 解法：三處錨點（Privacy 目錄、Guide 步驟、ContentSections）改 `scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))]`，CDP inset 59px 實測 targetTop 139 > headerBottom 124，補 ContentPageLayout 錨點斷言
+
+- 日期：2026-07-06
+- ID：reward-rw-font-preload-beasties-fontface-strip
+- 原因：品牌字體 @font-face 放 index.html 內嵌樣式，Beasties 逐 sheet 判定 critical fonts 時因該 sheet 無使用者而整條剝除，全站 unused preload 警告且 wordmark 永遠回落系統字體（正式站取證：HTML 無任何 @font-face）
+- 解法：@font-face 移至 src/index.css（與 .brand-wordmark 同 sheet）＋ ssgOptions.beastiesOptions 設 inlineFonts:true／preloadFonts:false，preview 驗證警告歸零、document.fonts.check 為 true、preload 單一化
+
+- 日期：2026-07-06
+- ID：neutral-rw-612-staging-manifest-cross-origin
+- 原因：staging manifest `scope`/`start_url` 由 generate-manifest.mjs 以 APP_INFO.siteUrl 硬編正式站絕對 URL，對 staging origin 跨網域；屬刻意設計（PWA partition／HTTPS-First）連動 SSOT 生成鏈
+- 解法：取證後立案 #612（附 curl 證據與範圍）不硬修；React #418 staging 複驗無殘留（#595 已修）
 
 - 日期：2026-07-06
 - ID：reward-rw-e5b-currency-page-uiux-six-section-ia


### PR DESCRIPTION
Refs #600（safe-area 主修已由 #605 完成並併入 base；本 PR 保留 #600 的兩件獨有價值）

## 摘要

- **錨點 scroll-mt 連動（#605 未涵蓋）**：sticky 返回列在 PWA standalone 下因 safe-area 變高（+59px），錨點目標的 `scroll-mt-20`（固定 80px）不足，隱私頁目錄與使用指南步驟跳轉後被返回列遮蔽。三處（Privacy 目錄、Guide 步驟、`ContentSections`）改 `scroll-mt-[calc(5rem+env(safe-area-inset-top,0px))]`。
- **字體根因修復（PM 裁定採本方案）**：品牌字體 `@font-face` 原在 `index.html` 內嵌樣式，Beasties 逐 sheet 判定 critical fonts 時因該 sheet 無使用者而整條剝除並注入重複 preload → 全站「unused preload」console warning、頁首 wordmark 永遠回落系統字體（正式站取證：HTML 無任何 `@font-face`）。修法：`@font-face` 移至 `src/index.css`（與 `.brand-wordmark` 同 sheet）＋ `ssgOptions.beastiesOptions = { inlineFonts: true, preloadFonts: false }`。#613 縮窄為 manifest 專用，不再碰字體。

## 錨點跳轉量測（CDP inset top 59px、390×844、build preview）

| 頁面 | 錨點 | targetTop | headerBottom | 不被遮蔽 |
| --- | --- | --- | --- | --- |
| /privacy/ | `#overview` | 139 | 124 | ✅ |
| /guide/ | `#step-1` | 139.25 | 124 | ✅ |

（修復前 `scroll-mt-20` 僅預留 80px，sticky 列實高 124px，target 會被壓在列下。）

## 字體前後證據

**修復前（正式站/staging 取證）**：
- HTML 經 Beasties 處理後無任何 `@font-face`（剝除）；同時被注入第二個 font preload
- 全站 console：`The resource ...nunito-wordmark-900.woff2 was preloaded using link preload but not used within a few seconds...`
- wordmark 一直以 fallback 系統字體渲染

**修復後（build dist + preview 驗證）**：
- dist HTML critical CSS 與外部 CSS 均保留 `@font-face`（URL 帶 base：`/ratewise/fonts/nunito-wordmark-900.woff2`）
- preload 單一化（`preloadCount === 1`），字體請求 200
- `document.fonts.check('900 16px "Nunito Wordmark"') === true`（首頁與 FAQ 頁）
- preload/React 警告歸零

## 與 #605 的分工

- sticky 返回列 `pt-[calc(0.625rem+env(safe-area-inset-top,0px))]` 與 8 條守門測試：**由 #605 完成**（已在 base，本 PR 零重複 hunk）
- 本 PR 的 `ContentPageLayout.test` 僅保留錨點連動斷言，sticky 列斷言註記由 `PageNavHeader.safe-area.test.tsx` 守門

## 附帶取證（沿用先前調查）

- staging manifest 跨網域：已立案 #612（`scope`/`start_url` 硬編正式站 URL，牽動 SSOT 生成鏈不硬修）
- React #418：staging（v2.27.1，含 #595）複驗無殘留

## 審查收斂（APPROVE 後）

- Should-fix（dist 層字體守門：build 產物斷言 `@font-face` 存活與 preload 單一化）：已由 PM 立案 **#621** 後續處理，不在本 PR 範圍
- Nit：`src/index.css` 過期註解「@font-face 定義於 index.html critical CSS」已刪除（與新現況矛盾）
- 已 rebase 至 base `5b8c9b24`（#615），002 檔頭累計以 base +2 重算為 +149

## 閘門

- `pnpm --filter @app/ratewise test`：3324 passed / 2 skipped（含 #605 的 8 條 + 本 PR 錨點斷言）
- `pnpm typecheck`、`pnpm build:ratewise`：綠（rebase 後重跑）
- pre-commit 5 步驟與 pre-push（typecheck + test + build）通過
