### PR TITLE
fix(docker): 安裝前複製 patches/ 修復 Zeabur build ENOENT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ COPY apps/park-keeper/package.json ./apps/park-keeper/
 COPY apps/split-meow/package.json ./apps/split-meow/
 COPY apps/shared/package.json ./apps/shared/
 
+# [fix:2026-07-14] patchedDependencies 需要 patch 檔於安裝時可讀（pnpm 讀檔算 hash）
+# 必須在 pnpm install 前先複製 patches/，否則 frozen install 報 ENOENT 導致 Zeabur build 失敗
+COPY patches ./patches/
+
 # [fix:2025-11-06] 安裝依賴時禁用 Husky 並清空 NODE_ENV
 # Zeabur 可能自動設置 NODE_ENV=production，導致 devDependencies 被跳過
 # Builder 階段需要 devDependencies（TypeScript, Vite 等構建工具）


### PR DESCRIPTION
## 問題

合併 #696 後 Zeabur production build 失敗（`Zeabur: failure` on `0615c890`）：

```
ENOENT: no such file or directory, open '/app/patches/vite-react-ssg@0.8.9.patch'
```

## 根因

#696 為 haotool 導入 `patchedDependencies`（`vite-react-ssg@0.8.9` patch）。Dockerfile 為 layer cache 最佳化，在 `pnpm install --frozen-lockfile` 前**只 COPY 各 app 的 package.json**，未複製 `patches/`。而 pnpm 安裝時需讀 patch 檔計算 hash → 缺檔 → `ENOENT` → build 失敗（exit 254）。

本機/CI 未暴露：源碼完整（`COPY . .` 已含 patches），只有 Docker 分階段 COPY 才觸發。

## 修法

在 `pnpm install` 前新增一行：
```dockerfile
COPY patches ./patches/
```

## 驗證（本機 Docker 完整重現）

- ❌ 修復前：`docker build` 於 install 步驟 ENOENT 失敗（重現 Zeabur 錯誤）
- ✅ 修復後：image 成功建成（404MB），含全 6 app build、sitemap 驗證、runtime stage 全通過

## 測試計畫

- [x] 本機 `docker build` 完整通過（修復前後對照）
- [ ] Zeabur production build（合併後驗證）

🤖 Generated with [Claude Code](https://claude.com/claude-code)