### PR TITLE
fix(ratewise): 內建主題 AA 對比批次修復（nitro/kawaii＋alpha 稀釋收斂）

### DIFF
--- a/.changeset/fix-609-builtin-theme-aa.md
+++ b/.changeset/fix-609-builtin-theme-aa.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+Nitro 與 Kawaii 主題文字對比達 WCAG AA：Nitro 按鈕白字與 hover 表面加深、Kawaii 主色文字改用加深粉色，底部導覽未選中項與小圖示不再因透明度稀釋而難以辨識。

--- a/apps/ratewise/src/components/BottomNavigation.tsx
+++ b/apps/ratewise/src/components/BottomNavigation.tsx
@@ -81,7 +81,7 @@ function BottomNavigationItem({
       <div
         className={`
           relative transition-all duration-200
-          ${isActive ? 'scale-110 opacity-100 text-primary-on-surface' : isPending ? 'opacity-70 scale-100' : 'opacity-[0.35] scale-100'}
+          ${isActive ? 'scale-110 text-primary-on-surface' : 'scale-100 text-[rgb(var(--color-text-muted))]'}
           group-active:scale-90
         `}
       >
@@ -103,7 +103,7 @@ function BottomNavigationItem({
       <span
         className={`
           text-2xs font-black uppercase tracking-[0.1em] transition-all duration-200
-          ${isActive ? 'text-primary-on-surface opacity-100 translate-y-0' : isPending ? 'opacity-70 translate-y-px' : 'opacity-[0.35] translate-y-px'}
+          ${isActive ? 'text-primary-on-surface translate-y-0' : 'text-[rgb(var(--color-text-muted))] translate-y-px'}
         `}
       >
         {t(item.labelKey)}

--- a/apps/ratewise/src/components/PullToRefreshIndicator.tsx
+++ b/apps/ratewise/src/components/PullToRefreshIndicator.tsx
@@ -49,12 +49,8 @@ export function PullToRefreshIndicator({
       ? t('pwa.releaseToRefresh')
       : t('pwa.pullToRefresh');
 
-  // Color scheme using SSOT tokens
-  const iconColor = isRefreshing
-    ? 'text-primary-on-surface'
-    : canTrigger
-      ? 'text-primary-on-surface'
-      : 'text-primary-on-surface/70';
+  // 圖示一律實色 on-surface 錨點（#609：/70 稀釋後實效對比不達標）。
+  const iconColor = 'text-primary-on-surface';
 
   return (
     <div

--- a/apps/ratewise/src/config/__tests__/alpha-composite-contrast.test.ts
+++ b/apps/ratewise/src/config/__tests__/alpha-composite-contrast.test.ts
@@ -1,0 +1,177 @@
+/**
+ * 文字 alpha 稀釋合成對比守門（issue #609）
+ *
+ * 背景：AA property 測試只驗實色 token；`text-primary-on-surface/70`、
+ * `opacity-[0.35]` 等 alpha 疊加會把達標實色稀釋到實效對比 < 4.5:1
+ * （kawaii text 0.7 合成後僅 3.56:1、zen text 0.35 合成後僅 2.22:1）。
+ *
+ * 守門規則：
+ * 1. 靜態掃描 src 下全部 .ts/.tsx（排除測試檔）：
+ *    - `text-primary-on-surface/<alpha>` 稀釋變體
+ *    - className 內任意值 `opacity-[<x>]`
+ *    兩者必須完全等於允許清單；新增條目需先以合成計算證明 ≥ 4.5:1。
+ * 2. 已收斂消費點的實色錨點斷言：底部導覽 inactive 錨定 text-muted、
+ *    換錢所 badge 圖示錨定 on-surface，對各主題自身底色 ≥ 4.5:1。
+ * 3. 歷史 alpha 值合成斷言：以合成公式證明 0.7 / 0.35 稀釋不達 AA，
+ *    作為收斂依據並防止回退。
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * alpha 稀釋允許清單（`相對 src 路徑:行號`）。
+ * #609 收斂後應維持為空；新增條目需附「合成後對比 ≥ 4.5:1」計算證明與 PM/a11y 裁決。
+ */
+const ALPHA_DILUTION_ALLOWLIST: readonly string[] = [];
+
+const SRC_ROOT = resolve(__dirname, '../..');
+const SCANNED_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+/** 文字消費面的 alpha 稀釋樣式。 */
+const ALPHA_DILUTION_PATTERNS: readonly RegExp[] = [
+  /text-primary-on-surface\/\d+/,
+  /opacity-\[0?\.\d+\]/,
+];
+
+function isTestFile(path: string): boolean {
+  return path.includes('__tests__') || /\.(test|spec)\.(ts|tsx)$/.test(path);
+}
+
+function collectSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(path);
+    if (!SCANNED_EXTENSIONS.has(extname(entry.name)) || isTestFile(path)) return [];
+    return [path];
+  });
+}
+
+function scanDilutions(): string[] {
+  return collectSourceFiles(SRC_ROOT).flatMap((path) => {
+    const lines = readFileSync(path, 'utf-8').split('\n');
+    return lines.flatMap((line, index) =>
+      ALPHA_DILUTION_PATTERNS.some((pattern) => pattern.test(line))
+        ? [`${relative(SRC_ROOT, path)}:${index + 1}`]
+        : [],
+    );
+  });
+}
+
+/** 'R G B' → 相對亮度（WCAG 2.x，測試內獨立實作）。 */
+function relativeLuminance(triple: string): number {
+  const [r, g, b] = triple.split(/\s+/).map((n) => {
+    const c = Number(n) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0);
+}
+
+function contrast(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** alpha 合成：前景以 alpha 疊在底色上的實效顏色（sRGB 線性插值）。 */
+function composite(foreground: string, background: string, alpha: number): string {
+  const fg = foreground.split(/\s+/).map(Number);
+  const bg = background.split(/\s+/).map(Number);
+  return fg.map((channel, i) => Math.round(alpha * channel + (1 - alpha) * (bg[i] ?? 0))).join(' ');
+}
+
+/** 由 index.css 解析各主題區塊變數（與 raw-primary-text-exposure 同法）。 */
+const css = readFileSync(resolve(SRC_ROOT, 'index.css'), 'utf-8');
+const blockStarts = [...css.matchAll(/\[data-style='([\w-]+)'\]\s*\{/g)];
+const themeBlocks = blockStarts.map((match, index) => ({
+  theme: match[1] ?? '',
+  body: css.slice(match.index ?? 0, blockStarts[index + 1]?.index ?? css.length),
+}));
+
+function readVar(body: string, name: string): string {
+  return new RegExp(`${name}:\\s*([0-9]+ [0-9]+ [0-9]+)\\s*;`).exec(body)?.[1] ?? '';
+}
+
+describe('文字 alpha 稀釋曝露面守門（#609）', () => {
+  it('掃描範圍非空（防止路徑失效讓守門空轉）', () => {
+    expect(collectSourceFiles(SRC_ROOT).length).toBeGreaterThan(100);
+  });
+
+  it('alpha 稀釋用法必須完全等於允許清單', () => {
+    const dilutions = scanDilutions().sort();
+    expect(
+      dilutions,
+      `發現未列管的文字 alpha 稀釋點（請改實色 token，或附合成對比證明加入允許清單）：\n${dilutions.join('\n')}`,
+    ).toEqual([...ALPHA_DILUTION_ALLOWLIST].sort());
+  });
+
+  it('守門樣式自檢：可辨識稀釋用法且不誤傷實色 token', () => {
+    const [onSurfacePattern, opacityPattern] = ALPHA_DILUTION_PATTERNS;
+    expect(onSurfacePattern?.test('text-primary-on-surface/70')).toBe(true);
+    expect(onSurfacePattern?.test('text-primary-on-surface')).toBe(false);
+    expect(opacityPattern?.test("'opacity-[0.35] scale-100'")).toBe(true);
+    expect(opacityPattern?.test('opacity-70')).toBe(false);
+    expect(opacityPattern?.test('opacity-100')).toBe(false);
+  });
+});
+
+describe('已收斂消費點的實色錨點合成驗證（#609）', () => {
+  it.each(themeBlocks)(
+    '[$theme] 底部導覽 inactive 錨點 text-muted 對 background ≥ 4.5:1',
+    ({ theme, body }) => {
+      const textMuted = readVar(body, '--color-text-muted');
+      const background = readVar(body, '--color-background');
+      expect(textMuted, `${theme} 缺少 --color-text-muted`).not.toBe('');
+      expect(
+        contrast(textMuted, background),
+        `${theme} text-muted on background`,
+      ).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+
+  // badge 為圖示（非文字），適用 WCAG 1.4.11 圖形對比 ≥ 3:1；
+  // 文字面的 4.5:1 由 raw-primary-text-exposure 的白名單合約守門。
+  it.each(themeBlocks)(
+    '[$theme] badge 圖示錨點 on-surface 對 surface ≥ 3:1（實色，無稀釋）',
+    ({ theme, body }) => {
+      const onSurface = readVar(body, '--color-primary-on-surface');
+      const surface = readVar(body, '--color-surface');
+      expect(onSurface, `${theme} 缺少 --color-primary-on-surface`).not.toBe('');
+      expect(contrast(onSurface, surface), `${theme} on-surface on surface`).toBeGreaterThanOrEqual(
+        3,
+      );
+    },
+  );
+});
+
+describe('歷史 alpha 消費點合成斷言（收斂依據，防回退）', () => {
+  const byTheme = new Map(themeBlocks.map(({ theme, body }) => [theme, body]));
+
+  it('kawaii text 以 0.7 疊底後對 background < 4.5:1（原 opacity-70 待命態不達 AA）', () => {
+    const body = byTheme.get('kawaii') ?? '';
+    const diluted = composite(
+      readVar(body, '--color-text'),
+      readVar(body, '--color-background'),
+      0.7,
+    );
+    expect(contrast(diluted, readVar(body, '--color-background'))).toBeLessThan(4.5);
+  });
+
+  it('zen text 以 0.35 疊底後對 background < 4.5:1（原 opacity-[0.35] inactive 態不達 AA）', () => {
+    const body = byTheme.get('zen') ?? '';
+    const diluted = composite(
+      readVar(body, '--color-text'),
+      readVar(body, '--color-background'),
+      0.35,
+    );
+    expect(contrast(diluted, readVar(body, '--color-background'))).toBeLessThan(4.5);
+  });
+
+  it('zen on-surface 以 0.7 疊白底後 < 4.5:1（原 text-primary-on-surface/70 badge 不達 AA）', () => {
+    const body = byTheme.get('zen') ?? '';
+    const surface = readVar(body, '--color-surface');
+    const diluted = composite(readVar(body, '--color-primary-on-surface'), surface, 0.7);
+    expect(contrast(diluted, surface)).toBeLessThan(4.5);
+  });
+});

--- a/apps/ratewise/src/config/__tests__/raw-primary-text-exposure.test.ts
+++ b/apps/ratewise/src/config/__tests__/raw-primary-text-exposure.test.ts
@@ -61,7 +61,37 @@ function scanExposures(): string[] {
   });
 }
 
-describe('內建主題 on-surface 錨點合約（#632 視覺不變）', () => {
+/**
+ * on-surface 覆寫白名單（issue #609 合約修訂）：
+ * 內建主題預設維持 on-surface == primary（#632 視覺零變化）；
+ * 列於本白名單者允許有意識覆寫，但必須通過對自身 surface / background /
+ * surface-elevated / surface-sunken 全部 ≥ 4.5:1 的 AA 驗證。
+ * 新增條目需 PM/a11y 裁決並附理由。
+ */
+const ON_SURFACE_OVERRIDE_WHITELIST: Record<string, string> = {
+  // hot pink primary 對白底僅 2.65:1，文字錨點加深至 pink-700（白底 6.04:1）；品牌色本身不動。
+  kawaii: 'primary 對白底不達 AA，文字面走加深 clamp 色',
+  // 深色主題文字錨點亮向（對 surface 8.36:1），原 primary 對 surface-elevated 僅 4.53:1 貼線。
+  nitro: '深色主題文字錨點亮向增加對比餘裕',
+};
+
+/** 'R G B' → 相對亮度（WCAG 2.x，測試內獨立實作）。 */
+function relativeLuminance(triple: string): number {
+  const [r, g, b] = triple.split(/\s+/).map((n) => {
+    const c = Number(n) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0);
+}
+
+function contrast(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('內建主題 on-surface 錨點合約（#632 預設零變化 + #609 白名單覆寫）', () => {
   const css = readFileSync(resolve(SRC_ROOT, 'index.css'), 'utf-8');
   const blockStarts = [...css.matchAll(/\[data-style='([\w-]+)'\]\s*\{/g)];
   const themeBlocks = blockStarts.map((match, index) => ({
@@ -73,15 +103,53 @@ describe('內建主題 on-surface 錨點合約（#632 視覺不變）', () => {
     return new RegExp(`${name}:\\s*([0-9]+ [0-9]+ [0-9]+)\\s*;`).exec(body)?.[1];
   }
 
+  it('白名單主題必須實際存在於 index.css（防止殘留條目）', () => {
+    const themes = new Set(themeBlocks.map((block) => block.theme));
+    Object.keys(ON_SURFACE_OVERRIDE_WHITELIST).forEach((theme) => {
+      expect(themes.has(theme), `白名單主題 ${theme} 不存在於 index.css`).toBe(true);
+    });
+  });
+
   it.each(themeBlocks)(
-    '[data-style=$theme] 的 --color-primary-on-surface 必須等於 --color-primary（靜態值視覺零變化）',
+    '[data-style=$theme] 的 --color-primary-on-surface 必須定義；非白名單主題必須等於 --color-primary',
     ({ theme, body }) => {
       const primary = readVar(body, '--color-primary');
       const onSurface = readVar(body, '--color-primary-on-surface');
       expect(primary, `${theme} 缺少 --color-primary`).toBeDefined();
-      expect(onSurface, `${theme} 缺少 --color-primary-on-surface（文字錨點需全主題齊備）`).toBe(
+      expect(
+        onSurface,
+        `${theme} 缺少 --color-primary-on-surface（文字錨點需全主題齊備）`,
+      ).toBeDefined();
+      if (!(theme in ON_SURFACE_OVERRIDE_WHITELIST)) {
+        expect(onSurface, `${theme} 未列於白名單，on-surface 必須等於 primary（視覺零變化）`).toBe(
+          primary,
+        );
+      }
+    },
+  );
+
+  it.each(themeBlocks.filter(({ theme }) => theme in ON_SURFACE_OVERRIDE_WHITELIST))(
+    '[data-style=$theme] 白名單覆寫必須對自身全部底色 ≥ 4.5:1（AA）',
+    ({ theme, body }) => {
+      const onSurface = readVar(body, '--color-primary-on-surface');
+      const primary = readVar(body, '--color-primary');
+      expect(onSurface).toBeDefined();
+      expect(onSurface, `${theme} 列於白名單但 on-surface 仍等於 primary（覆寫不存在）`).not.toBe(
         primary,
       );
+      for (const name of [
+        '--color-surface',
+        '--color-background',
+        '--color-surface-elevated',
+        '--color-surface-sunken',
+      ]) {
+        const surface = readVar(body, name);
+        expect(surface, `${theme} 缺少 ${name}`).toBeDefined();
+        expect(
+          contrast(onSurface ?? '', surface ?? ''),
+          `${theme} on-surface 對 ${name} 對比不達 AA`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
     },
   );
 });

--- a/apps/ratewise/src/config/__tests__/themes.test.ts
+++ b/apps/ratewise/src/config/__tests__/themes.test.ts
@@ -34,20 +34,38 @@ const WHITE = '255 255 255';
 describe('Nitro 主題可讀性守門', () => {
   const nitro = STYLE_DEFINITIONS.nitro.colors;
 
-  it('primary 上的白字對比 ≥ 3:1（AA-large / 按鈕）', () => {
+  it('primary 上的白字對比 ≥ 3:1（AA-large / 大字與圖形面）', () => {
     expect(contrastRatio(WHITE, nitro.primary)).toBeGreaterThanOrEqual(3);
+  });
+
+  // #609 字級分級門檻：白字小字表面（按鈕）錨定 strong，需一般文字 AA 4.5:1。
+  it('primaryStrong 上的白字對比 ≥ 4.5:1（AA 小字 / 白字表面錨點）', () => {
+    expect(contrastRatio(WHITE, nitro.primaryStrong)).toBeGreaterThanOrEqual(4.5);
   });
 
   it('textMuted 對 background 對比 ≥ 4.5:1（AA 內文）', () => {
     expect(contrastRatio(nitro.textMuted, nitro.background)).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('themes.ts 與 index.css 的 Nitro primary / textMuted 不得漂移', () => {
+  // #609：hover 是白字按鈕（bg-primary-strong hover:bg-primary-hover text-white）的表面，
+  // 同受一般文字 AA 4.5:1 約束（原 cyan-400 白字僅 ~1.8:1）。
+  it('index.css 的 Nitro primary-hover 上白字對比 ≥ 4.5:1（hover 白字表面）', () => {
+    const css = readFileSync(resolve(__dirname, '../../index.css'), 'utf-8');
+    const block = css.slice(css.indexOf("[data-style='nitro']"));
+    const hover = new RegExp(`--color-primary-hover:\\s*([0-9]+\\s+[0-9]+\\s+[0-9]+)`)
+      .exec(block)?.[1]
+      ?.trim();
+    expect(hover, 'nitro 缺少 --color-primary-hover').toBeDefined();
+    expect(contrastRatio(WHITE, hover ?? '')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('themes.ts 與 index.css 的 Nitro primary / primaryStrong / textMuted 不得漂移', () => {
     const css = readFileSync(resolve(__dirname, '../../index.css'), 'utf-8');
     const block = css.slice(css.indexOf("[data-style='nitro']"));
     const cssVar = (name: string) =>
       new RegExp(`--color-${name}:\\s*([0-9]+\\s+[0-9]+\\s+[0-9]+)`).exec(block)?.[1]?.trim();
     expect(cssVar('primary')).toBe(nitro.primary);
+    expect(cssVar('primary-strong')).toBe(nitro.primaryStrong);
     expect(cssVar('text-muted')).toBe(nitro.textMuted);
   });
 });

--- a/apps/ratewise/src/config/design-tokens/layout.ts
+++ b/apps/ratewise/src/config/design-tokens/layout.ts
@@ -349,7 +349,7 @@ export const singleConverterLayoutTokens = {
       'mx-auto inline-flex max-w-full flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-2xs font-medium leading-tight text-text-muted/60',
 
     /** 換錢所 badge 圖示 */
-    exchangeShopBadgeIcon: 'h-3 w-3 shrink-0 text-primary-on-surface/70',
+    exchangeShopBadgeIcon: 'h-3 w-3 shrink-0 text-primary-on-surface',
 
     /** 換錢所 badge 分隔點 */
     exchangeShopBadgeDot: 'text-text-muted/40',

--- a/apps/ratewise/src/config/themes.ts
+++ b/apps/ratewise/src/config/themes.ts
@@ -219,8 +219,8 @@ const nitroStyle: StyleDefinition = {
     surface: '15 23 42', // slate-900
     text: '255 255 255',
     textMuted: '203 213 225', // slate-300（修正 slate-500 在深底對比過低、次要文字看不清）
-    primary: '0 150 230', // 霓虹藍（深電光，白字達 3:1 AA，取代過亮 cyan）
-    primaryStrong: '0 150 230', // 同 primary（深色主題維持霓虹視覺）
+    primary: '0 150 230', // 霓虹藍（深電光，圖形/大字維持 3:1；品牌色不動）
+    primaryStrong: '0 113 173', // 同色相加深（#609 白字表面錨點，白字 5.30:1 AA）
     secondary: '129 140 248', // indigo-400
     accent: '0 255 136', // neon green
     border: '30 41 59', // slate-800

--- a/apps/ratewise/src/features/ratewise/RateWise.tsx
+++ b/apps/ratewise/src/features/ratewise/RateWise.tsx
@@ -284,7 +284,7 @@ const RateWise = ({ rememberConverterView = true }: { rememberConverterView?: bo
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-1 hover:text-primary-on-surface transition-colors"
                     >
-                      <Landmark className="h-3 w-3 text-primary-on-surface/70" aria-hidden="true" />
+                      <Landmark className="h-3 w-3 text-primary-on-surface" aria-hidden="true" />
                       臺灣銀行牌告
                     </a>
                     <span>·</span>

--- a/apps/ratewise/src/index.css
+++ b/apps/ratewise/src/index.css
@@ -810,9 +810,9 @@
     --color-surface: 15 23 42; /* slate-900 */
     --color-text: 255 255 255;
     --color-text-muted: 203 213 225; /* slate-300（修正 slate-500 在深底對比過低） */
-    --color-primary: 0 150 230; /* 霓虹藍（深電光，按鈕白字達 3:1 AA） */
-    --color-primary-strong: 0 150 230; /* 同 primary（深色主題維持霓虹視覺） */
-    --color-primary-on-surface: 0 150 230; /* 同 primary（#632 文字錨點） */
+    --color-primary: 0 150 230; /* 霓虹藍（深電光，圖形/大字維持 3:1；品牌色不動） */
+    --color-primary-strong: 0 113 173; /* 同色相加深（#609 白字表面錨點，白字 5.30:1 AA） */
+    --color-primary-on-surface: 61 187 255; /* #609 白名單覆寫：深色主題文字錨點亮向（對 surface 8.36:1） */
     --color-secondary: 129 140 248; /* indigo-400 */
     --color-accent: 0 255 136; /* 霓虹綠 */
     --color-border: 30 41 59; /* slate-800 */
@@ -835,7 +835,7 @@
     /* 舊版 primary 系列 - 霓虹風格 */
     --color-primary-bg: 30 41 59; /* slate-800 */
     --color-primary-light: 30 41 59; /* slate-800 - 深色背景用 */
-    --color-primary-hover: 34 211 238; /* cyan-400 - 霓虹藍亮色 */
+    --color-primary-hover: 0 120 184; /* 同色相微亮於 strong（#609 hover 白字 4.80:1 AA） */
     --color-primary-active: 103 232 249; /* cyan-300 - 深色主題按壓強調（亮向） */
     --color-primary-text-light: 34 211 238; /* cyan-400 */
     --color-primary-ring: 6 182 212; /* cyan-500 */
@@ -993,7 +993,7 @@
     --color-text-muted: 126 92 100; /* 對 background 5.62:1，AA */
     --color-primary: 255 105 180; /* hot pink */
     --color-primary-strong: 219 39 119; /* pink-600（白字 AA 對比） */
-    --color-primary-on-surface: 255 105 180; /* 同 primary（#632 文字錨點） */
+    --color-primary-on-surface: 190 24 93; /* #609 白名單覆寫：hot pink 對白底僅 2.65:1，文字錨點加深至 pink-700（6.04:1） */
     --color-secondary: 236 72 153; /* pink-500 */
     --color-accent: 255 182 193; /* light pink */
     --color-border: 255 228 225; /* misty rose */

--- a/apps/ratewise/src/pages/NotFound.tsx
+++ b/apps/ratewise/src/pages/NotFound.tsx
@@ -55,13 +55,13 @@ export default function NotFound() {
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Link
               to="/faq/"
-              className="px-4 py-2 text-primary-on-surface hover:text-primary-on-surface/80 hover:bg-primary/10 rounded-lg transition-colors font-medium"
+              className="px-4 py-2 text-primary-on-surface hover:bg-primary/10 rounded-lg transition-colors font-medium"
             >
               {t('settings.faq')}
             </Link>
             <Link
               to="/about/"
-              className="px-4 py-2 text-primary-on-surface hover:text-primary-on-surface/80 hover:bg-primary/10 rounded-lg transition-colors font-medium"
+              className="px-4 py-2 text-primary-on-surface hover:bg-primary/10 rounded-lg transition-colors font-medium"
             >
               {t('settings.aboutUs')}
             </Link>
@@ -75,7 +75,7 @@ export default function NotFound() {
             href="https://github.com/haotool/app/issues"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-on-surface hover:text-primary-on-surface/80 underline ml-1"
+            className="text-primary-on-surface underline ml-1"
           >
             回報問題
           </a>

--- a/apps/ratewise/src/pages/SeoTech.tsx
+++ b/apps/ratewise/src/pages/SeoTech.tsx
@@ -711,7 +711,7 @@ export default function SeoTech() {
                       : ''
                   }`}
                 >
-                  <span className="text-xs font-mono text-primary-on-surface/60 w-4 text-right flex-shrink-0">
+                  <span className="text-xs font-mono text-primary-on-surface w-4 text-right flex-shrink-0">
                     {idx + 1}
                   </span>
                   <div className="flex-1 min-w-0">

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+160
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+161
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-06
+- ID：reward-rw-609-builtin-theme-aa-batch
+- 原因：nitro primary-hover 白字僅 ~1.8:1、小字白字按鈕 3.23:1（守門鎖 3:1 放行）；kawaii hot pink 對白底 2.65:1 經 on-surface==primary 合約傳導到全站文字；`/70`、`opacity-[0.35]` alpha 疊加把達標實色稀釋到 <4.5:1 且守門只驗實色
+- 解法：nitro strong/hover 同色相加深（白字 5.30/4.80:1）、kawaii/nitro on-surface 白名單覆寫（pink-700／亮向 61 187 255），#632 合約改為「預設==primary＋白名單覆寫須對自身底色 ≥4.5:1」；alpha 稀釋點全數收斂實色並新增 alpha-composite 掃描守門與合成計算斷言
 
 - 日期：2026-07-06
 - ID：reward-rw-633-first-input-replaces-seed


### PR DESCRIPTION
Closes #609

## 摘要

處理 issue #609 本體（nitro 對比缺口）與 PM 兩項擴充追記（kawaii primary、alpha 稀釋縫隙），共三件事：

1. **nitro 白字表面**：`primary-strong` 與 `primary-hover` 同色相加深（品牌色 `primary: 0 150 230` 不動，圖形／大字面維持 3:1）。原 hover cyan-400 白字僅 ~1.8:1、小字白字按鈕 3.23:1。
2. **kawaii/nitro on-surface 白名單覆寫**：kawaii hot pink 對白底僅 2.65:1，文字錨點加深至 pink-700；nitro 文字錨點亮向增加深底對比餘裕。
3. **alpha 稀釋收斂**：`text-primary-on-surface/70`（換錢所 badge、下拉刷新圖示、牌告來源圖示）、`/60`（SeoTech）、hover `/80`（NotFound）、底部導覽 `opacity-[0.35]`／`opacity-70` 全數收斂為實色 token，並新增合成對比守門。

## 合約變更點（on-surface 白名單設計）

`raw-primary-text-exposure.test.ts` 原合約「每個 `[data-style]` 的 on-surface == primary」有意識打破，改為：

- 每個 `[data-style]` 區塊 **必須定義** `--color-primary-on-surface`
- **非白名單主題**：on-surface 必須等於 primary（#632 視覺零變化合約保留）
- **白名單主題**（`ON_SURFACE_OVERRIDE_WHITELIST`，現為 kawaii/nitro，附理由）：on-surface 必須 ≠ primary，且對自身 `surface` / `background` / `surface-elevated` / `surface-sunken` 全部 ≥ 4.5:1；另防呆檢查白名單主題必須實際存在於 index.css
- `custom-theme.test.ts` 的 AA property 與 parity 測試 **未放寬、未改動**（custom 主題行為不變）

新增 `alpha-composite-contrast.test.ts`：

- 靜態掃描 `text-primary-on-surface/<alpha>` 與 `opacity-[<x>]` 稀釋樣式，必須等於允許清單（現為空；新增需附合成對比 ≥4.5:1 證明）
- 已收斂消費點實色錨點斷言：7 主題 text-muted 對 background ≥4.5、on-surface 對 surface ≥3（圖示 WCAG 1.4.11）
- 歷史 alpha 合成計算斷言（0.7／0.35 稀釋不達 AA），作為收斂依據並防回退

## 色值與對比（WCAG 2.x 精算）

| 主題 | Token | 前 | 後 | 對比（後） |
| --- | --- | --- | --- | --- |
| nitro | `--color-primary-strong` | 0 150 230（白字 3.23:1） | **0 113 173** | 白字 **5.30:1** |
| nitro | `--color-primary-hover` | 34 211 238（白字 ~1.8:1） | **0 120 184** | 白字 **4.80:1**（hover 仍亮於 strong） |
| nitro | `--color-primary-on-surface` | 0 150 230（elevated 4.53:1 貼線） | **61 187 255** | surface **8.36:1**／elevated 6.85:1 |
| kawaii | `--color-primary-on-surface` | 255 105 180（白底 2.65:1） | **190 24 93**（pink-700） | 白底 **6.04:1**／cream 5.82／rose-50 5.50／rose-100 5.03 |

nitro 守門按字級分級：strong/hover 白字 ≥4.5（小字）、primary 白字 ≥3（大字／圖形），並鎖 `primary-strong` TS↔CSS 同步。

## 前後截圖（390×844 行動版，存 `screenshots/`）

| 主題 | Before | After | 預期 |
| --- | --- | --- | --- |
| kawaii | `screenshots/609-kawaii-before.png` | `screenshots/609-kawaii-after.png` | 主色文字加深（pink-700）、導覽未選中實色化 |
| nitro | `screenshots/609-nitro-before.png` | `screenshots/609-nitro-after.png` | CTA 加深、導覽選中亮向、未選中 slate-300 實色 |
| zen | `screenshots/609-zen-before.png` | `screenshots/609-zen-after.png` | token 面零變化（僅底部導覽未選中依第 3 項實色化） |
| violet | `screenshots/609-violet-before.png` | `screenshots/609-violet-after.png` | 同 zen |

註：zen/violet/classic/racing/forest/custom 的主題 token 未動（`git diff` 僅 nitro/kawaii 區塊）；唯一跨主題視覺差異是第 3 項 alpha 收斂（底部導覽未選中、badge 圖示由稀釋改實色），此為 issue 範圍內的刻意修正。已用 Playwright 實測 zen/nitro/kawaii 計算樣式確認 token 生效。

## 測試

- `pnpm --filter @app/ratewise test`：180 檔 4062 測試全綠（含新守門）
- `pnpm --filter @app/ratewise typecheck`、`generate:deterministic`、`verify:artifacts` 通過
- pre-commit（lint-staged／typecheck／prettier／SSOT）與 pre-push（typecheck＋test＋build:ratewise）全過
- changeset：patch（使用者可感知的可讀性修正）

Made with [Cursor](https://cursor.com)