### PR TITLE
fix(starpuff): 按鈕配置恢復預設誤清儲存與 Enter 越權開局

### DIFF
--- a/apps/starpuff/src/game/core/layout.test.ts
+++ b/apps/starpuff/src/game/core/layout.test.ts
@@ -6,6 +6,7 @@ import {
   LAYOUT_SCHEMA_VERSION,
   clampKeyPosition,
   clampKeyPositionForLayer,
+  getDefaultLayout,
   parseLayout,
 } from './layout';
 
@@ -46,6 +47,16 @@ describe('clampKeyPositionForLayer', () => {
       const short = clampKeyPositionForLayer(pos.cx, pos.cy, 820, 300, btnPx);
       expect(short.cy * 300 + btnPx / 2).toBeLessThanOrEqual(300);
     }
+  });
+});
+
+describe('getDefaultLayout', () => {
+  it('回傳預設布局深拷貝且不讀寫儲存', () => {
+    const layout = getDefaultLayout();
+    expect(layout).toEqual(DEFAULT_LAYOUT);
+    expect(layout).not.toBe(DEFAULT_LAYOUT);
+    layout.a.cx = 0;
+    expect(DEFAULT_LAYOUT.a.cx).not.toBe(0);
   });
 });
 

--- a/apps/starpuff/src/game/core/layout.ts
+++ b/apps/starpuff/src/game/core/layout.ts
@@ -102,13 +102,17 @@ export function saveLayout(layout: ControlLayout): void {
   }
 }
 
+export function getDefaultLayout(): ControlLayout {
+  return structuredClone(DEFAULT_LAYOUT);
+}
+
 export function resetLayout(): ControlLayout {
   try {
     localStorage.removeItem(LAYOUT_STORAGE_KEY);
   } catch {
     /* noop */
   }
-  return DEFAULT_LAYOUT;
+  return getDefaultLayout();
 }
 
 // 座標序列化為百分比字串：toFixed(2) 避免浮點尾數（0.92*100 = 92.00000000000001）。

--- a/apps/starpuff/src/game/scenes/TitleScene.ts
+++ b/apps/starpuff/src/game/scenes/TitleScene.ts
@@ -4,7 +4,7 @@ import { startBgm } from '../audio/bgm';
 import { playSfx, unlockAudio } from '../audio/sfx';
 import { createMenuBackdrop, type BackgroundHandle } from '../systems/background';
 import { addDomButton, addMuteButton, bindMenuRelayout } from '../systems/hud';
-import { openKeyConfig } from '../systems/keyConfig';
+import { closeKeyConfig, isKeyConfigOpen, openKeyConfig } from '../systems/keyConfig';
 
 const TITLE_GLOW_TEX = 'title-glow';
 
@@ -36,7 +36,10 @@ export class TitleScene extends Phaser.Scene {
       clouds: true,
       ambience: 'bg-meadow',
     });
-    this.events.once('shutdown', () => this.backdrop?.destroy());
+    this.events.once('shutdown', () => {
+      this.backdrop?.destroy();
+      closeKeyConfig();
+    });
     addMuteButton(this);
     bindMenuRelayout(this);
 
@@ -125,6 +128,7 @@ export class TitleScene extends Phaser.Scene {
 
     // 首次手勢：解鎖 iOS AudioContext 後啟動 BGM，再進入遊戲。
     const start = () => {
+      if (isKeyConfigOpen()) return;
       unlockAudio();
       startBgm();
       this.scene.start(SceneKeys.Game);

--- a/apps/starpuff/src/game/systems/keyConfig.ts
+++ b/apps/starpuff/src/game/systems/keyConfig.ts
@@ -1,8 +1,8 @@
 import {
   applyLayoutToDom,
   clampKeyPositionForLayer,
+  getDefaultLayout,
   loadLayout,
-  resetLayout,
   saveLayout,
   type ControlLayout,
 } from '../core/layout';
@@ -13,9 +13,14 @@ import { isPortrait, pointerToLocal } from './controls';
 // snapshot 且不儲存）。KISS：不做網格對齊與進階編輯器。
 
 let open = false;
+let dismissWithoutSave: (() => void) | null = null;
 
 export function isKeyConfigOpen(): boolean {
   return open;
+}
+
+export function closeKeyConfig(): void {
+  dismissWithoutSave?.();
 }
 
 function addAction(bar: HTMLElement, action: string, label: string, onPress: () => void): void {
@@ -67,11 +72,18 @@ export function openKeyConfig(onClose?: () => void): void {
     shell.classList.remove('is-configuring');
     controls.classList.remove('is-config');
     open = false;
+    dismissWithoutSave = null;
     onClose?.();
   };
 
+  const cancelWithoutSave = (): void => {
+    applyLayoutToDom(layer, original);
+    teardown();
+  };
+  dismissWithoutSave = cancelWithoutSave;
+
   addAction(bar, 'reset', '恢復預設', () => {
-    Object.assign(working, structuredClone(resetLayout()));
+    Object.assign(working, getDefaultLayout());
     applyLayoutToDom(layer, working);
   });
   addAction(bar, 'save', '儲存並返回', () => {
@@ -79,10 +91,7 @@ export function openKeyConfig(onClose?: () => void): void {
     teardown();
   });
   // 取消：還原進入時 snapshot、不寫入 localStorage。
-  addAction(bar, 'cancel', '取消', () => {
-    applyLayoutToDom(layer, original);
-    teardown();
-  });
+  addAction(bar, 'cancel', '取消', cancelWithoutSave);
 
   // 拖曳：座標經 pointerToLocal 轉 keys-layer 局部空間（portrait 旋轉殼換軸），
   // 中心點比例即時寫回 working 並套用（即時預覽）。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：0（reward 0、penalty 0、neutral 1）｜累計總分：+116
+> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+115
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-16
+- ID：penalty-starpuff-keyconfig-reset-preview
+- 原因：按鈕配置「恢復預設」預覽誤呼叫 resetLayout 立即清除 localStorage，取消後重載仍遺失自訂布局；標題場景 Enter 開始未攔截且 shutdown 未關閉配置覆層
+- 解法：getDefaultLayout 純預覽＋closeKeyConfig 於 TitleScene shutdown/Enter 守門；vitest 守門 getDefaultLayout 不觸碰儲存
 
 - 日期：2026-07-16
 - ID：neutral-papertrade-test-timeout-flaky


### PR DESCRIPTION
## Summary

修復 PR #708 Codex review 揭露的兩個真 bug（threads 已回覆待此 PR 收斂）：

1. **恢復預設誤清儲存**：按鈕配置「恢復預設」預覽階段即呼叫 `resetLayout()` 執行 `localStorage.removeItem`，使用者按「取消」後重載仍遺失原自訂布局。改為 `getDefaultLayout()` 純預覽（深拷貝、不觸碰儲存），僅「儲存並返回」才寫入。
2. **Enter 越權開局＋覆層殘留**：配置模式開啟時標題場景 Enter 快捷鍵仍可啟動 GameScene，且 `.cfg-bar` 覆層與 `is-configuring`/`is-config` class 未綁 shutdown 清理，殘留在遊戲畫面上並卡住暫停入口。改為 `start` 以 `isKeyConfigOpen()` 守門，TitleScene shutdown 呼叫新增的 `closeKeyConfig()`（等同取消路徑：還原 snapshot、不寫入儲存）。

## Test plan

- `pnpm --filter @app/starpuff test`：160 passed（含新增 `getDefaultLayout` 深拷貝守門測試）
- CI 全量 Quality Checks 把關

## 受控偏離說明

- 本地 pre-push 因無關 app flaky 繞過（HUSKY=0，PM 授權）；證據：三次失敗均為 nihonname/papertrade `Test timed out in 5000ms` 逾時類，無 starpuff 失敗，CI 仍為權威閘門。

Made with [Cursor](https://cursor.com)