### PR TITLE
fix(papertrade): 深層路由下 favicon 與資產路徑修正

### DIFF
--- a/.changeset/papertrade-favicon-deep-link.md
+++ b/.changeset/papertrade-favicon-deep-link.md
@@ -1,0 +1,5 @@
+---
+'@app/papertrade': patch
+---
+
+修復深層路由（如 /papertrade/chart/BTCUSDT）下 favicon 與 apple-touch-icon 404：分頁圖示與加入主畫面圖示在所有頁面正常顯示。

--- a/apps/papertrade/index.html
+++ b/apps/papertrade/index.html
@@ -26,8 +26,8 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="PaperTrade 零風險模擬合約交易所" />
     <meta name="twitter:card" content="summary_large_image" />
-    <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml" />
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link rel="icon" href="%BASE_URL%favicon.svg" sizes="any" type="image/svg+xml" />
+    <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%apple-touch-icon.png" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+115
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+116
 
 ## 新增模板（4 行）
 
@@ -42,6 +42,11 @@
 - ID：reward-starpuff-v4-norotate-elements
 - 原因：v4 需求「直持免轉向、寬幅隨螢幕、平台元素與更豐富內容」涉及 CSS 旋轉殼與 Phaser 私有 API 補償的高風險結構改造
 - 解法：旋轉殼模組化（shellLayout+enemyFsm 純邏輯 21 案守門測）、四平台元素表驅動、疾衝/新怪x2/魔王P3；140 unit+12 e2e 綠、深度 QA 七劇本全 PASS、三席終審收斂 APPROVE（可維護性 8）
+
+- 日期：2026-07-15
+- ID：reward-papertrade-favicon-deep-link-404
+- 原因：index.html 的 favicon 與 apple-touch-icon 用相對路徑，深層路由（/papertrade/chart/BTCUSDT）下解析為 /papertrade/chart/favicon.svg 致 404
+- 解法：改用 Vite %BASE_URL% 慣例（對齊 nihonname 寫法）展開為 /papertrade/ 絕對路徑，build 後驗證 dist/index.html、246 unit 與 typecheck/format 全綠
 
 - 日期：2026-07-15
 - ID：reward-papertrade-wave5-final-convergence


### PR DESCRIPTION
## Summary
- `apps/papertrade/index.html` 的 favicon 與 apple-touch-icon 原為相對路徑，在 `/papertrade/chart/BTCUSDT` 等深層路由下解析為 `/papertrade/chart/favicon.svg` 造成 404。
- 改用 Vite `%BASE_URL%` 慣例（對齊 `apps/nihonname/index.html` 既有寫法），build 後展開為 `/papertrade/` 絕對路徑。
- 已掃描 index.html 全部資產連結：`og:image` 與 JSON-LD `image` 原為絕對 URL，不受影響；本次僅兩個 `<link>` 需修正。
- 附 `@app/papertrade` patch changeset 與 002 紀錄。

## Test plan
- [x] `pnpm --filter @app/papertrade build`：`dist/index.html` 實際輸出 `href="/papertrade/favicon.svg"`、`href="/papertrade/apple-touch-icon.png"`
- [x] `pnpm --filter @app/papertrade test:run`：26 files / 246 tests 綠
- [x] `pnpm --filter @app/papertrade typecheck` 綠
- [x] root `pnpm format` 綠
- [x] pre-push hook（typecheck + test + build:ratewise）通過

Made with [Cursor](https://cursor.com)