### PR TITLE
perf(ratewise): 行動端 Lighthouse mobile 效能 78→86，達成 #639 ≥85 門檻

### DIFF
--- a/.changeset/fix-639-mobile-perf.md
+++ b/.changeset/fix-639-mobile-perf.md
@@ -1,0 +1,5 @@
+---
+'@app/ratewise': patch
+---
+
+行動版首屏載入更快（Lighthouse mobile 效能 78→86，FCP 約快 0.5 秒、LCP 約快 0.8 秒）；PWA 安裝指引改為使用者互動後才顯示，不再打斷初次瀏覽（Threads、Instagram 等內建瀏覽器的外開引導維持自動顯示）。

--- a/apps/ratewise/src/components/PwaInstallGuide.tsx
+++ b/apps/ratewise/src/components/PwaInstallGuide.tsx
@@ -13,7 +13,12 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 const DISMISSED_KEY = 'ratewise:pwa-install-guide-dismissed:v1';
+// 首次互動後再延遲顯示：對齊 Chrome install promotion 指引（互動後才推薦安裝），
+// 亦避免指引成為 LCP 元素拖垮行動端分數（LCP 於首次輸入後凍結）。
+// 不含 scroll：程式化捲動（scroll restoration／anchor）會在 LCP 未凍結時誤觸 gate；
+// 真實捲動必先觸發 touchstart／wheel／pointerdown 之一，招回損失趨近零。
 const SHOW_DELAY_MS = 1800;
+const ENGAGEMENT_EVENTS = ['pointerdown', 'keydown', 'touchstart', 'wheel'] as const;
 
 function getAssetPath(fileName: string) {
   const basePath = import.meta.env.BASE_URL || '/';
@@ -110,8 +115,37 @@ function PwaInstallGuideClient() {
       return;
     }
 
-    const timer = window.setTimeout(() => setIsVisible(true), SHOW_DELAY_MS);
-    return () => window.clearTimeout(timer);
+    // 等待首次互動再起算顯示計時：未互動的過客不會被安裝指引打斷，
+    // 且 LCP 於首次輸入後凍結，指引海報不再成為 LCP 元素。
+    let timer: number | null = null;
+
+    const removeEngagementListeners = () => {
+      for (const eventName of ENGAGEMENT_EVENTS) {
+        window.removeEventListener(eventName, startTimer);
+      }
+    };
+
+    function startTimer() {
+      removeEngagementListeners();
+      timer = window.setTimeout(() => setIsVisible(true), SHOW_DELAY_MS);
+    }
+
+    // 內建瀏覽器豁免互動 gate：「請改用外部瀏覽器」屬功能性逃逸引導（非行銷推廣），
+    // 且 webview 不在 Lighthouse 量測面內——維持載入後直接起算顯示。
+    if (currentEnvironment.inAppBrowser) {
+      startTimer();
+    } else {
+      for (const eventName of ENGAGEMENT_EVENTS) {
+        window.addEventListener(eventName, startTimer, { once: true, passive: true });
+      }
+    }
+
+    return () => {
+      removeEngagementListeners();
+      if (timer != null) {
+        window.clearTimeout(timer);
+      }
+    };
   }, []);
 
   React.useEffect(() => {

--- a/apps/ratewise/src/components/__tests__/PwaInstallGuide.test.tsx
+++ b/apps/ratewise/src/components/__tests__/PwaInstallGuide.test.tsx
@@ -20,7 +20,9 @@ function mockNavigator(userAgent: string, platform: string, maxTouchPoints = 5) 
 }
 
 function showGuide() {
+  // 指引改為首次互動後才起算顯示計時：先模擬使用者互動再推進計時器。
   act(() => {
+    fireEvent.pointerDown(window);
     vi.advanceTimersByTime(1800);
   });
 }
@@ -39,6 +41,55 @@ describe('PwaInstallGuide', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     sessionStorage.clear();
+  });
+
+  it('stays hidden until the user interacts (LCP-safe engagement gate)', () => {
+    mockNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1',
+      'iPhone',
+    );
+
+    render(<PwaInstallGuide />);
+
+    // 未互動：即使超過顯示延遲，也不得出現指引。
+    // scroll 不在互動集合內：程式化捲動（scroll restoration／anchor）不得誤觸 gate。
+    act(() => {
+      fireEvent.scroll(window);
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // 互動後起算延遲，時間到才顯示。
+    act(() => {
+      fireEvent.pointerDown(window);
+      vi.advanceTimersByTime(1799);
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('shows automatically without interaction inside in-app browsers (functional escape guidance)', () => {
+    mockNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Threads 337.0 Instagram 337.0',
+      'iPhone',
+    );
+
+    render(<PwaInstallGuide />);
+
+    // 內建瀏覽器豁免互動 gate：未互動經過顯示延遲即自動顯示逃逸引導。
+    act(() => {
+      vi.advanceTimersByTime(1799);
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole('dialog', { name: '請先用外部瀏覽器開啟' })).toBeInTheDocument();
   });
 
   it('renders the clearer iPhone Safari install flow', () => {

--- a/apps/ratewise/src/main.tsx
+++ b/apps/ratewise/src/main.tsx
@@ -15,6 +15,11 @@ import './trusted-types-bootstrap';
 // Initialize i18n (must be before any React rendering)
 import './i18n';
 
+// 提前靜態載入 react-dom/client：vite-react-ssg 於 hydrate 時才動態 import，
+// 若無此靜態依賴，vendor-react chunk 需等 app chunk 下載並執行後才開始下載，
+// 串行化的 60KB 下載會直接拖慢 hydration 與 LCP。
+import 'react-dom/client';
+
 import { ViteReactSSG } from 'vite-react-ssg';
 import { routes } from './routes';
 import './index.css';

--- a/apps/ratewise/vite.config.ts
+++ b/apps/ratewise/vite.config.ts
@@ -367,6 +367,15 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'es2020',
       sourcemap: 'hidden',
+      // 首頁 head 的十餘個 modulepreload 會與 HTML 本體、關鍵 CSS 競爭 4G 頻寬，
+      // 實測拖慢 FCP 約 700ms；entry 為 async module，其靜態依賴仍會被瀏覽器
+      // 於 app chunk 抵達後平行下載，LCP 實測不受影響。
+      // 僅移除 HTML 注入的 modulepreload；動態 import 的依賴預載（js host）保留。
+      modulePreload: {
+        resolveDependencies(_url, deps, context) {
+          return context.hostType === 'html' ? [] : deps;
+        },
+      },
       rolldownOptions: {
         output: {
           minify: {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+163
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+164
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-06
+- ID：reward-rw-639-lh-mobile-perf-85
+- 原因：LH mobile perf 79（#639）——PWA 安裝指引於載入 1.8s 後彈出，其海報（126K px²）成為 LCP 元素（LCP 4.48s）；首頁 head 14 個 modulepreload 與 HTML／關鍵 CSS 競爭模擬 4G 頻寬拖慢 FCP 約 700ms；vite-react-ssg 動態 import react-dom/client 使 vendor-react 串行下載
+- 解法：指引改首次互動後起算顯示（LCP 於首次輸入後凍結，對齊 Chrome install promotion 指引）＋移除 HTML modulepreload（動態 import 依賴預載保留）＋ main 靜態載入 react-dom/client；preview 三次中位數 perf 86（FCP 2.65s、LCP 3.65s、TBT 0／CLS 0.002 不回退），SSG 255 頁零 diff、precache 98 項不變
 
 - 日期：2026-07-06
 - ID：reward-rw-638-591-star-hotzone-mobile-polish


### PR DESCRIPTION
Closes #639

## 摘要

- LH mobile（vite preview @4173、模擬 4G、3 次取中位數）效能 **78 → 86**（驗收門檻 ≥85）。
- 根因量測（trace LCP 候選序列）：**PWA 安裝指引於載入 1.8s 後彈出，其海報（126,540 px²，是首屏最大文字塊的 19 倍）成為 LCP 元素**，將 LCP 鎖死在 hydration + 1800ms ≈ 4.5s；另 head 14 個 modulepreload（約 300KB JS）與 HTML 本體、關鍵 CSS 競爭 4G 頻寬，拖慢 FCP 約 700ms。

## 手段 × A/B 量測對照（每步單獨建置後 3 次取中位數）

| 手段（累加） | perf | FCP | LCP | TBT | CLS |
| --- | --- | --- | --- | --- | --- |
| 基準（e520e86d） | 78 | 3181ms | 4480ms | 0ms | 0.003 |
| ① main 靜態載入 `react-dom/client`（消除 vendor-react 串行下載） | 78（中性） | 3253ms | 4540ms | 0ms | 0.003 |
| ② 移除 HTML modulepreload（動態 import 依賴預載保留） | **80** | **2562ms** | 4590ms | 0ms | 0.002 |
| ③ 安裝指引改首次互動後起算顯示 | **86** | 2653ms | **3647ms** | 0ms | 0.002 |

- 診斷佐證：封鎖 `PwaInstallGuide` chunk 的對照組 perf 86 / LCP 3334ms（LCP 元素回歸首屏匯率文字），證明指引即為 LCP 天花板。
- ① 單獨量測為中性（雜訊內），但移除 modulepreload 後成為 hydration 平行下載的結構性前提，予以保留。
- LH JSON 證據：`/tmp/lh-base-*.json`、`/tmp/lh-exp1-*.json`、`/tmp/lh-exp2-*.json`、`/tmp/lh-exp3-*.json`。

## 變更內容

1. `PwaInstallGuide.tsx`：顯示計時改為**首次互動（pointerdown/keydown/touchstart/wheel，once+passive）後才起算 1800ms**。對齊 Chrome install promotion 指引（互動後再推薦安裝）；LCP 於首次輸入後凍結，海報自然不再參與 LCP。互動門檻與豁免分支均有回歸測試。
   - **內建瀏覽器豁免（PM 裁決）**：Threads/IG 等 in-app browser 的「請改用外部瀏覽器開啟」屬功能性逃逸引導（非行銷推廣），且 webview 不在 LH 量測面內——沿用既有 `inAppBrowser` 偵測，此分支維持載入後 1.8s 自動顯示。
   - **scroll 不在互動集合（PM 裁決）**：程式化捲動（scroll restoration／anchor）會在 LCP 未凍結時誤觸 gate；真實捲動必先觸發 touchstart／wheel／pointerdown 之一，招回損失趨近零。
2. `vite.config.ts`：`build.modulePreload.resolveDependencies` 對 `hostType === 'html'` 回傳空集合——首頁 head 不再注入 modulepreload；JS host（動態 import 的依賴預載）行為不變，路由切換無 waterfall 回退。
3. `main.tsx`：靜態 `import 'react-dom/client'`——vite-react-ssg 於 hydrate 時才動態載入，導致 vendor-react（60KB）需等 app chunk 執行後才開始下載。

## UX 行為變更（PM 已裁決）

安裝指引（一般瀏覽器）從「載入後 1.8s 自動彈出」改為「使用者首次互動後 1.8s 彈出」：

- 未互動的過客不再被安裝指引打斷（符合 Chrome「先互動、後推薦安裝」最佳實踐）。
- 有互動意圖的使用者仍會看到完整指引（Android/iOS 分流邏輯、session 關閉記憶均不變）。
- 內建瀏覽器逃逸引導不受影響，維持自動顯示（見上方豁免說明）。
- Puppeteer 實測：互動前不顯示、點擊後 1.8s 正常顯示。

## 已知限制（PM 接受之招回率取捨）

- **pre-hydration 互動漏接**：4G 下約 0–3s 的 hydration 前窗口內發生的互動不會被監聽器捕捉；使用者需在 hydration 完成後再互動一次才起算顯示計時。
- **單次互動後靜止**：互動 gate 為 session 內單向閘門，若使用者互動一次後即靜止離開，本 session 仍會於互動後 1.8s 顯示；但若使用者從未互動，該 session 完全不會看到指引（相較舊行為的自動曝光，此為招回率損失，PM 裁決接受）。

## 紅線驗證

- SSG 輸出語意不變：`verify-ssg-invariance.mjs` base vs current，255 頁 `#root` DOM 零 diff。
- PWA precache 完整性：`sw.js` precache 條目 base=98、current=98。
- Hydration：Puppeteer 行動版載入 console 僅 1 個外部 429（GitHub raw 匯率備援節流，與本 PR 無關），無 hydration mismatch。
- TBT 0ms／CLS 0.002 不回退；`pnpm --filter @app/ratewise exec vitest run` 4077 全綠；pre-commit／pre-push 全過。
- changeset（patch）＋ 002 記錄（reward +1 → 累計 +164）。

## 已知事項（非本 PR 範疇）

- `homepage-modulepreload.test.ts`（opt-in bundle 預算測試，CI 不執行）在 base 已雙項失敗（brotli 208KB > 135KB 預算、vendor-motion 進入首屏圖）。本 PR 使 modulepreload 斷言恢復通過；brotli 預算因 ① 將 vendor-react 計入靜態圖而升至 260KB（實際載入時序不變——vendor-react 原本就在 hydration 前下載）。建議另開 issue 處理首屏 bundle 預算漂移（`seo-metadata` 三檔約 104KB source 佔 app chunk、LH unused-js 估 36KB 可省）。
- 正式站部署後需依 issue 驗收以 cache-busting probe 複測一輪並記錄對照。

Made with [Cursor](https://cursor.com)
