### PR TITLE
ci(release): release PR 全自動合併鏈根治 Quality Checks 不觸發（#771）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+  # bot 合併 release PR 的 push 不觸發 push workflow（GITHUB_TOKEN 防遞迴），
+  # 由合併步驟以 workflow_dispatch 補派本 workflow 於 main 執行 tags / releases / 部署。
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -104,19 +107,144 @@ jobs:
           # If this fails with HTTP 403, ask an org admin to enable the setting.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # GITHUB_TOKEN 建立的 PR 不觸發 pull_request CI（防遞迴）；workflow_dispatch 為官方例外。
+      # GITHUB_TOKEN 建立/更新 PR 時，pull_request run 停在 approval-required 狀態（防遞迴），
+      # 必要檢查 Quality Checks 永不自動執行、auto-merge 也不會被喚醒（issue #771）。
+      # 無 PAT / GitHub App 憑證下的全自動補償：workflow_dispatch 補跑 CI（官方例外）→
+      # 等待 Quality Checks → 受 branch protection 把關的直接合併 → 補派 main workflows。
       - name: Trigger CI for release PR
+        id: release_pr_ci
         if: steps.changesets.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code origin refs/heads/changeset-release/main >/dev/null 2>&1; then
-            gh workflow run ci.yml --ref changeset-release/main
-            echo "Dispatched CI workflow on changeset-release/main"
-          else
-            echo "changeset-release/main branch not found, skipping CI dispatch"
+          # changesets 成功卻無 branch / 無 open PR：多為全空 changeset 被 action 略過
+          # （"All changesets are empty; not creating PR"），空檔會永久殘留並堵住 tag 路徑，必須曝光。
+          if ! git ls-remote --exit-code origin refs/heads/changeset-release/main >/dev/null 2>&1; then
+            echo "::error::changesets step succeeded but changeset-release/main branch was not created. Check for empty changeset files blocking the release (remove .changeset/*.md with empty frontmatter)."
+            exit 1
           fi
+
+          PR_NUMBER=$(gh pr list --head changeset-release/main --base main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::changesets step succeeded but no open release PR was found on changeset-release/main."
+            exit 1
+          fi
+
+          # 釘住本次 QC 驗證的 head SHA，合併時以 --match-head-commit 防止合到未驗證的新 head。
+          HEAD_SHA=$(git ls-remote origin refs/heads/changeset-release/main | cut -f1)
+
+          # 以 run id 基準點定位本次 dispatch 產生的 run，避免時鐘偏移誤配舊 run。
+          BASELINE_ID=$(gh run list --workflow ci.yml --branch changeset-release/main --event workflow_dispatch \
+            --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run ci.yml --ref changeset-release/main
+          echo "Dispatched CI workflow on changeset-release/main for release PR #${PR_NUMBER}"
+
+          RUN_ID=""
+          for i in {1..12}; do
+            sleep 5
+            RUN_ID=$(gh run list --workflow ci.yml --branch changeset-release/main --event workflow_dispatch \
+              --limit 5 --json databaseId --jq "map(select(.databaseId > ${BASELINE_ID})) | .[0].databaseId // empty")
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Dispatched CI run not found on changeset-release/main"
+            exit 1
+          fi
+
+          echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      # 只等必要檢查 Quality Checks；e2e / lighthouse 等非必要 job 不阻擋合併（與人工流程一致）。
+      - name: Wait for release PR Quality Checks
+        if: steps.release_pr_ci.outputs.dispatched == 'true'
+        timeout-minutes: 25
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RUN_ID="${{ steps.release_pr_ci.outputs.run_id }}"
+
+          while true; do
+            # gh 暫時性失敗視同 pending，交由下一輪重查；不因 API 抖動失敗整個 release。
+            STATUS=$(gh run view "$RUN_ID" --json jobs \
+              --jq '.jobs[] | select(.name == "Quality Checks") | .status + ":" + (.conclusion // "")' || true)
+
+            case "$STATUS" in
+              completed:success)
+                echo "Quality Checks passed on run ${RUN_ID}"
+                break
+                ;;
+              completed:*)
+                echo "::error::Quality Checks concluded '${STATUS#completed:}' on run ${RUN_ID}; release PR will not be merged."
+                exit 1
+                ;;
+              *)
+                echo "Quality Checks status: ${STATUS:-pending}, waiting..."
+                sleep 30
+                ;;
+            esac
+          done
+
+      # 直接合併仍受 branch protection 伺服器端把關：required check 未過會被拒絕，並非繞過檢查。
+      # 不能依賴 GitHub auto-merge：非 PR 事件的 check 完成不會喚醒 auto-merge（issue #771 實證）。
+      - name: Merge release PR
+        id: release_pr_merge
+        if: steps.release_pr_ci.outputs.dispatched == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ steps.release_pr_ci.outputs.pr_number }}"
+          HEAD_SHA="${{ steps.release_pr_ci.outputs.head_sha }}"
+
+          STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "Release PR #${PR_NUMBER} is ${STATE}, skipping merge"
+            exit 0
+          fi
+
+          # 等待期間若 main 又累積新 changeset，改由排隊中的下一個 release run 整併後合併，
+          # 避免先合入只含部分 bump 的 release PR 造成 tag 視窗（HEAD^ 比對）漏建 tag。
+          git fetch origin main --quiet
+          if [ -n "$(git log "${GITHUB_SHA}..origin/main" --pretty=%H -- .changeset)" ]; then
+            echo "New changesets landed on main during Quality Checks; skipping merge and deferring to the queued release run for consolidation."
+            exit 0
+          fi
+
+          for i in {1..3}; do
+            if gh pr merge "$PR_NUMBER" --squash --match-head-commit "$HEAD_SHA"; then
+              echo "merged=true" >> "$GITHUB_OUTPUT"
+              echo "Release PR #${PR_NUMBER} merged"
+              exit 0
+            fi
+            if [ "$i" -lt 3 ]; then
+              echo "Merge attempt ${i}/3 failed, retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+
+          echo "::error::Failed to merge release PR #${PR_NUMBER} after Quality Checks passed."
+          echo "::error::If the merge was rejected for missing required checks, branch protection did not accept the dispatched run — see issue #771; a PAT or GitHub App token would then be required."
+          exit 1
+
+      # bot（GITHUB_TOKEN）合併產生的 main push 不觸發 push workflow（防遞迴），
+      # 必須補派 release.yml（tags / GitHub releases / 部署）與 ci.yml（main 品質訊號）。
+      - name: Re-dispatch main workflows after bot merge
+        if: steps.release_pr_merge.outputs.merged == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sleep 5
+          gh workflow run release.yml --ref main
+          gh workflow run ci.yml --ref main
+          echo "Dispatched release.yml and ci.yml on main to compensate suppressed push events"
 
       - name: Report Release PR status
         if: steps.changesets.outcome == 'failure'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,7 +473,7 @@ git push origin main     # pre-push 自動驗證
 - `pnpm --filter @app/ratewise generate:deterministic`：由 repo SSOT 重建 sitemap、manifest、offline shell、LLMs text、Markdown mirrors、API JSON 與 OpenAPI。
 - `pnpm --filter @app/ratewise verify:artifacts`：執行 SSOT sync 與 image resource 檢查。
 - `pnpm --filter @app/ratewise prebuild`：只執行 deterministic generation、artifact verification 與 rating placeholder refresh；禁止把 tracked live rate refresh 塞回單一長命令。
-- `update-seo-rate-examples.yml`：建立資料更新 PR 後必須以 `gh pr merge --auto` 掛上 GitHub auto-merge；合併仍由 branch protection 與 required checks 把關，禁止繞過 checks 的直接合併（不得使用非 `--auto` 的 `gh pr merge`）。
+- `update-seo-rate-examples.yml`：建立資料更新 PR 後必須以 `gh pr merge --auto` 掛上 GitHub auto-merge；合併仍由 branch protection 與 required checks 把關，禁止繞過 checks 的直接合併（不得使用非 `--auto` 的 `gh pr merge`）。唯一例外：`release.yml` 的 release PR 合併鏈——因 auto-merge 不會被非 PR 事件喚醒，必須在 `Quality Checks` 成功後以 `gh pr merge --squash` 直接合併；該合併仍受 branch protection 伺服器端把關，required check 未過會被 GitHub 拒絕，不構成繞過。
 
 ### Release PR 自動化失敗治理
 
@@ -497,7 +497,7 @@ git push origin main     # pre-push 自動驗證
 8. 發版前以 `pnpm changeset:status` 確認待發 changeset，並以 release PR 的 package / CHANGELOG diff 作為 AGT-VER-02 證據。
 9. 若一般 PR 與 release PR 連續合併，合併 release PR 前必須確認前一個 main SHA 的 Zeabur production deployment 已完成；避免較舊 SHA 在 release SHA 後才 active，造成正式站版本回退。
 10. Release workflow 若在 `Wait for RateWise production deployment` 失敗，必須查 GitHub deployments；若最新 release SHA 已成功部署但較舊 SHA 隨後 active，需以最小 PR 重新觸發最新 main 部署，並重新跑正式站 `app-version` 與 live precache 驗證。
-11. changesets/action 以 `GITHUB_TOKEN` 開/更新 release PR 時，`pull_request` 事件不觸發 CI（防遞迴規則）；`release.yml` 在 changesets 成功後必須 `gh workflow run ci.yml --ref changeset-release/main` 補觸發 `Quality Checks`。手動排障：`gh workflow run ci.yml --ref changeset-release/main`。
+11. changesets/action 以 `GITHUB_TOKEN` 開/更新 release PR 時，`pull_request` run 停在 approval-required 狀態（GITHUB_TOKEN 防遞迴），必要檢查 `Quality Checks` 永不自動執行；且非 PR 事件的 check 完成不會喚醒 GitHub auto-merge，bot 合併產生的 main push 也不會觸發 push workflow。無 PAT / GitHub App 憑證下，`release.yml` 必須在 changesets 成功後完成全自動合併鏈：`gh workflow run ci.yml --ref changeset-release/main` 補跑 CI → 等待 `Quality Checks` 成功 → `gh pr merge --squash` 直接合併（仍受 branch protection 伺服器端把關，required check 未過會被拒絕，非繞過檢查）→ `gh workflow run release.yml --ref main` 與 `gh workflow run ci.yml --ref main` 補派被抑制的 main push workflows（tags / GitHub releases / 部署）。等待 QC 期間若 main 又新增 changeset，本輪跳過合併並遞延給排隊中的下一個 release run 整併，避免 `--changed`（HEAD^ 比對）漏建 tag。手動排障 fallback：close/reopen release PR 觸發原生 `pull_request` run（issue #771）。
 
 **GitHub Actions Node 24 控制**：
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
   （sitemap、manifest、offline shell、LLMs text、Markdown mirrors、API JSON、OpenAPI）。
 - `pnpm --filter @app/ratewise verify:artifacts`：SSOT sync 與 image resource 檢查。
 - `prebuild` 只執行 deterministic generation、artifact verification 與 rating placeholder refresh；不得刷新 tracked live rate data。`lighthouse-report.json`、`*.tsbuildinfo` 屬本機工具輸出，必須保持 untracked。
-- `update-seo-rate-examples.yml` 建立資料更新 PR 後必須以 `gh pr merge --auto` 掛上 GitHub auto-merge；合併仍由 branch protection 與 required checks 把關，禁止繞過 checks 的直接合併（不得使用非 `--auto` 的 `gh pr merge`）。
+- `update-seo-rate-examples.yml` 建立資料更新 PR 後必須以 `gh pr merge --auto` 掛上 GitHub auto-merge；合併仍由 branch protection 與 required checks 把關，禁止繞過 checks 的直接合併（不得使用非 `--auto` 的 `gh pr merge`）。唯一例外：`release.yml` 的 release PR 合併鏈於 `Quality Checks` 成功後以 `gh pr merge --squash` 直接合併（auto-merge 不會被非 PR 事件喚醒；合併仍受 branch protection 伺服器端把關，非繞過）。
 
 **Release PR 自動化控制**：
 
@@ -171,6 +171,7 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
 - README 同步規則：公開指令、workflow、部署、版本流程或使用者可見行為變更時，必須更新 root `README.md` 與受影響 app README
 - 連續合併一般 PR 與 release PR 時，release PR 前先確認較早 main SHA 的 Zeabur production deployment 已完成；若舊 SHA 在 release SHA 之後 active，會讓正式站版本回退
 - `Wait for RateWise production deployment` 失敗時，先查 GitHub deployments 的 active SHA；若 release SHA 被較舊 SHA 覆蓋，以最小 PR 重新觸發最新 main 部署，再重跑 `app-version` 與 live precache 驗證
+- release PR 全自動合併鏈（issue #771）：`GITHUB_TOKEN` 開的 PR 其 `pull_request` run 停在 approval-required、auto-merge 不會被非 PR 事件喚醒、bot 合併的 main push 不觸發 push workflow；`release.yml` 必須自行「補跑 CI → 等 `Quality Checks` → `gh pr merge --squash`（受 branch protection 把關）→ 補派 `release.yml`/`ci.yml` 於 main」；等待期間 main 若新增 changeset 則本輪遞延合併交下一個 release run 整併；人工 close/reopen 僅作 fallback
 
 **依賴安全管理**（Dependabot 警告處理）：
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ release 清單。禁止手動修改版本號、手動編輯 CHANGELOG，或在 C
 `pnpm changeset tag` 建 tag；CI 內部 tag push 會以 `HUSKY=0` 單次推送，避免重複觸發
 pre-push hook。
 
+release PR 由 `release.yml` 全自動合併：因 `GITHUB_TOKEN` 建立的 PR 其
+`pull_request` CI 停在 approval-required 狀態（GitHub 防遞迴），workflow 會自行補跑
+CI、等待 `Quality Checks` 通過後直接合併（仍受 branch protection 把關），並補派
+main 上的 `release.yml` / `ci.yml` 完成 tags 與部署，全程無需人工介入。
+
 正式站部署由 Zeabur production deployment 接 GitHub main。合併一般 PR 後若會再合併
 changesets release PR，需先確認較早的 production deployment 已完成，避免舊 SHA 在 release
 SHA 之後才變成 active，造成正式站版本回退。Release 後以

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+131
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+132
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-19
+- ID：reward-release-pr-automerge-chain
+- 原因：GITHUB_TOKEN 開/更新的 release PR 其 pull_request run 停在 approval-required（官方防遞迴），required check Quality Checks 永不執行；#742 的 workflow_dispatch 補償只補 check run，auto-merge 不被非 PR 事件喚醒（#755 掛 auto-merge 後 dispatch QC 綠仍卡 6.5 小時），且 bot 合併的 main push 不觸發 workflow，每次發版需人工 close/reopen（#755/#762/#770/#773，issue #771）
+- 解法：release.yml 補全自動合併鏈——dispatch CI 後等待 Quality Checks 成功、gh pr merge --squash 受 branch protection 伺服器端把關直接合併、再補派 main 的 release.yml/ci.yml 補償被抑制的 push 事件；同步 AGENTS/CLAUDE/README 治理節並保留 close/reopen 為 fallback
 
 - 日期：2026-07-19
 - ID：penalty-starpuff-dropthrough-touch-gesture


### PR DESCRIPTION
## Summary

- 根因（官方文檔+實證）：`GITHUB_TOKEN` 開/更新的 release PR，其 `pull_request` run 停在 **approval-required** 狀態（GitHub 防遞迴；run 顯示 `action_required`、0 jobs，如 run 29661968129），required check `Quality Checks` 永不自動執行
- #742 的 workflow_dispatch 補償只讓 check run 變綠，**auto-merge 不會被非 PR 事件喚醒**：#755 於 02:04 掛 auto-merge、02:08 dispatch QC 綠（rollup SUCCESS），仍卡 6.5 小時；#773 則在 pull_request 事件 QC 完成 2 秒內合併
- repo 無 PAT / GitHub App 憑證（secrets 僅 RATING_API_URL）→ 採無憑證補償鏈：**dispatch CI → 等待 Quality Checks → `gh pr merge --squash --match-head-commit`（仍受 branch protection 伺服器端把關，非繞過）→ 補派 `release.yml`/`ci.yml` @main**（bot 合併的 main push 同樣被防遞迴抑制，不補派就沒有 tags/GitHub releases/部署）
- 防護：changesets 成功但無 branch/PR 一律 `exit 1` 曝光（含空 changeset 堵塞情境）；等待 QC 期間 main 新增 changeset 則本輪遞延合併，交排隊中的下一個 release run 整併，防 `--changed`（HEAD^ 比對）漏 tag；QC 失敗 `exit 1` 不偽 success
- 文檔同步：AGENTS.md 規則 11 改寫＋非 `--auto` 禁令的 release 例外定性、CLAUDE.md、README、002（+1，累計 +132）

## 查證出處

- [GitHub Docs: GITHUB_TOKEN 觸發 workflow 的限制](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs) — pull_request(opened/synchronize/reopened) 進 approval-required；官方解法為 App token / PAT
- [changesets/action maintenance/v1 原始碼](https://github.com/changesets/action/blob/maintenance/v1/src/index.ts) — 全空 changeset 不開 PR（`All changesets are empty; not creating PR`），故不採空 changeset 驗證載具
- gh 2.96.0 `gh pr merge --match-head-commit` 旗標確認存在

## Test plan

- [x] YAML 解析、prettier、pre-commit（lint-staged/typecheck/format）、pre-push（typecheck+test+build:ratewise）通過
- [x] cursor-grok-4.5-high-fast 唯讀阻塞審查兩輪：REQUEST_CHANGES（空 changeset 載具）→ 修正 → APPROVE
- [ ] 合併後盯下一個真實 release PR：Quality Checks 於 5 分鐘內自動觸發、全自動合併、tags/releases/部署齊備，零人工

Closes #771

Made with [Cursor](https://cursor.com)