### PR TITLE
ci(scripts): 002 記分守門 CI 端強制——base-ref 模式驗 PR 最終態 vs merge-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
+      # 002 記分守門 CI 端強制（issue #661）：驗 PR 最終態 vs merge-base，堵 --no-verify 與網頁端 merge 繞過。
+      # 002 未變更時毫秒級跳過；與 pre-commit 共用 validate002 核心，零 npm 依賴故置於 install 前搶先紅燈。
+      - name: Verify 002 log (vs merge-base)
+        if: github.event_name == 'pull_request'
+        run: node scripts/verify-002-log.mjs --base-ref "${{ github.event.pull_request.base.sha }}"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+202
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+203
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-08
+- ID：reward-rw-661-002-ci-merge-base-guard
+- 原因：#652 的 002 記分守門只掛 pre-commit，--no-verify 與 GitHub 網頁端 merge/squash 均可繞過；CI 只跑守門單元測試、不對實際 002 檔案 vs merge-base 對帳（issue 661）
+- 解法：verify-002-log.mjs 增設 --base-ref 入口與 pre-commit 共用同一 validate002 核心（HEAD＝PR 最終態 vs merge-base、002 未變更毫秒級跳過、整檔刪除必紅），Quality Checks 於 install 前加 PR 專屬守門步驟（零 npm 依賴搶先紅燈），vitest 補 6 條臨時 git repo 整合測試（計數不符必紅／正確 append／未變更跳過／多 commit 只驗最終態／merge-base 非 base tip／刪檔必紅）並以構造壞版分支本地重演 CI 紅燈
 
 - 日期：2026-07-08
 - ID：reward-rw-666-persisted-hydration-inventory

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@eslint/js": "^9.39.2",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.61.1",
+    "@types/node": "^24",
     "@vitejs/plugin-react": "^6.0.1",
     "depcheck": "^1.4.7",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,10 @@ importers:
         version: 0.6.0
       '@changesets/cli':
         specifier: ^2.29.8
-        version: 2.29.8(@types/node@25.0.3)
+        version: 2.29.8(@types/node@24.10.1)
       '@commitlint/cli':
         specifier: ^21.0.0
-        version: 21.0.0(@types/node@25.0.3)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.0.0(@types/node@24.10.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^20.3.1
         version: 20.3.1
@@ -85,9 +85,12 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@types/node':
+        specifier: ^24
+        version: 24.10.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -114,7 +117,7 @@ importers:
         version: 27.4.0
       knip:
         specifier: ^5.83.1
-        version: 5.83.1(@types/node@25.0.3)(typescript@5.9.3)
+        version: 5.83.1(@types/node@24.10.1)(typescript@5.9.3)
       lighthouse:
         specifier: ^13.0.1
         version: 13.0.1
@@ -135,13 +138,13 @@ importers:
         version: 8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       unlighthouse:
         specifier: ^0.17.4
-        version: 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)
+        version: 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)
       vite:
         specifier: '>=8.0.10'
-        version: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
+        version: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -3693,9 +3696,6 @@ packages:
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
-
-  '@types/node@25.0.3':
-    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -10122,7 +10122,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.8(@types/node@25.0.3)':
+  '@changesets/cli@2.29.8(@types/node@24.10.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -10138,7 +10138,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.0.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -10255,11 +10255,11 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@commitlint/cli@21.0.0(@types/node@25.0.3)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.0.0(@types/node@24.10.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 21.0.0
       '@commitlint/lint': 21.0.0
-      '@commitlint/load': 21.0.0(@types/node@25.0.3)(typescript@5.9.3)
+      '@commitlint/load': 21.0.0(@types/node@24.10.1)(typescript@5.9.3)
       '@commitlint/read': 21.0.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.0
       tinyexec: 1.1.2
@@ -10304,14 +10304,14 @@ snapshots:
       '@commitlint/rules': 21.0.0
       '@commitlint/types': 21.0.0
 
-  '@commitlint/load@21.0.0(@types/node@25.0.3)(typescript@5.9.3)':
+  '@commitlint/load@21.0.0(@types/node@24.10.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.0
       '@commitlint/execute-rule': 21.0.0
       '@commitlint/resolve-extends': 21.0.0
       '@commitlint/types': 21.0.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.0.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.10.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -10833,12 +10833,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.0.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 25.0.3
+      '@types/node': 24.10.1
 
   '@internationalized/date@3.10.0':
     dependencies:
@@ -10967,32 +10967,32 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 3.20.1(magicast@0.5.2)
       execa: 8.0.1
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.2)
       execa: 8.0.1
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/fonts@0.12.1(idb-keyval@6.2.2)(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
+  '@nuxt/fonts@0.12.1(idb-keyval@6.2.2)(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       '@nuxt/kit': 4.2.1(magicast@0.5.2)
       consola: 3.4.2
       css-tree: 3.1.0
       defu: 6.1.6
       esbuild: 0.25.12
       fontaine: 0.7.0
-      fontless: 0.1.0(idb-keyval@6.2.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      fontless: 0.1.0(idb-keyval@6.2.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       h3: 1.15.9
       jiti: 2.7.0
       magic-regexp: 0.10.0
@@ -11029,13 +11029,13 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.1.0(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))':
+  '@nuxt/icon@2.1.0(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.625
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.0
       '@iconify/vue': 5.0.0(vue@3.5.25(typescript@5.9.3))
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       '@nuxt/kit': 4.2.1(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
@@ -11109,19 +11109,19 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 3.10.0
 
-  '@nuxt/ui@4.2.1(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)':
+  '@nuxt/ui@4.2.1(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)':
     dependencies:
       '@iconify/vue': 5.0.0(vue@3.5.25(typescript@5.9.3))
       '@internationalized/date': 3.10.0
       '@internationalized/number': 3.6.5
-      '@nuxt/fonts': 0.12.1(idb-keyval@6.2.2)(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
-      '@nuxt/icon': 2.1.0(magicast@0.5.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))
+      '@nuxt/fonts': 0.12.1(idb-keyval@6.2.2)(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      '@nuxt/icon': 2.1.0(magicast@0.5.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))
       '@nuxt/kit': 4.2.1(magicast@0.5.2)
       '@nuxt/schema': 4.2.1
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.0.0
       '@tailwindcss/postcss': 4.1.17
-      '@tailwindcss/vite': 4.2.1(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      '@tailwindcss/vite': 4.2.1(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       '@tanstack/vue-table': 8.21.3(vue@3.5.25(typescript@5.9.3))
       '@tanstack/vue-virtual': 3.13.12(vue@3.5.25(typescript@5.9.3))
       '@unhead/vue': 2.0.19(vue@3.5.25(typescript@5.9.3))
@@ -12214,13 +12214,6 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
 
-  '@tailwindcss/vite@4.2.1(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
-    dependencies:
-      '@tailwindcss/node': 4.2.1
-      '@tailwindcss/oxide': 4.2.1
-      tailwindcss: 4.2.1
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
-
   '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.13.12': {}
@@ -12501,10 +12494,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.0.3':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -12649,10 +12638,10 @@ snapshots:
       unhead: 2.1.13
       vue: 3.5.25(typescript@5.9.3)
 
-  '@unlighthouse/cli@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)':
+  '@unlighthouse/cli@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)':
     dependencies:
       '@lhci/utils': 0.15.1
-      '@unlighthouse/client': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
+      '@unlighthouse/client': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
       '@unlighthouse/core': 0.17.4(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(rollup@4.59.0)
       '@unlighthouse/server': 0.17.4(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(rollup@4.59.0)
       better-opn: 3.0.2
@@ -12722,11 +12711,11 @@ snapshots:
       - yup
       - zod
 
-  '@unlighthouse/client@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)':
+  '@unlighthouse/client@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)':
     dependencies:
       '@headlessui/vue': 1.7.23(vue@3.5.25(typescript@5.9.3))
-      '@nuxt/ui': 4.2.1(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)
-      '@tailwindcss/vite': 4.2.1(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
+      '@nuxt/ui': 4.2.1(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13)
+      '@tailwindcss/vite': 4.2.1(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
       dayjs: 1.11.19
       defu: 6.1.6
       fuse.js: 7.1.0
@@ -12913,11 +12902,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
-
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -12956,14 +12940,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -13861,9 +13837,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@25.0.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.10.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 24.10.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -14800,7 +14776,7 @@ snapshots:
       unicode-properties: 1.4.1
       unicode-trie: 2.0.0
 
-  fontless@0.1.0(idb-keyval@6.2.2)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
+  fontless@0.1.0(idb-keyval@6.2.2)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.1.0
@@ -14816,7 +14792,7 @@ snapshots:
       unifont: 0.6.0
       unstorage: 1.17.3(idb-keyval@6.2.2)
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15728,10 +15704,10 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.83.1(@types/node@25.0.3)(typescript@5.9.3):
+  knip@5.83.1(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 25.0.3
+      '@types/node': 24.10.1
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
@@ -18274,10 +18250,10 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlighthouse@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13):
+  unlighthouse@0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.25(typescript@5.9.3))(zod@4.1.13):
     dependencies:
-      '@unlighthouse/cli': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
-      '@unlighthouse/client': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
+      '@unlighthouse/cli': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
+      '@unlighthouse/client': 0.17.4(@babel/parser@7.29.7)(axios@1.18.1)(embla-carousel@8.6.0)(idb-keyval@6.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))(zod@4.1.13)
       '@unlighthouse/core': 0.17.4(magicast@0.5.2)(puppeteer@24.32.0(typescript@5.9.3))(rollup@4.59.0)
     optionalDependencies:
       puppeteer: 24.32.0(typescript@5.9.3)
@@ -18631,21 +18607,6 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.3
 
-  vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.0.3
-      esbuild: 0.27.2
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.44.1
-      yaml: 2.8.3
-
   vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.27.2)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
@@ -18701,36 +18662,6 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.10.1
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      jsdom: 27.4.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@27.4.0)(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.0.3)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.44.1)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.0.3
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       jsdom: 27.4.0
     transitivePeerDependencies:

--- a/scripts/__tests__/lighthouse-production.test.ts
+++ b/scripts/__tests__/lighthouse-production.test.ts
@@ -48,9 +48,10 @@ describe('lighthouse-production SSOT controls', () => {
 
   it('keeps refreshed summary fields after spreading an existing baseline', () => {
     const source = readFileSync(SCRIPT_PATH, 'utf8');
-    const existingBaselineWrite = source.match(
-      /JSON\.stringify\(\s*\{\s*\.\.\.baseline[\s\S]*?paths: summary\.paths,[\s\S]*?\}\s*,\s*null,\s*2,\s*\)/,
-    );
+    const existingBaselineWrite =
+      /JSON\.stringify\(\s*\{\s*\.\.\.baseline[\s\S]*?paths: summary\.paths,[\s\S]*?\}\s*,\s*null,\s*2,\s*\)/.exec(
+        source,
+      );
 
     expect(existingBaselineWrite).not.toBeNull();
     const existingBaselineWriteBlock = existingBaselineWrite?.[0];

--- a/scripts/__tests__/verify-002-log.test.ts
+++ b/scripts/__tests__/verify-002-log.test.ts
@@ -258,8 +258,10 @@ describe('validate002', () => {
 describe('--base-ref 模式（CI 語意，issue #661）', () => {
   const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'verify-002-log.mjs');
   // 隔離全域/系統 git config（gpgsign、hooksPath 等），身分改由環境變數提供。
+  // 先剝除繼承的 GIT_* 變數：hook 環境（pre-push 跑 vitest）會注入 GIT_DIR/GIT_INDEX_FILE，
+  // 子行程若繼承會把臨時 repo 的 git 操作導向父 repo。
   const GIT_ENV = {
-    ...process.env,
+    ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))),
     GIT_CONFIG_GLOBAL: '/dev/null',
     GIT_CONFIG_SYSTEM: '/dev/null',
     GIT_AUTHOR_NAME: 'vitest',
@@ -306,6 +308,7 @@ describe('--base-ref 模式（CI 語意，issue #661）', () => {
     try {
       const stdout = execFileSync('node', [SCRIPT_PATH, '--base-ref', baseRef], {
         cwd: repo,
+        env: GIT_ENV,
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'pipe'],
       });

--- a/scripts/__tests__/verify-002-log.test.ts
+++ b/scripts/__tests__/verify-002-log.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
+  LOG_PATH as LOG_PATH_UNTYPED,
   parseEntries,
   parsePreviousTotal,
   parseStrictHeader,
   validate002,
 } from '../verify-002-log.mjs';
+
+// .mjs 無型別宣告，正規化為 string 供路徑參數使用（維持 SSOT、不複製字面值）。
+const LOG_PATH = String(LOG_PATH_UNTYPED);
 
 function buildLog({
   header,
@@ -243,5 +252,171 @@ describe('validate002', () => {
       ],
     });
     expect(validate002({ stagedContent: staged, headContent: head }).errors).toEqual([]);
+  });
+});
+
+describe('--base-ref 模式（CI 語意，issue #661）', () => {
+  const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'verify-002-log.mjs');
+  // 隔離全域/系統 git config（gpgsign、hooksPath 等），身分改由環境變數提供。
+  const GIT_ENV = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_SYSTEM: '/dev/null',
+    GIT_AUTHOR_NAME: 'vitest',
+    GIT_AUTHOR_EMAIL: 'vitest@example.com',
+    GIT_COMMITTER_NAME: 'vitest',
+    GIT_COMMITTER_EMAIL: 'vitest@example.com',
+  };
+  const repos: string[] = [];
+
+  afterEach(() => {
+    for (const repo of repos.splice(0)) {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  function git(cwd: string, ...args: string[]) {
+    // stderr 收進 pipe，避免 checkout 等訊息污染測試輸出。
+    return execFileSync('git', args, {
+      cwd,
+      env: GIT_ENV,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  function commitLog(repo: string, content: string, message: string) {
+    writeFileSync(join(repo, LOG_PATH), content);
+    git(repo, 'add', '--all');
+    git(repo, 'commit', '-m', message);
+  }
+
+  // 建立 main 上有基準 002 的臨時 repo，並切到 pr 分支模擬 PR HEAD。
+  function setupRepo() {
+    const repo = mkdtempSync(join(tmpdir(), 'verify-002-'));
+    repos.push(repo);
+    git(repo, 'init', '-b', 'main');
+    mkdirSync(join(repo, dirname(LOG_PATH)), { recursive: true });
+    commitLog(repo, HEAD_CONTENT, 'init');
+    git(repo, 'checkout', '-b', 'pr');
+    return repo;
+  }
+
+  function runGuard(repo: string, baseRef: string) {
+    try {
+      const stdout = execFileSync('node', [SCRIPT_PATH, '--base-ref', baseRef], {
+        cwd: repo,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { status: 0, output: stdout };
+    } catch (error) {
+      const failed = error as { status?: number | null; stdout?: string; stderr?: string };
+      return {
+        status: failed.status ?? 1,
+        output: `${failed.stdout ?? ''}${failed.stderr ?? ''}`,
+      };
+    }
+  }
+
+  it('構造計數不符的 PR 最終態必紅', () => {
+    const repo = setupRepo();
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+2（reward 2、penalty 0、neutral 0）｜累計總分：+172',
+        entries: [{ id: 'reward-new-entry' }, { id: 'reward-existing-entry' }],
+      }),
+      'bad count',
+    );
+    const { status, output } = runGuard(repo, 'main');
+    expect(status).toBe(1);
+    expect(output).toContain('不符');
+  });
+
+  it('正確 append 的 PR 綠燈', () => {
+    const repo = setupRepo();
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+171',
+        entries: [{ id: 'reward-new-entry' }, { id: 'reward-existing-entry' }],
+      }),
+      'good append',
+    );
+    const { status, output } = runGuard(repo, 'main');
+    expect(status).toBe(0);
+    expect(output).toContain('通過');
+  });
+
+  it('002 未變更的 PR 跳過（零額外負擔）', () => {
+    const repo = setupRepo();
+    writeFileSync(join(repo, 'other.txt'), 'unrelated');
+    git(repo, 'add', '--all');
+    git(repo, 'commit', '-m', 'unrelated');
+    const { status, output } = runGuard(repo, 'main');
+    expect(status).toBe(0);
+    expect(output).toContain('跳過');
+  });
+
+  it('多 commit PR 只驗最終態 vs merge-base（中間態不一致不擋）', () => {
+    const repo = setupRepo();
+    // 中間 commit：新增條目但檔頭未同步（單看此 commit 會紅）。
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+170',
+        entries: [{ id: 'reward-step-one' }, { id: 'reward-existing-entry' }],
+      }),
+      'step 1',
+    );
+    // 最終 commit：整體對帳一致（新增 2 筆、+2、總分 172）。
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+2（reward 2、penalty 0、neutral 0）｜累計總分：+172',
+        entries: [
+          { id: 'reward-step-two' },
+          { id: 'reward-step-one' },
+          { id: 'reward-existing-entry' },
+        ],
+      }),
+      'step 2',
+    );
+    const { status } = runGuard(repo, 'main');
+    expect(status).toBe(0);
+  });
+
+  it('base 分支前進後仍以 merge-base 為基準（非 base tip）', () => {
+    const repo = setupRepo();
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+171',
+        entries: [{ id: 'reward-from-pr' }, { id: 'reward-existing-entry' }],
+      }),
+      'pr entry',
+    );
+    git(repo, 'checkout', 'main');
+    commitLog(
+      repo,
+      buildLog({
+        header: '> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+171',
+        entries: [{ id: 'reward-from-main' }, { id: 'reward-existing-entry' }],
+      }),
+      'main entry',
+    );
+    git(repo, 'checkout', 'pr');
+    const { status } = runGuard(repo, 'main');
+    expect(status).toBe(0);
+  });
+
+  it('刪除 002 檔案的 PR 必紅', () => {
+    const repo = setupRepo();
+    git(repo, 'rm', LOG_PATH);
+    git(repo, 'commit', '-m', 'delete log');
+    const { status, output } = runGuard(repo, 'main');
+    expect(status).toBe(1);
+    expect(output).toContain('不可刪除');
   });
 });

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    // scripts 為 Node 腳本與其測試：覆寫 base 的 types 白名單以載入 node 內建模組型別。
+    "types": ["node"]
+  },
   "include": ["**/*.ts"]
 }

--- a/scripts/verify-002-log.mjs
+++ b/scripts/verify-002-log.mjs
@@ -1,12 +1,16 @@
 /**
- * 002 記分守門（issue #608）
+ * 002 記分守門（issue #608；CI 端強制 issue #661）
  *
  * 驗證重點:
- * 1. 檔頭「本次分數變化：+N（reward a、penalty b、neutral c）」與本次 staged 新增條目計數一致
- * 2. 檔頭「累計總分」= 前版（HEAD）累計總分 + N；初始 commit 或前版無法解析時跳過
+ * 1. 檔頭「本次分數變化：+N（reward a、penalty b、neutral c）」與本次新增條目計數一致
+ * 2. 檔頭「累計總分」= 基準版累計總分 + N；初始 commit 或基準版無法解析時跳過
  * 3. 新增條目符合四行模板（日期/ID/原因/解法）、日期為 YYYY-MM-DD、ID 對全檔唯一
+ *
+ * 兩種執行語意共用同一 validate002 核心（無雙實作）:
+ * - pre-commit（預設）：staged 版 vs HEAD 版
+ * - CI（--base-ref <ref>）：HEAD 版 vs merge-base(<ref>, HEAD) 版；檔案未變更時跳過
  */
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 export const LOG_PATH = 'docs/dev/002_development_reward_penalty_log.md';
@@ -106,8 +110,9 @@ export function parseEntries(content) {
 }
 
 /**
- * 核心驗證：比對 staged 內容與前版（HEAD）內容。
- * headContent 為 null 表示初始 commit 情境（跳過總分鏈驗證）。
+ * 核心驗證：比對待驗版本（stagedContent）與基準版本（headContent）。
+ * pre-commit 語意為 staged vs HEAD；CI 語意為 HEAD vs merge-base。
+ * headContent 為 null 表示無基準版本情境（跳過刪除防護與總分鏈驗證）。
  */
 export function validate002({ stagedContent, headContent }) {
   const errors = [];
@@ -203,30 +208,16 @@ export function validate002({ stagedContent, headContent }) {
   return { errors };
 }
 
-function readStaged(filePath) {
+// spec 形如「:path」（staged）、「HEAD:path」、「<sha>:path」；物件不存在時回傳 null。
+function gitShow(spec) {
   try {
-    return execSync(`git show :${filePath}`, { encoding: 'utf-8' });
+    return execFileSync('git', ['show', spec], { encoding: 'utf-8' });
   } catch {
     return null;
   }
 }
 
-function readFromHead(filePath) {
-  try {
-    return execSync(`git show HEAD:${filePath}`, { encoding: 'utf-8' });
-  } catch {
-    return null;
-  }
-}
-
-function main() {
-  const stagedContent = readStaged(LOG_PATH);
-  if (stagedContent === null) {
-    console.log(`002 記分守門跳過（${LOG_PATH} 不在 staged set）`);
-    return;
-  }
-
-  const { errors } = validate002({ stagedContent, headContent: readFromHead(LOG_PATH) });
+function report(errors) {
   if (errors.length > 0) {
     console.error('002 記分守門失敗:');
     for (const message of errors) {
@@ -235,6 +226,59 @@ function main() {
     process.exit(1);
   }
   console.log('002 記分守門通過');
+}
+
+// pre-commit 語意：staged 版 vs HEAD 版。
+function runPreCommit() {
+  const stagedContent = gitShow(`:${LOG_PATH}`);
+  if (stagedContent === null) {
+    console.log(`002 記分守門跳過（${LOG_PATH} 不在 staged set）`);
+    return;
+  }
+  report(validate002({ stagedContent, headContent: gitShow(`HEAD:${LOG_PATH}`) }).errors);
+}
+
+// CI 語意：HEAD 版（PR 最終態）vs merge-base 版；只驗整體一致性、不逐 commit。
+function runAgainstBaseRef(baseRef) {
+  let mergeBase;
+  try {
+    mergeBase = execFileSync('git', ['merge-base', baseRef, 'HEAD'], { encoding: 'utf-8' }).trim();
+  } catch {
+    console.error(`002 記分守門失敗：無法解析 merge-base（base ref「${baseRef}」）`);
+    process.exit(1);
+  }
+
+  const currentContent = gitShow(`HEAD:${LOG_PATH}`);
+  const baseContent = gitShow(`${mergeBase}:${LOG_PATH}`);
+
+  if (currentContent === null) {
+    if (baseContent === null) {
+      console.log(`002 記分守門跳過（${LOG_PATH} 不存在）`);
+      return;
+    }
+    report([`${LOG_PATH} 不可刪除（merge-base ${mergeBase.slice(0, 12)} 存在此檔）`]);
+    return;
+  }
+  if (currentContent === baseContent) {
+    console.log(`002 記分守門跳過（${LOG_PATH} 相對 merge-base ${mergeBase.slice(0, 12)} 無變更）`);
+    return;
+  }
+  report(validate002({ stagedContent: currentContent, headContent: baseContent }).errors);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const flagIndex = args.indexOf('--base-ref');
+  if (flagIndex === -1) {
+    runPreCommit();
+    return;
+  }
+  const baseRef = args[flagIndex + 1];
+  if (!baseRef) {
+    console.error('002 記分守門失敗：--base-ref 需指定基準 ref（例如 origin/main 或 base SHA）');
+    process.exit(1);
+  }
+  runAgainstBaseRef(baseRef);
 }
 
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;


### PR DESCRIPTION
## 摘要

Closes #661

- `scripts/verify-002-log.mjs` 增設 `--base-ref <ref>` 入口：以 `merge-base(<ref>, HEAD)` 為基準版、HEAD（PR 最終態）為待驗版，與 pre-commit staged 語意共用**同一 `validate002` 核心**（無雙實作，僅內容取得方式不同）
- `.github/workflows/ci.yml` Quality Checks 於 `pnpm install` 前新增 PR 專屬步驟 `Verify 002 log (vs merge-base)`（守門腳本零 npm 依賴，可搶先紅燈），堵 `--no-verify` 與 GitHub 網頁端 merge/squash 繞過本地 hook 的破口
- vitest 補 6 條臨時 git repo 整合測試（真實 git 語意下驗 CLI 進入點）
- root 顯式宣告 `@types/node ^24`＋`scripts/tsconfig.json` 覆寫 `types` 白名單：root 測試首次使用 node 內建模組，typed lint 需要型別

## CI 語意選擇（issue 規格第 4 點）

- CI 驗的是「**PR 最終態（HEAD）vs merge-base**」的整體一致性，**不逐 commit**：本 repo 以 squash 合併，中間 commit 不進入 base 歷史，逐 commit 驗證無意義；多 commit PR 只要最終 002 檔頭與新增條目差集對帳一致即綠（有整合測試鎖定此語意）
- base 前進後仍以 merge-base 為基準（非 base tip），他人先合併的 002 條目不造成誤紅；若 PR 與 base 同時動 002，檔頭記分行必然衝突，交由 GitHub 衝突機制擋下（衝突 PR 不產生 merge ref、CI 不跑）
- 驗證面向與 pre-commit 完全一致：條目差集計數、`N = reward − penalty`、總分鏈（基準總分 + N）、ID 全檔唯一、歷史條目不可刪；base-ref 模式額外把「整檔刪除」也列為必紅
- 002 未變更的 PR 毫秒級跳過（實測約 40ms、僅 2 個 git 指令），正常 PR 零額外負擔

## 紅測證據（本地以 base-ref 模式重演，CI 同款指令）

構造「新增條目但檔頭計數未同步」的壞版，以 `--no-verify` 提交（模擬繞過 pre-commit）：

```text
=== 壞版已以 --no-verify 提交（模擬繞過 pre-commit）===
$ node scripts/verify-002-log.mjs --base-ref origin/experiment/ratewise-product-2026h2
002 記分守門失敗:
- 檔頭計數（reward 1、penalty 0、neutral 0）與本次新增條目（reward 2、penalty 0、neutral 0）不符
- 本次分數變化應為 2（reward - penalty），檔頭為 1
exit code: 1
```

對照組：

```text
=== 本 PR 分支（002 正確 +203）===
002 記分守門通過
exit code: 0

=== 002 未變更情境（base HEAD、新腳本）===
002 記分守門跳過（docs/dev/002_development_reward_penalty_log.md 相對 merge-base eac973d9d8fe 無變更）
0.03s user 0.01s system 97% cpu 0.037 total
exit code: 0
```

## 驗收對照

- [x] 構造計數不符的 PR 在 CI 語意下必紅（上方重演證據＋vitest 整合測試「構造計數不符的 PR 最終態必紅」）
- [x] 正常 PR 零額外負擔（002 未觸及即跳過，約 40ms）
- [x] 與 pre-commit 共用同一驗證核心 `validate002`（無雙實作）
- [x] workflow YAML 解析通過（python `yaml.safe_load` ＋ js-yaml 雙驗）
- [x] `pnpm vitest run scripts/__tests__/verify-002-log.test.ts` 24 passed（18 既有＋6 新 base-ref 整合測試）
- [x] pre-commit／pre-push 全過（push 已成功，typecheck＋workspace tests＋build:ratewise 全綠）
- [x] changeset 不需：純 CI／scripts／測試變更，無使用者可見行為；版本 SSOT 守門（pre-commit Step 5）通過、未要求 changeset
- [x] 002 一筆 reward（累計 +202 → **+203**）

## 附註

- `@types/node` 先前僅由各 app 宣告，root lockfile peer 漂移至 25.0.3；root 顯式宣告 `^24`（對齊 engines `^24.0.0`）後收斂為 24.10.1——`pnpm-lock.yaml` 的大量 diff 均為此 peer 版本替換，無任何依賴新增或升版
- 整合測試曾在 hook 環境全紅：pre-push 跑 vitest 時 husky 注入 `GIT_DIR`／`GIT_INDEX_FILE`，臨時 repo 的 git 子行程繼承後被導向父 repo；`GIT_ENV` 已剝除 `GIT_*` 前綴變數，hook 注入環境與一般環境雙重驗證各 24 passed

Made with [Cursor](https://cursor.com)