### PR TITLE
fix(ratewise): 修復內容頁與 404 頁殘留的 React #418 hydration mismatch

### DIFF
--- a/.changeset/content-pages-hydration-418.md
+++ b/.changeset/content-pages-hydration-418.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+修復內容頁（FAQ／指南／幣別／金額頁）與 404 頁載入時 console 出現的 React #418 hydration 錯誤：頁尾建置時間固定以台北時區顯示，未預渲染路徑改走乾淨的 client render 不再對錯誤快照 hydrate。

--- a/apps/ratewise/src/config/__tests__/version.test.ts
+++ b/apps/ratewise/src/config/__tests__/version.test.ts
@@ -61,6 +61,25 @@ describe('version', () => {
       // 格式: YYYY/MM/DD HH:mm
       expect(formatted).toMatch(/\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}/);
     });
+
+    it('should format BUILD_TIME in Asia/Taipei regardless of runtime timezone (issue #459 #418)', () => {
+      // SSG（CI 為 UTC）與使用者瀏覽器（Asia/Taipei）必須產出同一字串，
+      // 否則 Footer 建置時間文字節點觸發 React #418；CI（UTC）會抓到 timeZone 遺失。
+      const buildDate = new Date(BUILD_TIME);
+      const expectedDate = buildDate.toLocaleDateString('zh-TW', {
+        timeZone: 'Asia/Taipei',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      });
+      const expectedTime = buildDate.toLocaleTimeString('zh-TW', {
+        timeZone: 'Asia/Taipei',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+      expect(getFormattedBuildTime()).toBe(`${expectedDate} ${expectedTime}`);
+    });
   });
 
   describe('getVersionInfo', () => {

--- a/apps/ratewise/src/config/version.ts
+++ b/apps/ratewise/src/config/version.ts
@@ -59,16 +59,20 @@ export function getFullVersion(): string {
 
 /**
  * 格式化建置時間
+ * timeZone 固定 Asia/Taipei：SSG（CI 為 UTC）與使用者瀏覽器必須產出同一字串，
+ * 否則 Footer 建置時間文字節點會觸發 React #418 hydration mismatch。
  * @returns 格式化的日期時間字串
  */
 export function getFormattedBuildTime(): string {
   const buildDate = new Date(BUILD_TIME);
   const date = buildDate.toLocaleDateString('zh-TW', {
+    timeZone: 'Asia/Taipei',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
   });
   const time = buildDate.toLocaleTimeString('zh-TW', {
+    timeZone: 'Asia/Taipei',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/apps/ratewise/src/main.tsx
+++ b/apps/ratewise/src/main.tsx
@@ -31,6 +31,7 @@ import {
   toError,
 } from './utils/errorClassification';
 import { initPWAStorageManager, primePwaColdStartRecovery } from './utils/pwaStorageManager';
+import { applySsgFallbackGuard } from './utils/ssgFallbackGuard';
 import {
   clearPwaAppReadyMarker,
   flushPwaDiagnosticAnalyticsQueue,
@@ -117,6 +118,10 @@ const resolveColdStartPrimeResult = async (
     };
   }
 };
+
+// SPA fallback 守門：快照路由 ≠ 當前 URL（404／SW shell fallback）時，
+// 於 hydration 前清空 root 改走 client render，避免結構性 React #418。
+applySsgFallbackGuard(import.meta.env.BASE_URL || '/');
 
 // Vite React SSG Configuration
 export const createRoot = ViteReactSSG(

--- a/apps/ratewise/src/prerender.test.ts
+++ b/apps/ratewise/src/prerender.test.ts
@@ -556,6 +556,48 @@ describe('Prerendering Static HTML Generation (SEOHelmet Architecture)', () => {
       expect(content).not.toContain('aria-label="Main Navigation"');
     });
 
+    it.each(['index.html', 'faq/index.html', 'guide/index.html', 'usd-twd/index.html'])(
+      '%s 必須含 ssg-route 標記供 SPA fallback 守門比對（issue #459 #418）',
+      (relPath) => {
+        const htmlPath = resolve(distPath, relPath);
+        expect(existsSync(htmlPath)).toBe(true);
+
+        const content = readFileSync(htmlPath, 'utf-8');
+        const markerMatch = /<meta[^>]*name="ssg-route"[^>]*content="([^"]*)"/.exec(content);
+        expect(markerMatch).toBeTruthy();
+
+        const expectedRoute =
+          relPath === 'index.html' ? '/' : `/${relPath.replace('index.html', '')}`;
+        expect(markerMatch?.[1]).toBe(expectedRoute);
+      },
+    );
+
+    it('內容頁 Footer 建置時間必須以 Asia/Taipei 格式化，與 build 機器時區無關（issue #459 #418）', () => {
+      // CI（UTC）build 產出的 SSG 文字若隨 build 機器時區漂移，
+      // 使用者瀏覽器（Asia/Taipei）client 首屏就會 mismatch 觸發 React #418。
+      const faqHtml = resolve(distPath, 'faq/index.html');
+      expect(existsSync(faqHtml)).toBe(true);
+
+      const content = readFileSync(faqHtml, 'utf-8');
+      const buildTimeMatch = /<meta[^>]*name="build-time"[^>]*content="([^"]*)"/.exec(content);
+      expect(buildTimeMatch?.[1]).toBeTruthy();
+
+      const buildDate = new Date(buildTimeMatch?.[1] ?? '');
+      const expectedDate = buildDate.toLocaleDateString('zh-TW', {
+        timeZone: 'Asia/Taipei',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      });
+      const expectedTime = buildDate.toLocaleTimeString('zh-TW', {
+        timeZone: 'Asia/Taipei',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+      expect(content).toContain(`Built on ${expectedDate} ${expectedTime}`);
+    });
+
     it('All pages should have lang="zh-TW" attribute', () => {
       const pages = [
         resolve(distPath, 'index.html'),

--- a/apps/ratewise/src/utils/__tests__/ssgFallbackGuard.test.ts
+++ b/apps/ratewise/src/utils/__tests__/ssgFallbackGuard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * ssgFallbackGuard 測試
+ *
+ * 驗證 SPA fallback 快照（快照路由 ≠ 當前 URL）在 hydration 前被降級為 client render，
+ * 而正確路由的快照維持 hydrate（issue #459 404／fallback React #418）。
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { isStaleSsgSnapshot, applySsgFallbackGuard } from '../ssgFallbackGuard';
+
+function setupDom({
+  marker,
+  serverRendered = true,
+}: {
+  marker: string | null;
+  serverRendered?: boolean;
+}) {
+  document.head.innerHTML = marker ? `<meta name="ssg-route" content="${marker}">` : '';
+  document.body.innerHTML = `<div id="root"${serverRendered ? ' data-server-rendered="true"' : ''}><main>ssg content</main></div>`;
+}
+
+afterEach(() => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+});
+
+describe('isStaleSsgSnapshot', () => {
+  it('路由相符（含 base 與尾斜線正規化）不判定 stale', () => {
+    expect(isStaleSsgSnapshot('/faq/', '/ratewise/faq/', '/ratewise/')).toBe(false);
+    expect(isStaleSsgSnapshot('/faq', '/ratewise/faq/', '/ratewise/')).toBe(false);
+    expect(isStaleSsgSnapshot('/', '/ratewise/', '/ratewise/')).toBe(false);
+    expect(isStaleSsgSnapshot('/usd-twd/100/', '/ratewise/usd-twd/100/', '/ratewise/')).toBe(false);
+  });
+
+  it('首頁快照被送到未知路徑（404 SPA fallback）判定 stale', () => {
+    expect(isStaleSsgSnapshot('/', '/ratewise/definitely-not-a-page/', '/ratewise/')).toBe(true);
+  });
+
+  it('首頁快照被送到無尾斜線的既有路由（host fallback）判定 stale', () => {
+    expect(isStaleSsgSnapshot('/', '/ratewise/multi', '/ratewise/')).toBe(true);
+  });
+
+  it('無標記（舊快取 HTML）採保守策略不介入', () => {
+    expect(isStaleSsgSnapshot(null, '/ratewise/anything/', '/ratewise/')).toBe(false);
+    expect(isStaleSsgSnapshot(undefined, '/ratewise/anything/', '/ratewise/')).toBe(false);
+  });
+
+  it('base 為根路徑時仍可正確比對', () => {
+    expect(isStaleSsgSnapshot('/faq/', '/faq/', '/')).toBe(false);
+    expect(isStaleSsgSnapshot('/', '/unknown/', '/')).toBe(true);
+  });
+});
+
+describe('applySsgFallbackGuard', () => {
+  it('stale 快照：清空 root 並移除 data-server-rendered（改走 client render）', () => {
+    setupDom({ marker: '/' });
+    window.history.replaceState(null, '', '/ratewise/definitely-not-a-page/');
+
+    const applied = applySsgFallbackGuard('/ratewise/');
+
+    expect(applied).toBe(true);
+    const root = document.getElementById('root');
+    expect(root?.hasAttribute('data-server-rendered')).toBe(false);
+    expect(root?.childNodes.length).toBe(0);
+  });
+
+  it('路由相符：保留 SSG 內容與 data-server-rendered（維持 hydrate）', () => {
+    setupDom({ marker: '/faq/' });
+    window.history.replaceState(null, '', '/ratewise/faq/');
+
+    const applied = applySsgFallbackGuard('/ratewise/');
+
+    expect(applied).toBe(false);
+    const root = document.getElementById('root');
+    expect(root?.getAttribute('data-server-rendered')).toBe('true');
+    expect(root?.textContent).toContain('ssg content');
+  });
+
+  it('無標記：不介入', () => {
+    setupDom({ marker: null });
+    window.history.replaceState(null, '', '/ratewise/definitely-not-a-page/');
+
+    expect(applySsgFallbackGuard('/ratewise/')).toBe(false);
+    expect(document.getElementById('root')?.getAttribute('data-server-rendered')).toBe('true');
+  });
+});

--- a/apps/ratewise/src/utils/ssgFallbackGuard.ts
+++ b/apps/ratewise/src/utils/ssgFallbackGuard.ts
@@ -1,0 +1,56 @@
+/**
+ * SSG SPA fallback 守門
+ *
+ * 靜態主機（或 SW navigation fallback）對未預渲染路徑回傳「其他路由的 SSG 快照」
+ * （通常是首頁 index.html）時，快照帶有 data-server-rendered=true，
+ * vite-react-ssg 會對不相符的 DOM 樹 hydrate，必然觸發 React #418。
+ * 本守門在 hydration 前比對快照路由標記（meta[name="ssg-route"]，由
+ * vite.config.ts onBeforePageRender 注入）與當前 URL：不相符即清空 root 並移除
+ * data-server-rendered，讓 client 改走乾淨的 render()（vite-react-ssg PR #90 行為）。
+ *
+ * @see https://github.com/Daydreamer-riri/vite-react-ssg/pull/90
+ */
+
+/** 正規化路徑供比對：小寫＋前後斜線齊一。 */
+function normalizePath(path: string): string {
+  let value = path.trim().toLowerCase();
+  if (!value.startsWith('/')) value = `/${value}`;
+  if (!value.endsWith('/')) value = `${value}/`;
+  return value;
+}
+
+/** 判斷快照路由是否與當前路徑不符（即 SPA fallback 送錯快照）。 */
+export function isStaleSsgSnapshot(
+  markerRoute: string | null | undefined,
+  pathname: string,
+  baseUrl: string,
+): boolean {
+  // 無標記（舊快取 HTML）採保守策略：不介入，維持既有 hydrate 行為。
+  if (!markerRoute) return false;
+
+  const base = normalizePath(baseUrl || '/');
+  let routePath = normalizePath(pathname);
+  if (base !== '/' && routePath.startsWith(base)) {
+    routePath = normalizePath(routePath.slice(base.length - 1));
+  }
+  return normalizePath(markerRoute) !== routePath;
+}
+
+/**
+ * 在 hydration 前套用守門：偵測到 stale 快照時清空 root 改走 client render。
+ * 必須於 ViteReactSSG 啟動前（main.tsx 模組層）同步執行。
+ */
+export function applySsgFallbackGuard(baseUrl: string): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+
+  const marker = document.querySelector('meta[name="ssg-route"]')?.getAttribute('content');
+
+  if (!isStaleSsgSnapshot(marker, window.location.pathname, baseUrl)) return false;
+
+  const root = document.querySelector('[data-server-rendered=true]');
+  if (!root) return false;
+
+  root.removeAttribute('data-server-rendered');
+  root.replaceChildren();
+  return true;
+}

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -532,8 +532,15 @@ export default defineConfig(({ mode }) => {
 
         return PRERENDER_PATHS;
       },
-      // 預渲染前處理 HTML：金額路由注入換算結果
+      // 預渲染前處理 HTML：注入 SSG 路由標記＋金額路由換算結果
       async onBeforePageRender(route, indexHTML) {
+        // SSG 路由標記：client 端 ssgFallbackGuard 據此判斷「快照路由 ≠ 當前 URL」
+        // 的 SPA fallback 情境（404、SW shell fallback），改走 client render 避免 React #418。
+        indexHTML = indexHTML.replace(
+          '</head>',
+          `<meta name="ssg-route" content="${route}"></head>`,
+        );
+
         // 檢查是否為金額路由（例如：/usd-twd/500/）
         const amountRouteMatch = route.match(/\/([a-z]{3})-([a-z]{3})\/(\d+(?:\.\d+)?)\/$/i);
         if (amountRouteMatch) {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+152
+> 本次分數變化：0（reward 1、penalty 1、neutral 0）｜累計總分：+152
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,16 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-06
+- ID：penalty-rw-459-595-tz-blind-spot
+- 原因：#595 驗證只在本地同時區（build 與瀏覽器皆 Asia/Taipei）抽測，未覆蓋 staging「UTC build × 台北瀏覽器」情境，漏掉 Footer 建置時間 toLocale 無 timeZone 造成內容頁全數 #418
+- 解法：本地以 TZ=UTC build＋Asia/Taipei 瀏覽器重演 staging 差異定位根因；此後 hydration 修復驗證必須含跨時區組合（build TZ ≠ browser TZ）
+
+- 日期：2026-07-06
+- ID：reward-rw-459-content-pages-418
+- 原因：內容頁 Footer `getFormattedBuildTime()` 無 timeZone 隨 build 機器時區漂移（args[]=text）；404／SPA fallback 送首頁快照帶 data-server-rendered，vite-react-ssg 0.8.9 production 一律 hydrate（args[]=HTML）
+- 解法：建置時間固定 Asia/Taipei；SSG 注入 ssg-route 標記＋client 守門偵測 stale 快照改走 render＋patch vite-react-ssg（上游已 merge 未發版的 PR #90）；11 路由雙時區停 SW 巡檢 #418 歸零＋prerender 守門測試
 
 - 日期：2026-07-06
 - ID：penalty-rw-587-keyboard-modifier-passthrough

--- a/package.json
+++ b/package.json
@@ -168,6 +168,9 @@
       "yaml@>=2.0.0 <2.8.3": "2.8.3",
       "smol-toml@<1.6.1": "1.6.1",
       "@vitest/coverage-v8": "4.1.5"
+    },
+    "patchedDependencies": {
+      "vite-react-ssg@0.8.9": "patches/vite-react-ssg@0.8.9.patch"
     }
   }
 }

--- a/patches/vite-react-ssg@0.8.9.patch
+++ b/patches/vite-react-ssg@0.8.9.patch
@@ -1,0 +1,39 @@
+diff --git a/dist/client/single-page.mjs b/dist/client/single-page.mjs
+index 8a1d522..e1712a4 100644
+--- a/dist/client/single-page.mjs
++++ b/dist/client/single-page.mjs
+@@ -60,7 +60,7 @@ function ViteReactSSG(App, fn, options = {}) {
+       window.__VITE_REACT_SSG_CONTEXT__ = context;
+       const app = /* @__PURE__ */ jsx(HelmetProvider, { children: App });
+       const isSSR = document.querySelector("[data-server-rendered=true]") !== null;
+-      if (!isSSR && process.env.NODE_ENV === "development") {
++      if (!isSSR) {
+         render(app, container, options);
+       } else {
+         hydrate(app, container, options);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 6a969ba..bb5fb38 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -144,7 +144,7 @@ function ViteReactSSG(routerOptions, fn, options = {}) {
+       const { router } = context;
+       const app = /* @__PURE__ */ jsx(HelmetProvider, { children: /* @__PURE__ */ jsx(RouterProvider, { router, future: { v7_startTransition } }) });
+       const isSSR = document.querySelector("[data-server-rendered=true]") !== null;
+-      if (!isSSR && process.env.NODE_ENV === "development") {
++      if (!isSSR) {
+         render(app, container, options);
+       } else {
+         hydrate(app, container, options);
+diff --git a/dist/tanstack.mjs b/dist/tanstack.mjs
+index 6ec0430..2806a14 100644
+--- a/dist/tanstack.mjs
++++ b/dist/tanstack.mjs
+@@ -122,7 +122,7 @@ function Experimental_ViteReactSSG(routerOptions, fn, options = {}) {
+       window.__VITE_REACT_SSG_CONTEXT__ = context;
+       const { router } = context;
+       const isSSR = document.querySelector("[data-server-rendered=true]") !== null;
+-      if (!isSSR && process.env.NODE_ENV === "development") {
++      if (!isSSR) {
+         render(
+           /* @__PURE__ */ jsx(HelmetProvider, { children: /* @__PURE__ */ jsx(RouterProvider, { router }) }),
+           container,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,11 @@ overrides:
   smol-toml@<1.6.1: 1.6.1
   '@vitest/coverage-v8': 4.1.5
 
+patchedDependencies:
+  vite-react-ssg@0.8.9:
+    hash: tvkzfhyqpbwntatr2jnxgcpena
+    path: patches/vite-react-ssg@0.8.9.patch
+
 importers:
 
   .:
@@ -203,7 +208,7 @@ importers:
         version: 1.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
@@ -285,7 +290,7 @@ importers:
         version: 1.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3))
+        version: 0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3))
@@ -385,7 +390,7 @@ importers:
         version: 1.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
@@ -482,7 +487,7 @@ importers:
         version: 1.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
@@ -618,7 +623,7 @@ importers:
         version: 1.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-react-ssg:
         specifier: ^0.8.9
-        version: 0.8.9(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
@@ -18530,7 +18535,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-react-ssg@0.8.9(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
+  vite-react-ssg@0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       fs-extra: 11.3.2
       html5parser: 2.0.2
@@ -18552,7 +18557,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  vite-react-ssg@0.8.9(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3)):
+  vite-react-ssg@0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       fs-extra: 11.3.2
       html5parser: 2.0.2
@@ -18574,7 +18579,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  vite-react-ssg@0.8.9(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
+  vite-react-ssg@0.8.9(patch_hash=tvkzfhyqpbwntatr2jnxgcpena)(beasties@0.4.2)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react-router-dom@6.30.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       fs-extra: 11.3.2
       html5parser: 2.0.2


### PR DESCRIPTION
## Summary

staging 驗證（#459 comment、`.claude/product-intel/qa-staging-report.md` P1-2）發現 #595 部署後 app 殼層四頁已乾淨，但**內容頁（/faq/、/guide/、/usd-twd/、/sell-rate-vs-mid-rate/、/usd-twd/100/）每次載入仍拋 `#418 args[]=text`，404 頁拋 `args[]=HTML`**。本 PR 定位並修復兩個獨立根因。

### 根因 A｜內容頁 `args[]=text`：建置時間格式化隨時區漂移

`apps/ratewise/src/config/version.ts` 的 `getFormattedBuildTime()` 用 `toLocaleDateString('zh-TW')`／`toLocaleTimeString('zh-TW')` **未指定 `timeZone`**。staging/CI 在 UTC build → SSG HTML 寫入 `Built on 2026/07/05 19:27`；使用者瀏覽器在 Asia/Taipei → client 算出 `2026/07/06 03:27` → Footer tooltip 文字節點 mismatch。只有掛 `Layout`（含 Footer）的內容頁中招；app 殼層走 `AppLayout` 無 Footer，所以 #595 後看似「殼層已修、內容頁沒修」——實為另一獨立根因。

**為何 #595 驗證沒抓到（誠實檢討）**：#595 本地驗證 build 與瀏覽器同在 Asia/Taipei，兩側格式化結果相同、必然通過——是**驗證方法盲點（缺跨時區組合）**，不是路由集合漏抽。本次以 `TZ=UTC pnpm build` × 台北時區瀏覽器在本地完整重演 staging 現象後定位。

**修法**：`getFormattedBuildTime()` 兩處格式化固定 `timeZone: 'Asia/Taipei'`。

### 根因 B｜404 頁 `args[]=HTML`：SPA fallback 送首頁快照仍被 hydrate

未知路徑經 SW navigation fallback（或任何 `/* → index.html` 主機）拿到**首頁 SSG 快照**（帶 `data-server-rendered=true`），client 端渲染 NotFound 樹 → 結構性 mismatch。vite-react-ssg 0.8.9 production 因 `NODE_ENV` gate **一律 hydrate**；上游已在 [PR #90](https://github.com/Daydreamer-riri/vite-react-ssg/pull/90) merge 修正（`!isSSR` → `render()`）但尚未發版。

**修法（三件一組）**：
1. `vite.config.ts` `onBeforePageRender` 為每個預渲染頁注入 `<meta name="ssg-route">` 標記
2. `src/utils/ssgFallbackGuard.ts`＋`main.tsx`：hydration 前比對標記與當前 URL，不符（404／SW shell fallback／無尾斜線 fallback）即清空 root 並移除 `data-server-rendered`
3. `patches/vite-react-ssg@0.8.9.patch`：對齊上游 PR #90 一行修正，讓無標記快照走乾淨 `render()`；上游發版後應移除 patch 改升版

### 防回歸

- `version.test.ts`：`getFormattedBuildTime()` 必須等於 Asia/Taipei 顯式格式化結果（CI 為 UTC，timeZone 被移除即紅）
- `prerender.test.ts`：抽樣 dist 頁必含 `ssg-route` 標記；faq 頁 `Built on` 文字必須等於以 Asia/Taipei 格式化 `build-time` meta 的結果（build 機器時區漂移即紅）
- `ssgFallbackGuard.test.ts`：stale 快照降級 render／正確路由維持 hydrate／無標記保守不介入

## 驗證（零 #418 證據）

停 SW、production build＋preview，11 路由（`/`、`/multi`、`/favorites`、`/settings`、`/faq/`、`/guide/`、`/about/`、`/usd-twd/`、`/sell-rate-vs-mid-rate/`、`/usd-twd/100/`、404 未知路徑）Playwright console 巡檢：

| 組合 | 修復前 | 修復後 |
| --- | --- | --- |
| 台北 build × 台北瀏覽器 | 4 筆（fallback 類） | **0** |
| 台北 build × UTC 瀏覽器 | 10 筆 | **0** |
| **UTC build × 台北瀏覽器（staging 重演）** | 內容頁全中 | **0** |

404 頁修復後正確渲染 NotFound（h1「404」＋h2「頁面不存在」）、`/multi`（無尾斜線 fallback）正確渲染多幣別頁。

## 閘門

- `pnpm typecheck` 全綠
- ratewise vitest：**3322 passed | 2 skipped**（含新增守門測試）
- `pnpm build:ratewise` 成功（pre-push 亦全綠）
- changeset：patch（使用者可感知：console 不再出現錯誤）
- 002 已更新（reward+1／penalty−1，總分 +134 不變）

## Refs

- 追蹤 issue：#459（staging 驗證 comment 指認中招頁面）
- staging 報告：`.claude/product-intel/qa-staging-report.md` P1-2
- 前置修復：#595（i18n SSG 語言首屏，本 PR 補齊其未涵蓋的兩個獨立根因）

## Follow-up（已立案，非本 PR 範圍）

- #623：`patches/vite-react-ssg@0.8.9.patch` 升版陷阱——上游 PR #90 已 merge 未發版，升版時必須移除 patch 改吃官方版本
- #624：全 repo 無 locale 參數的 `toLocaleString()` 盤點（SingleConverter／MultiConverter 等金額顯示，同型時區／locale 漂移風險）
- #625：跨時區驗證閘門制度化（build TZ ≠ browser TZ 組合納入 hydration 修復 SOP）＋ SPA fallback 軟 404（200 回應）既有債

**請勿直接 merge：等待 review 與使用者授權。**

Made with [Cursor](https://cursor.com)
