### PR TITLE
docs(deploy): 落檔 Zeabur Dockerfile 覆寫治理 SOP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,8 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 
 **Cloudflare 邊緣同步**：release 需確認 `security-headers` worker 也已部署；`wrangler deploy` 需 `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`；secret 缺失時明確 `skip` 並回報，不可假設 edge 已同步。完整 SOP 見 `AGENTS.md` § security-headers Worker 部署 SOP。
 
+**Zeabur Dockerfile 覆寫 split-brain**：GH/Zeabur 部署 success 但新路徑 404、build log 建置鏈與 repo `Dockerfile` 不符（`rg "pnpm build:" Dockerfile` 對照 log 缺步驟）→ 查 Zeabur `spec.source.dockerfile` 是否殘留排障貼入的舊版覆寫；修法：`updateDockerfile(serviceID, dockerfile: "")` 清空恢復 repo SSOT 後 redeploy。詳見 `docs/DEPLOYMENT.md` § Zeabur 服務層 Dockerfile 覆寫治理。
+
 ## Cloudflare SEO 直通實踐（CF SEO Straight-Path Patterns）
 
 基於 2026-03 SEO 審核執行歷史提煉，避免重蹈彎路。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -146,6 +146,22 @@ curl -I http://localhost:8080/park-keeper/about/ | head -n 5
 - Cloudflare：設定 `CLOUDFLARE_ZONE_ID` 與 `CLOUDFLARE_API_TOKEN`。
 - 無 API 時：依腳本輸出清單於 CDN 後台手動操作。
 
+### Zeabur 服務層 Dockerfile 覆寫治理
+
+> 2026-07-14 P0 事故：Zeabur service `app` 的 `spec.source.dockerfile` 殘留排障期間貼入的舊版覆寫，完全取代 repo `Dockerfile`，導致 main 新程式碼（如 `apps/starpuff`）未進入生產映像而 404。
+
+- **必須（MUST）**：Zeabur 服務層 `spec.source.dockerfile` 非空時，**完全覆蓋** repo 根目錄 `Dockerfile` 與 `zbpack.json` 指向的建置定義；平台不會合併兩者，也不會自動同步 repo 更新。
+- **必須（MUST）**：排障期間若曾透過 Dashboard 或 GraphQL 貼入臨時 Dockerfile，收工時必須清空覆寫以恢復 repo SSOT，再觸發 redeploy。清空範例（不含 token）：
+  ```graphql
+  mutation {
+    updateDockerfile(serviceID: "<SERVICE_ID>", dockerfile: "") {
+      ok
+    }
+  }
+  ```
+- **必須（MUST）**：部署異常（GH/Zeabur 顯示 success 但新路徑 404、或 build log 與預期不符）時，比對 Zeabur build log 建置鏈與 repo `Dockerfile`：以 `rg "pnpm build:" Dockerfile` 列出預期步驟，對照 log 是否缺漏（例如缺 `pnpm build:starpuff` 或 stage-1 `COPY` 步數不符）。
+- **建議（RECOMMENDED）**：變更 Zeabur 服務設定（Dockerfile 覆寫、環境變數、build 參數）前，先讀出並保存當前設定備份（例如 GraphQL `service { spec { source { dockerfile } } }` 或 Dashboard 匯出），以便事故後比對與還原。
+
 ### Release Workflow 與 Cloudflare Worker 同步
 
 - `Release` workflow 在 `main` push 時，會先嘗試部署 `security-headers/wrangler.jsonc` 對應的 Cloudflare Worker，再執行 CDN purge；有版本變更時則會一併建立 GitHub release/tag。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+113
+> 本次分數變化：+0（reward 0、penalty 0、neutral 1）｜累計總分：+113
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-14
+- ID：neutral-zeabur-dockerfile-override-p0
+- 原因：Zeabur service 層 spec.source.dockerfile 殘留昨日排障貼入的舊版覆寫，蓋掉 repo Dockerfile 致 starpuff 上線後生產 404（split-brain：首頁卡片在、app 本體缺）
+- 解法：GraphQL updateDockerfile 清空覆寫恢復 repo SSOT + redeploy，11/11 資源復綠；SOP 落檔 DEPLOYMENT.md 防重演
 
 - 日期：2026-07-14
 - ID：reward-starpuff-24h-multiagent-game-delivery


### PR DESCRIPTION
## Summary

2026-07-14 P0 事故：Zeabur service `app` 的 `spec.source.dockerfile` 殘留昨日排障貼入的舊版覆寫，完全取代 repo `Dockerfile`，造成 main 新程式碼（`apps/starpuff`）未進入生產映像。症狀為 split-brain——首頁 bento 卡片可見，但 `/starpuff/` 全路徑 404。修復方式為 GraphQL `updateDockerfile` 清空覆寫恢復 repo SSOT 後 redeploy，11/11 資源復綠。

本 PR 將教訓落檔為部署 SOP，防止重演。

## SOP 要點

- `spec.source.dockerfile` 非空時完全覆蓋 repo `Dockerfile` 與 `zbpack.json`，平台不合併兩者
- 排障貼入臨時 Dockerfile 後，收工必須 `updateDockerfile(serviceID, dockerfile: "")` 清空
- 部署異常時以 `rg "pnpm build:" Dockerfile` 對照 Zeabur build log 建置鏈
- 服務設定變更前先讀出備份

## 變更檔案

- `docs/DEPLOYMENT.md`：新增「Zeabur 服務層 Dockerfile 覆寫治理」小節
- `CLAUDE.md`：Build/Deploy 速查條目
- `docs/dev/002_development_reward_penalty_log.md`：`neutral-zeabur-dockerfile-override-p0`

## Test plan

- [x] pre-commit 全步驟通過（lint-staged / typecheck / format）
- [x] pre-push 通過（typecheck / test / build:ratewise）
- [ ] PM review 後 merge

Made with [Cursor](https://cursor.com)