### PR TITLE
ci: release PR 自動補觸發必要檢查修復防遞迴缺口

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
@@ -102,6 +103,20 @@ jobs:
           #       → "Allow GitHub Actions to create and approve pull requests" enabled
           # If this fails with HTTP 403, ask an org admin to enable the setting.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GITHUB_TOKEN 建立的 PR 不觸發 pull_request CI（防遞迴）；workflow_dispatch 為官方例外。
+      - name: Trigger CI for release PR
+        if: steps.changesets.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin refs/heads/changeset-release/main >/dev/null 2>&1; then
+            gh workflow run ci.yml --ref changeset-release/main
+            echo "Dispatched CI workflow on changeset-release/main"
+          else
+            echo "changeset-release/main branch not found, skipping CI dispatch"
+          fi
 
       - name: Report Release PR status
         if: steps.changesets.outcome == 'failure'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,6 +497,7 @@ git push origin main     # pre-push 自動驗證
 8. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
 9. 若一般 PR 與 release PR 連續合併，合併 release PR 前必須確認前一個 main SHA 的 Zeabur production deployment 已完成；避免較舊 SHA 在 release SHA 後才 active，造成正式站版本回退。
 10. Release workflow 若在 `Wait for RateWise production deployment` 失敗，必須查 GitHub deployments；若最新 release SHA 已成功部署但較舊 SHA 隨後 active，需以最小 PR 重新觸發最新 main 部署，並重新跑正式站 `app-version` 與 live precache 驗證。
+11. changesets/action 以 `GITHUB_TOKEN` 開/更新 release PR 時，`pull_request` 事件不觸發 CI（防遞迴規則）；`release.yml` 在 changesets 成功後必須 `gh workflow run ci.yml --ref changeset-release/main` 補觸發 `Quality Checks`。手動排障：`gh workflow run ci.yml --ref changeset-release/main`。
 
 **GitHub Actions Node 24 控制**：
 

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+5（reward 6、penalty 1、neutral 0）｜累計總分：+125
+> 本次分數變化：0（reward 0、penalty 0、neutral 1）｜累計總分：+125
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-17
+- ID：neutral-ci-release-pr-checks-dispatch
+- 原因：changesets/action 以 GITHUB_TOKEN 開 release PR 時 pull_request 不觸發 CI，branch protection 缺 Quality Checks 致 auto-merge 永久 BLOCKED
+- 解法：release.yml changesets 成功後以 workflow_dispatch 補跑 `gh workflow run ci.yml --ref changeset-release/main`（GITHUB_TOKEN 允許的防遞迴例外）
 
 - 日期：2026-07-17
 - ID：reward-park-keeper-round2-convergence


### PR DESCRIPTION
## Summary

- changesets/action 以 `GITHUB_TOKEN` 開/更新 `changeset-release/main` PR 時，`pull_request` 事件不觸發 CI（GitHub 防遞迴規則），導致 branch protection 缺 `Quality Checks`、auto-merge 永久 BLOCKED（#737 已手動驗證 workaround）
- 在 `release.yml` changesets 成功後新增 `gh workflow run ci.yml --ref changeset-release/main`（`workflow_dispatch` 為 GITHUB_TOKEN 官方例外，不受防遞迴限制）
- 同步 AGENTS.md 排障規則與 002 neutral 條目

## 查證出處

- [GitHub Docs: GITHUB_TOKEN 防遞迴](https://docs.github.com/en/actions/concepts/security/github_token#using-the-github_token-in-a-workflow) — `workflow_dispatch` / `repository_dispatch` 例外
- [GitHub Changelog 2022-09-08](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/) — 明確允許 GITHUB_TOKEN 觸發 workflow_dispatch

## Test plan

- [x] `gh workflow view ci.yml --yaml` 確認 `workflow_dispatch:` 觸發器存在
- [ ] CI `Quality Checks` 綠燈
- [ ] 合併後下次 release PR 應自動收到 CI check（需待 changeset 累積驗證）


Made with [Cursor](https://cursor.com)