### PR TITLE
ci(ratewise): 刷卡匯率 canary pipeline（ADR-002 Phase 2, Refs #651）

### DIFF
--- a/.github/workflows/update-card-rates.yml
+++ b/.github/workflows/update-card-rates.yml
@@ -1,0 +1,275 @@
+# 刷卡匯率 canary 快照（ADR-002 Phase 2）
+#
+# 職責：每日抓取 Visa/MC 清算匯率，寫入 data 分支 canary/card-rates.json（不接前端）。
+# 姿態：headed browser + xvfb（純 fetch 對兩官方端點皆 403，需真瀏覽器 same-origin context）。
+# canary：僅記錄成功率、驗證 schema 契約；連續 3 日失敗自動開 issue 告警。
+# AGPL 隔離：僅參考 ForexRadar 的 workflow 結構，未複製其原始碼。
+
+name: Update Card Rates (Canary)
+
+# 並發控制：與台銀 5 分鐘排程共用 data-branch-push，避免 push race。
+concurrency:
+  group: data-branch-push
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # 每日一次於 14:02 UTC（美東上午後；避開整點降低掉單機率）。
+    # 時點推定依據（MC 無公開權威 refresh 時鐘，2026-07-08 查證）：
+    # - MC 官方僅說明匯率每日更新一次、週末不發布新匯率；第三方長期觀察當日匯率
+    #   需至日中才可用（github.com/XanderXAJ/mastercardConvert Known issues）。
+    # - MC 總部位於美東；取美東營業日上午後（10:02 EDT）為保守時點。
+    # - 實測 Visa cmsapi lastUpdatedVisaRate ≈ 前日 23:50 UTC，14:02 UTC 時兩來源
+    #   當日匯率均已發布。
+    - cron: '2 14 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/fetch-card-rates.mjs'
+      - 'scripts/lib/card-rates-schema.mjs'
+      - '.github/workflows/update-card-rates.yml'
+
+jobs:
+  update-card-rates:
+    runs-on: ubuntu-latest
+
+    # headed 瀏覽器最易掛起；逾時上限防止佔住 data-branch-push 群組癱瘓台銀 5 分鐘排程。
+    timeout-minutes: 15
+
+    permissions:
+      contents: write
+      issues: write
+
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      CANARY_FILE: public/rates/canary/card-rates.json
+      STATUS_FILE: public/rates/canary/card-rates-status.json
+      CONSECUTIVE_FAILURE_THRESHOLD: '3'
+
+    steps:
+      - name: Checkout data branch
+        uses: actions/checkout@v7
+        with:
+          ref: data
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Create data branch if not exists
+        if: failure()
+        run: |
+          git checkout -b data main
+          git push -u origin data
+          git checkout data
+
+      - name: Sync fetch scripts from triggering ref
+        run: |
+          # 使用觸發 ref 的腳本版本：schedule 為 main HEAD；push/dispatch 為對應分支。
+          git fetch origin ${{ github.sha }}
+          git checkout ${{ github.sha }} -- scripts/fetch-card-rates.mjs
+          git checkout ${{ github.sha }} -- scripts/lib/card-rates-schema.mjs
+          # checkout <sha> -- <path> 會同時寫入 index；必須 unstage，
+          # 否則後續 canary commit 會把程式碼檔混進 data 分支（canary-only 契約）。
+          git restore --staged scripts/fetch-card-rates.mjs scripts/lib/card-rates-schema.mjs
+          mkdir -p public/rates/canary
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Fetch card rates via headed browser (xvfb)
+        id: fetch-rates
+        timeout-minutes: 10
+        continue-on-error: true
+        run: |
+          echo "🤖 Fetching Visa/MC settlement rates via headed browser..."
+          WORK_DIR="$RUNNER_TEMP/card-rates-browser"
+          mkdir -p "$WORK_DIR"
+          cp -r scripts "$WORK_DIR/scripts"
+          pushd "$WORK_DIR" > /dev/null
+          npm init -y > /dev/null
+          npm install --no-audit --no-fund --silent @playwright/test@1.61.1
+          popd > /dev/null
+          # 於暫存目錄執行以解析 @playwright/test，輸出寫回 repo 的 canary 檔。
+          xvfb-run -a node "$WORK_DIR/scripts/fetch-card-rates.mjs" "$GITHUB_WORKSPACE/$CANARY_FILE"
+
+      - name: Record canary success-rate status
+        id: record-status
+        env:
+          FETCH_OUTCOME: ${{ steps.fetch-rates.outcome }}
+          RUN_TRIGGER: ${{ github.event_name }}
+        run: |
+          node -e "
+            const { readFileSync, writeFileSync, mkdirSync, appendFileSync } = require('fs');
+            const path = process.env.STATUS_FILE;
+            const threshold = Number(process.env.CONSECUTIVE_FAILURE_THRESHOLD);
+            const trigger = process.env.RUN_TRIGGER;
+            const ok = process.env.FETCH_OUTCOME === 'success';
+            mkdirSync('public/rates/canary', { recursive: true });
+            let log = [];
+            try { log = JSON.parse(readFileSync(path, 'utf8')).runs ?? []; } catch {}
+            log.push({ date: new Date().toISOString().slice(0, 10), ok, trigger });
+            log = log.slice(-30); // 保留最近 30 筆滾動視窗（涵蓋 14 天 canary）。
+            // 14 天 ≥90% 閘門與連續失敗告警只量測 schedule 排程；
+            // workflow_dispatch 手測與 push 煙霧測試留有紀錄但不污染成功率。
+            const scheduled = log.filter((r) => r.trigger === 'schedule');
+            const recent = scheduled.slice(-threshold);
+            const consecutiveFail = recent.length >= threshold && recent.every((r) => !r.ok);
+            const successRate = scheduled.length
+              ? scheduled.filter((r) => r.ok).length / scheduled.length
+              : 0;
+            writeFileSync(
+              path,
+              JSON.stringify(
+                { runs: log, successRate, scheduledRunCount: scheduled.length },
+                null,
+                2,
+              ) + '\n',
+            );
+            appendFileSync(process.env.GITHUB_OUTPUT, 'consecutive_fail=' + consecutiveFail + '\n');
+            appendFileSync(process.env.GITHUB_OUTPUT, 'success_rate=' + successRate.toFixed(3) + '\n');
+            console.log('canary success rate (schedule-only):', successRate.toFixed(3), 'consecutiveFail:', consecutiveFail);
+          "
+
+      - name: Commit and push canary snapshot
+        id: push-canary
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add "$CANARY_FILE" "$STATUS_FILE" 2>/dev/null || git add "$STATUS_FILE"
+
+          if git diff --cached --quiet; then
+            echo "ℹ️ No canary changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(card-rates): update canary snapshot - $(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            -m "Visa/MC settlement rates (canary, not wired to frontend)" \
+            -m "🤖 ADR-002 Phase 2 canary pipeline"
+
+          git pull --rebase origin data || true
+          for i in 1 2 3; do
+            echo "📤 Attempting to push (try $i/3)..."
+            if git push origin data; then
+              echo "✅ Push successful"
+              break
+            else
+              if [ $i -lt 3 ]; then
+                echo "⚠️ Push failed, retrying in 5 seconds..."
+                sleep 5
+                git pull --rebase origin data || true
+              else
+                echo "❌ Push failed after 3 attempts"
+                exit 1
+              fi
+            fi
+          done
+
+      - name: Purge jsDelivr CDN cache
+        if: steps.fetch-rates.outcome == 'success'
+        run: |
+          echo "🧹 Purging jsDelivr CDN cache..."
+          for URL in \
+            "https://purge.jsdelivr.net/gh/haotool/app@data/public/rates/canary/card-rates.json" \
+            "https://purge.jsdelivr.net/gh/haotool/app@data/public/rates/canary/card-rates-status.json"; do
+            for i in 1 2 3; do
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+              if [ "$HTTP_STATUS" = "200" ]; then
+                echo "✅ Purged ($i): $URL"
+                break
+              else
+                echo "⚠️ Purge attempt $i failed (HTTP $HTTP_STATUS): $URL"
+                if [ $i -lt 3 ]; then sleep 5; fi
+              fi
+            done
+          done
+
+      - name: Refresh canary snapshot from remote data branch
+        id: refresh-remote
+        if: steps.fetch-rates.outcome == 'success'
+        continue-on-error: true
+        run: |
+          # 收尾同步僅用於摘要校對，不得覆蓋已成功的資料推送結果。
+          git rebase --abort 2>/dev/null || true
+          for i in 1 2 3; do
+            echo "🔄 Refreshing canary snapshot from remote (try $i/3)..."
+            if git fetch origin data && git checkout origin/data -- "$CANARY_FILE"; then
+              echo "✅ Remote refresh successful"
+              exit 0
+            fi
+            if [ $i -lt 3 ]; then
+              echo "⚠️ Remote refresh failed, retrying in 5 seconds..."
+              sleep 5
+            fi
+          done
+          echo "❌ Remote refresh failed after 3 attempts"
+          exit 1
+
+      - name: Update workflow summary (success)
+        if: steps.fetch-rates.outcome == 'success'
+        run: |
+          echo "# ✅ Card rates canary snapshot updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** \`data\` → \`$CANARY_FILE\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Canary success rate (schedule-only, rolling):** ${{ steps.record-status.outputs.success_rate }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Currencies:** $(node -p "Object.keys(JSON.parse(require('fs').readFileSync('$CANARY_FILE')).rates).length")" >> $GITHUB_STEP_SUMMARY
+          echo "- **Update time:** $(node -p "JSON.parse(require('fs').readFileSync('$CANARY_FILE')).updateTime")" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> Canary 模式：僅寫 data 分支，未接前端（ADR-002 Phase 2，14 天 ≥90% 才進 Phase 3）。" >> $GITHUB_STEP_SUMMARY
+
+      - name: Update workflow summary (remote refresh warning)
+        if: steps.fetch-rates.outcome == 'success' && steps.refresh-remote.outcome == 'failure'
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## ⚠️ Post-push verification warning" >> $GITHUB_STEP_SUMMARY
+          echo "- Canary push succeeded, but GitHub returned a transient error during post-push refresh." >> $GITHUB_STEP_SUMMARY
+          echo "- The workflow kept the successful update and will verify again on the next run." >> $GITHUB_STEP_SUMMARY
+
+      - name: Open alert issue on consecutive failures
+        if: steps.fetch-rates.outcome != 'success' && steps.record-status.outputs.consecutive_fail == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="[card-rates-canary] 連續 ${CONSECUTIVE_FAILURE_THRESHOLD} 次抓取失敗"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "ℹ️ Alert issue already open, skip"
+            exit 0
+          fi
+          BODY_FILE="$RUNNER_TEMP/card-rates-alert.md"
+          {
+            echo "## 摘要"
+            echo "刷卡匯率 canary pipeline 連續多次抓取失敗（ADR-002 Phase 2）。"
+            echo ""
+            echo "## 背景/證據"
+            echo "- workflow：\`.github/workflows/update-card-rates.yml\`"
+            echo "- 成功率記錄：\`data\` 分支 \`public/rates/canary/card-rates-status.json\`"
+            echo "- 姿態：headed browser + xvfb；官方端點純 fetch 為 403，需真瀏覽器 context"
+            echo ""
+            echo "## 影響"
+            echo "- canary 未達 ≥90% 成功率門檻風險上升；可能觸發 ADR-002 kill criteria 第 3 條（兩輪 14 天 <90%）。"
+            echo ""
+            echo "## 範圍"
+            echo "- 檢查 Visa cmsapi \`/cmsapi/fx/rates\` 與 MC \`conversion-rates\` 端點是否改版"
+            echo "- 檢查邊緣封鎖（Cloudflare/Akamai）姿態是否升級"
+            echo ""
+            echo "## 驗收標準"
+            echo "- 定位失敗根因並修復抓取腳本；canary 恢復連續成功"
+          } > "$BODY_FILE"
+          gh issue create \
+            --title "$TITLE" \
+            --label "bug,severity:p2" \
+            --body-file "$BODY_FILE"
+
+      - name: Fail job to expose persistent outage
+        if: steps.fetch-rates.outcome != 'success'
+        run: |
+          echo "# ⚠️ Card rates canary fetch failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Fetch outcome: ${{ steps.fetch-rates.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Consecutive failure alert: ${{ steps.record-status.outputs.consecutive_fail }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Canary success rate (schedule-only, rolling): ${{ steps.record-status.outputs.success_rate }}" >> $GITHUB_STEP_SUMMARY
+          echo "::error::Card rates canary fetch failed (see canary status log)"
+          exit 1

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+193
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+194
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-08
+- ID：reward-rw-651-card-rate-phase2-canary-pipeline
+- 原因：ADR-002 Phase 2 需 data pipeline 以 canary 模式驗證 Visa/MC 清算匯率抓取排程成功率，前提是官方免費 API 不可用且非官方端點被邊緣封鎖，須先實測確認
+- 解法：瀏覽器實測確認 Visa `/cmsapi/fx/rates` 與 MC `conversion-rates` 純 curl 皆 403（Cloudflare/Akamai）、須 headed same-origin context，官方 Developer API 仍需審核＋mutual TLS／訂閱制（前提成立）；新增 fetch-card-rates.mjs（headed＋xvfb 姿態、雙來源逐幣別、schema 契約過關才寫檔）＋card-rates-schema.mjs SSOT＋9 項 contract test，canary workflow 只寫 data 分支 canary/card-rates.json＋成功率記錄（不接前端）並對齊 data-branch-push concurrency、git 3 重試、post-push refresh continue-on-error、outcome 判定、jsDelivr purge 3 重試、連續 3 日失敗自動開 issue，本地實跑 17 幣別雙來源成功佐證
 
 - 日期：2026-07-08
 - ID：reward-rw-624-ssg-localestring-explicit-locale

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "format:fix": "prettier --write .",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test && pnpm test:root",
-    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/verify-002-log.test.ts",
+    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/fetch-card-rates.test.ts scripts/__tests__/verify-002-log.test.ts",
     "test:unit": "pnpm -r test && pnpm test:root",
     "test:integration": "pnpm --filter @app/ratewise exec vitest run integration",
     "test:e2e": "pnpm --filter @app/ratewise exec playwright test && pnpm --filter @app/nihonname exec playwright test",

--- a/scripts/__tests__/fetch-card-rates.test.ts
+++ b/scripts/__tests__/fetch-card-rates.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CARD_RATE_CURRENCIES,
+  MIN_CARD_RATE_CURRENCIES,
+  validateCardRates,
+} from '../lib/card-rates-schema.mjs';
+
+function buildValidSnapshot() {
+  const rates: Record<string, { visa?: number; mastercard?: number }> = {};
+  for (const currency of CARD_RATE_CURRENCIES) {
+    rates[currency] = { visa: 32.0, mastercard: 32.2 };
+  }
+  return {
+    updateTime: '2026-07-07T19:17:57.063Z',
+    source: {
+      visa: { url: 'https://usa.visa.com/...', fetchedAt: '2026-07-07T19:18:23.088Z' },
+      mastercard: { url: 'https://www.mastercard.com/...', fetchedAt: '2026-07-07T19:18:45.366Z' },
+    },
+    rates,
+  };
+}
+
+describe('card-rates schema contract', () => {
+  it('接受結構完整的快照', () => {
+    expect(validateCardRates(buildValidSnapshot())).toEqual({ valid: true, errors: [] });
+  });
+
+  it('updateTime 非 UTC ISO 時失敗', () => {
+    const snapshot = buildValidSnapshot();
+    snapshot.updateTime = '2026/07/07 19:17:57';
+    const result = validateCardRates(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('updateTime 非 UTC ISO 格式');
+  });
+
+  it('source.visa.fetchedAt 非 UTC ISO 時失敗', () => {
+    const snapshot = buildValidSnapshot();
+    snapshot.source.visa.fetchedAt = 'yesterday';
+    expect(validateCardRates(snapshot).valid).toBe(false);
+  });
+
+  it('幣別數低於熔斷門檻時失敗', () => {
+    const snapshot = buildValidSnapshot();
+    const currencies = CARD_RATE_CURRENCIES as readonly string[];
+    const only = currencies.slice(0, MIN_CARD_RATE_CURRENCIES - 1);
+    snapshot.rates = Object.fromEntries(only.map((c) => [c, { visa: 32, mastercard: 32.2 }]));
+    const result = validateCardRates(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('低於熔斷門檻'))).toBe(true);
+  });
+
+  it('非正數匯率視為髒資料', () => {
+    const snapshot = buildValidSnapshot();
+    snapshot.rates.USD = { visa: 0, mastercard: 32.2 };
+    const result = validateCardRates(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('rates.USD.visa 非正數');
+  });
+
+  it('未知幣別被拒', () => {
+    const snapshot = buildValidSnapshot() as unknown as {
+      rates: Record<string, { visa: number; mastercard: number }>;
+    };
+    snapshot.rates.XXX = { visa: 1, mastercard: 1 };
+    const result = validateCardRates(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('rates.XXX 非支援幣別');
+  });
+
+  it('單一 provider 缺失仍可接受（另一來源有效）', () => {
+    const snapshot = buildValidSnapshot();
+    snapshot.rates.USD = { visa: 32.0 };
+    expect(validateCardRates(snapshot).valid).toBe(true);
+  });
+
+  it('幣別兩 provider 皆缺時失敗', () => {
+    const snapshot = buildValidSnapshot();
+    snapshot.rates.USD = {};
+    const result = validateCardRates(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('rates.USD 無任何 provider 匯率');
+  });
+
+  it('拒絕非物件輸入', () => {
+    expect(validateCardRates(null).valid).toBe(false);
+    expect(validateCardRates('nope' as unknown).valid).toBe(false);
+  });
+});

--- a/scripts/fetch-card-rates.mjs
+++ b/scripts/fetch-card-rates.mjs
@@ -1,0 +1,217 @@
+/**
+ * 刷卡匯率（Visa/MC 清算匯率）快照抓取腳本（ADR-002 Phase 2 canary）。
+ *
+ * 姿態：headed browser（workflow 以 xvfb-run 執行）。純 fetch/curl 對兩官方端點皆回 403
+ * （Visa Cloudflare、MC Akamai 邊緣封鎖），必須在通過邊緣驗證的真瀏覽器 same-origin
+ * context 內呼叫頁面本身使用的 XHR 端點。
+ *   - Visa：計算器 widget 的 GET /cmsapi/fx/rates（cmsapi 直打）。
+ *   - MC：貨幣轉換器的 GET .../currency-conversions/conversion-rates（頁面 XHR 端點）。
+ *
+ * 職責單一：取得雙來源清算匯率、通過 schema 契約後才寫檔；髒資料不落地。
+ * AGPL 隔離：僅參考 ForexRadar 的 workflow 結構，未複製其原始碼。
+ *
+ * 用法：node scripts/fetch-card-rates.mjs [輸出檔路徑]
+ *   預設輸出：public/rates/canary/card-rates.json（canary 模式，不接前端）。
+ * 依賴：@playwright/test（workflow 於暫存目錄按需安裝）＋系統 Chrome（runner 預裝）。
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+
+import {
+  CARD_RATE_CURRENCIES,
+  MIN_CARD_RATE_CURRENCIES,
+  validateCardRates,
+} from './lib/card-rates-schema.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const DEFAULT_OUTPUT = join(REPO_ROOT, 'public', 'rates', 'canary', 'card-rates.json');
+
+const VISA_PAGE =
+  'https://usa.visa.com/support/consumer/travel-support/exchange-rate-calculator.html';
+const VISA_API = '/cmsapi/fx/rates';
+const MC_PAGE =
+  'https://www.mastercard.com/us/en/personal/get-support/currency-exchange-rate-converter.html';
+const MC_API =
+  'https://www.mastercard.com/marketingservices/public/mccom-services/currency-conversions/conversion-rates';
+
+// 禮貌原則：同來源逐幣別查詢間隔，避免高頻。
+const PER_QUERY_DELAY_MS = 700;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function todayParts() {
+  const now = new Date();
+  return {
+    yyyy: now.getUTCFullYear(),
+    mm: String(now.getUTCMonth() + 1).padStart(2, '0'),
+    dd: String(now.getUTCDate()).padStart(2, '0'),
+  };
+}
+
+async function launchBrowser() {
+  // 系統 Chrome 指紋最接近真實使用者；失敗退回 bundled chromium。
+  for (const channel of ['chrome', undefined]) {
+    try {
+      return await chromium.launch({ headless: false, channel });
+    } catch (error) {
+      console.warn(`⚠️ launch via ${channel ?? 'bundled chromium'} failed: ${error.message}`);
+    }
+  }
+  throw new Error('無法啟動瀏覽器（chrome 與 bundled chromium 皆失敗）');
+}
+
+/** Visa：頁面 context 內打 /cmsapi/fx/rates，回傳 TWD per 1 foreign（fxRateVisa）。 */
+async function fetchVisaRates(page) {
+  await page.goto(VISA_PAGE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await sleep(1500);
+  const { mm, dd, yyyy } = todayParts();
+  const dateStr = `${mm}/${dd}/${yyyy}`;
+  const rates = {};
+
+  for (const currency of CARD_RATE_CURRENCIES) {
+    try {
+      const value = await page.evaluate(
+        async ({ api, dateStr, currency }) => {
+          // fromCurr=TWD、toCurr=foreign → 回應 fxRateVisa = TWD per 1 foreign。
+          const qs = new URLSearchParams({
+            amount: '1',
+            fee: '0.0',
+            utcConvertedDate: dateStr,
+            exchangedate: dateStr,
+            fromCurr: 'TWD',
+            toCurr: currency,
+          });
+          const res = await fetch(`${api}?${qs.toString()}`, {
+            headers: { accept: 'application/json' },
+          });
+          if (!res.ok) return { error: `HTTP ${res.status}` };
+          const json = await res.json();
+          const rate = Number(json?.originalValues?.fxRateVisa);
+          return Number.isFinite(rate) ? { rate } : { error: 'no fxRateVisa' };
+        },
+        { api: VISA_API, dateStr, currency },
+      );
+      if (typeof value.rate === 'number') {
+        rates[currency] = value.rate;
+      } else {
+        console.warn(`  ⚠️ Visa ${currency}: ${value.error}`);
+      }
+    } catch (error) {
+      console.warn(`  ⚠️ Visa ${currency} failed: ${error.message}`);
+    }
+    await sleep(PER_QUERY_DELAY_MS);
+  }
+  return rates;
+}
+
+/** MC：頁面 context 內打 conversion-rates，回傳 TWD per 1 foreign（conversionRate）。 */
+async function fetchMastercardRates(page) {
+  await page.goto(MC_PAGE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await sleep(2000);
+  const rates = {};
+
+  for (const currency of CARD_RATE_CURRENCIES) {
+    try {
+      const value = await page.evaluate(
+        async ({ api, currency }) => {
+          // transaction_currency=foreign、billing=TWD → conversionRate = TWD per 1 foreign。
+          // exchange_date=0000-00-00 取當前最新清算匯率（頁面預設）。
+          const qs = new URLSearchParams({
+            exchange_date: '0000-00-00',
+            transaction_currency: currency,
+            cardholder_billing_currency: 'TWD',
+            bank_fee: '0',
+            transaction_amount: '1',
+          });
+          const res = await fetch(`${api}?${qs.toString()}`, {
+            headers: { accept: 'application/json' },
+          });
+          if (!res.ok) return { error: `HTTP ${res.status}` };
+          const json = await res.json();
+          const rate = Number(json?.data?.conversionRate);
+          return Number.isFinite(rate) ? { rate } : { error: 'no conversionRate' };
+        },
+        { api: MC_API, currency },
+      );
+      if (typeof value.rate === 'number') {
+        rates[currency] = value.rate;
+      } else {
+        console.warn(`  ⚠️ MC ${currency}: ${value.error}`);
+      }
+    } catch (error) {
+      console.warn(`  ⚠️ MC ${currency} failed: ${error.message}`);
+    }
+    await sleep(PER_QUERY_DELAY_MS);
+  }
+  return rates;
+}
+
+function mergeRates(visaRates, mcRates) {
+  const merged = {};
+  for (const currency of CARD_RATE_CURRENCIES) {
+    const entry = {};
+    if (typeof visaRates[currency] === 'number') entry.visa = visaRates[currency];
+    if (typeof mcRates[currency] === 'number') entry.mastercard = mcRates[currency];
+    if (Object.keys(entry).length > 0) merged[currency] = entry;
+  }
+  return merged;
+}
+
+async function main() {
+  const outputFile = process.argv[2] || DEFAULT_OUTPUT;
+  const browser = await launchBrowser();
+  const nowIso = new Date().toISOString();
+
+  try {
+    const context = await browser.newContext({ locale: 'en-US', timezoneId: 'America/New_York' });
+
+    console.log('🌐 Fetching Visa settlement rates...');
+    const visaPage = await context.newPage();
+    const visaRates = await fetchVisaRates(visaPage);
+    const visaFetchedAt = new Date().toISOString();
+    console.log(`  ✅ Visa: ${Object.keys(visaRates).length} currencies`);
+
+    console.log('🌐 Fetching Mastercard settlement rates...');
+    const mcPage = await context.newPage();
+    const mcRates = await fetchMastercardRates(mcPage);
+    const mcFetchedAt = new Date().toISOString();
+    console.log(`  ✅ Mastercard: ${Object.keys(mcRates).length} currencies`);
+
+    const snapshot = {
+      updateTime: nowIso,
+      source: {
+        visa: { url: VISA_PAGE, fetchedAt: visaFetchedAt },
+        mastercard: { url: MC_PAGE, fetchedAt: mcFetchedAt },
+      },
+      rates: mergeRates(visaRates, mcRates),
+    };
+
+    const { valid, errors } = validateCardRates(snapshot);
+    if (!valid) {
+      console.error('❌ Schema contract failed — refusing to write:');
+      for (const err of errors) console.error(`   - ${err}`);
+      process.exit(1);
+    }
+
+    const currencyCount = Object.keys(snapshot.rates).length;
+    if (currencyCount < MIN_CARD_RATE_CURRENCIES) {
+      console.error(`❌ Only ${currencyCount} currencies (< ${MIN_CARD_RATE_CURRENCIES})`);
+      process.exit(1);
+    }
+
+    mkdirSync(dirname(outputFile), { recursive: true });
+    writeFileSync(outputFile, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+    console.log(`✅ Wrote ${currencyCount} currencies to ${outputFile}`);
+    console.log(
+      `   Sample USD: visa=${snapshot.rates.USD?.visa}, mc=${snapshot.rates.USD?.mastercard}`,
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+await main();

--- a/scripts/lib/card-rates-schema.mjs
+++ b/scripts/lib/card-rates-schema.mjs
@@ -1,0 +1,103 @@
+// 刷卡匯率快照 schema 契約（SSOT）。抓取腳本與 contract test 共用，杜絕 schema drift。
+// 快照語意：rates[幣別].{visa,mastercard} = 1 單位外幣的清算 TWD 金額（TWD per 1 foreign unit）。
+
+/** 支援的刷卡幣別（TWD 為帳單幣別，故不列於外幣清單）。對齊 latest.json 幣別集。 */
+export const CARD_RATE_CURRENCIES = Object.freeze([
+  'USD',
+  'HKD',
+  'GBP',
+  'AUD',
+  'CAD',
+  'SGD',
+  'CHF',
+  'JPY',
+  'NZD',
+  'THB',
+  'PHP',
+  'IDR',
+  'EUR',
+  'KRW',
+  'VND',
+  'MYR',
+  'CNY',
+]);
+
+/** 至少要有這麼多幣別成功，快照才算有效（canary 熔斷，防半套髒資料）。 */
+export const MIN_CARD_RATE_CURRENCIES = 10;
+
+const UTC_ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+function isFiniteRate(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function validateSourceEntry(errors, label, entry) {
+  if (typeof entry !== 'object' || entry === null) {
+    errors.push(`source.${label} 缺失或非物件`);
+    return;
+  }
+  if (typeof entry.url !== 'string' || entry.url.length === 0) {
+    errors.push(`source.${label}.url 缺失`);
+  }
+  if (typeof entry.fetchedAt !== 'string' || !UTC_ISO_PATTERN.test(entry.fetchedAt)) {
+    errors.push(`source.${label}.fetchedAt 非 UTC ISO`);
+  }
+}
+
+/**
+ * 驗證刷卡匯率快照結構。回傳 { valid, errors }；errors 為訊息陣列。
+ * 純函式、零依賴，供 contract test 與抓取腳本 commit 前置檢查共用。
+ */
+export function validateCardRates(data) {
+  const errors = [];
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['快照非物件'] };
+  }
+
+  if (typeof data.updateTime !== 'string' || !UTC_ISO_PATTERN.test(data.updateTime)) {
+    errors.push('updateTime 非 UTC ISO 格式');
+  }
+
+  if (typeof data.source !== 'object' || data.source === null) {
+    errors.push('source 缺失');
+  } else {
+    validateSourceEntry(errors, 'visa', data.source.visa);
+    validateSourceEntry(errors, 'mastercard', data.source.mastercard);
+  }
+
+  if (typeof data.rates !== 'object' || data.rates === null) {
+    errors.push('rates 缺失');
+    return { valid: errors.length === 0, errors };
+  }
+
+  const currencyKeys = Object.keys(data.rates);
+  if (currencyKeys.length < MIN_CARD_RATE_CURRENCIES) {
+    errors.push(`rates 幣別數 ${currencyKeys.length} 低於熔斷門檻 ${MIN_CARD_RATE_CURRENCIES}`);
+  }
+
+  for (const [currency, entry] of Object.entries(data.rates)) {
+    if (!CARD_RATE_CURRENCIES.includes(currency)) {
+      errors.push(`rates.${currency} 非支援幣別`);
+      continue;
+    }
+    if (typeof entry !== 'object' || entry === null) {
+      errors.push(`rates.${currency} 非物件`);
+      continue;
+    }
+    // 每幣別至少要有一個 provider 的有效匯率；兩者皆缺視為髒資料。
+    const hasVisa = 'visa' in entry;
+    const hasMc = 'mastercard' in entry;
+    if (!hasVisa && !hasMc) {
+      errors.push(`rates.${currency} 無任何 provider 匯率`);
+    }
+    if (hasVisa && !isFiniteRate(entry.visa)) {
+      errors.push(`rates.${currency}.visa 非正數`);
+    }
+    if (hasMc && !isFiniteRate(entry.mastercard)) {
+      errors.push(`rates.${currency}.mastercard 非正數`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
## 摘要

ADR-002 Phase 2：新增刷卡匯率（Visa/MC 清算匯率）canary data pipeline。**canary 模式僅寫 data 分支，不接前端**；14 天觀察成功率 ≥90% 才進 Phase 3。

`Refs #651`（Phase 2 canary，不 close）。

## 官方管道實測結論（最重要）

使用者指示以 headed 瀏覽器實測官方查詢管道與 API 可接入性，結論如下：

| 來源 | 頁面查詢管道 | 純 curl/fetch | 官方 Developer API 門檻 |
|---|---|---|---|
| **Visa** | 計算器 widget `GET /cmsapi/fx/rates`（回 JSON `originalValues.fxRateVisa`） | **HTTP 403**（Cloudflare "Just a moment"） | FX Rates API 需 sandbox→production **審核**＋**mutual TLS（Two-Way SSL）**＋簽約＋production fees |
| **Mastercard** | 轉換器 `GET .../currency-conversions/conversion-rates`（回 JSON `data.conversionRate`） | **HTTP 403**（Akamai Access Denied） | Currency Conversion Calculator API 為**訂閱制**，需 onboarding＋partner ID＋專案經理＋機構別報價 |

實測證據（各查 1 筆，禮貌原則）：
- Visa `1 USD = 32.039 TWD`（`fxRateVisa`）
- Mastercard `1 USD ≈ 32.19 TWD`（`conversionRate` 反向查得）

**判定：無免審核可直接接入的官方 API**。兩官方 Developer API 皆需審核／簽約／訂閱；兩公開查詢端點純 curl 皆 403，僅能在通過邊緣驗證的真瀏覽器 same-origin context 內呼叫——**與 ADR-002 前提完全一致，續行 Playwright canary 路線，無需改走官方 API**。

## 本地抓取成功證據

`node scripts/fetch-card-rates.mjs` 本地實跑：**17 幣別 × 雙來源全數成功**，schema contract 通過後寫檔。樣本 `USD: visa=32.039, mastercard=32.1932175`（雙來源差異 <0.5%，與台銀牌告同區間，合理）。

## 變更內容

- `scripts/fetch-card-rates.mjs`：headed browser＋xvfb 姿態，Visa cmsapi 直打＋MC 頁面 XHR 端點，逐幣別禮貌延遲，schema 契約過關才寫檔（髒資料不落地）。
- `scripts/lib/card-rates-schema.mjs`：schema SSOT（`validateCardRates`），抓取腳本與測試共用杜絕 drift。
- `scripts/__tests__/fetch-card-rates.test.ts`：9 項 contract test（掛 `test:root`）。
- `.github/workflows/update-card-rates.yml`：canary workflow。
- 更新 `docs/dev/002`（reward-rw-651-card-rate-phase2-canary-pipeline）。

## card-rates.json schema

\`\`\`
{ updateTime(UTC ISO), source: { visa: {url, fetchedAt}, mastercard: {url, fetchedAt} },
  rates: { USD: { visa, mastercard }, ... } }   // rates = 1 單位外幣的清算 TWD 金額
\`\`\`

## AGENTS.md 同型 workflow 條款對齊表

| 條款 | 落地 |
|---|---|
| `data-branch-push` concurrency group | ✅ 與台銀 5 分鐘排程互斥 |
| git 操作 3 次重試 | ✅ push 迴圈 3 retry |
| post-push refresh `continue-on-error` | ✅ `refresh-remote` step |
| summary 以 `steps.<id>.outcome` 判定 | ✅ 全程 outcome（未用 conclusion） |
| jsDelivr purge 3 次重試 | ✅ canary json＋status 皆 purge |
| 每日 1 次（MC 日切後） | ✅ cron `2 14 * * *`（14:02 UTC = 22:02 台北；時點推定依據見 workflow 註解） |
| schema contract 為 commit 前置 | ✅ 抓取腳本內建、髒資料不寫 |

## 審查修正（REQUEST CHANGES 回應）

1. **timeout 防掛起**：job `timeout-minutes: 15`＋抓取 step `timeout-minutes: 10`——headed 瀏覽器掛起不再佔住 `data-branch-push` concurrency group（原 GitHub 預設上限 6 小時會癱瘓台銀 5 分鐘排程）。
2. **status.json 成功率隔離**：每筆 run 記錄新增 `trigger` 欄位（`github.event_name`）；**14 天 ≥90% 閘門與連續失敗告警只量測 `schedule`**，`workflow_dispatch` 手測與 `push` 煙霧測試留有紀錄但不污染成功率（status 檔另輸出 `scheduledRunCount`）。
3. **002 重算**：rebase 至 experiment 最新 head 後依實際 base（+193）重算為 **+194**，`verify-002-log.mjs` 通過。
4. **cron 依據**：MC 無公開權威 refresh 時鐘（2026-07-08 查證）；採保守時點 14:02 UTC（美東營業日上午後），推定依據（MC 官方「每日更新一次、週末不發布」＋第三方長期觀察「日中才可用」＋Visa lastUpdatedVisaRate 實測）已入 workflow 註解。
5. **MC 抓取姿態偏離申報**：見下方「ADR-002 姿態偏離申報」。
6. **canary 時鐘現實**：見下方「14 天 canary 觀察計畫」。

## ADR-002 姿態偏離申報（MC 抓取）

ADR-002 技術姿態寫「MC 走 **UI 模擬＋攔截 conversion-rate XHR**」；本實作為 headed 真瀏覽器載入 MC 轉換器頁面後，於頁面 same-origin context 內以 `page.evaluate` **直接呼叫頁面本身使用的 `conversion-rates` XHR 端點**（不模擬表單操作、不攔截 response）。申報偏離理由：

1. **信任邊界相同**：兩姿態皆依賴通過 Akamai 邊緣驗證的真瀏覽器 same-origin context；差異僅在觸發方式，端點、參數與回應 schema 與頁面 UI 實際使用者完全一致。
2. **脆弱面更小**：UI 模擬需依賴 17 幣別 × 表單 selector（上游改版面即斷裂）；直呼 JSON 端點只依賴端點契約，且 schema contract test 已守門。
3. **禮貌性更佳**：免去逐幣別表單互動與重複頁面載入，以單次頁面載入＋700ms 逐幣別延遲維持低頻。
4. **canary 即為此姿態的存活率量測**：若 14 天成功率不達標，退回 ADR 字面 UI 模擬攔截姿態屬 pipeline 修正選項，修正後重新起算。

Visa 側 cmsapi 直打與 ADR-002 一致，無偏離。

## canary 專屬

- 僅寫 `public/rates/canary/card-rates.json`（data 分支），**不接前端**。
- 成功率記錄 `public/rates/canary/card-rates-status.json`（滾動 30 筆）。
- 連續 3 日失敗 → 自動開 issue 告警（去重）＋job 失敗曝光。

## AGPL 隔離

僅參考 ForexRadar workflow 結構，**未複製其原始碼**。

## 14 天 canary 觀察計畫

**時鐘現實**：GitHub Actions `schedule` cron 只在 default branch（main）生效；本 PR base 為 `experiment/ratewise-product-2026h2`，合入 experiment 期間 cron 不會排程。**14 天 canary 時鐘自 experiment→main 合併後起算**。

1. workflow 檔進 main 後每日排程（`2 14 * * *`）；追蹤 `card-rates-status.json` 的 `successRate`（只計 `schedule` trigger）。
2. 手測入口：`workflow_dispatch`（進 main 後可由 UI／`gh workflow run` 觸發；手測 run 記錄帶 `trigger` 欄位，不計入成功率）。`push` paths 觸發則作為腳本變更的煙霧測試。
3. 觀察期 14 天，門檻**成功率 ≥90%** 且 schema contract 全過 → 進 Phase 3（前端切換真實清算價＋降級層＋文案同步）。
4. 未達門檻 → 停留 Phase 1 估算模式，修正 pipeline 後重新起算（ADR-002 kill criteria 第 3 條：兩輪各 14 天仍 <90% 即永久降級）。

## 測試

- `pnpm typecheck` 全綠。
- `pnpm test:root` 46 通過（含 9 項新 contract test）。
- workflow YAML 解析通過。
- 本地實跑抓取 17 幣別雙來源成功。
- pre-commit / pre-push 全過（另兩測試檔 `FAQ.test.tsx`、`SingleConverter.trend.test.tsx` 在完整套件偶發 flaky，單獨重跑皆通過，與本變更無關）。

## 不 merge

本 PR 僅供審查，**請勿 merge**。

Made with [Cursor](https://cursor.com)
