### PR TITLE
fix(starpuff): #835 review 三項 Blocking 收斂——console error 退出碼、EX 勝負回合判定、swallow 門檻 SSOT

### DIFF
--- a/apps/starpuff/scripts/level-audit.mjs
+++ b/apps/starpuff/scripts/level-audit.mjs
@@ -113,17 +113,9 @@ async function runStandardAudit(page, level, { tier, ex, capSec, runCount, error
       // 勝利動線：Game → Result →（自動）Map；L20 全破走 Credits。
       if (scene === 'Result' || scene === 'Map' || scene === 'Credits') {
         if (isBoss) {
-          const won =
-            scene !== 'Result'
-              ? true
-              : ex
-                ? await page
-                    .evaluate(
-                      (id) => window.__sp.save().levels[String(id)]?.exCleared === true,
-                      level.id,
-                    )
-                    .catch(() => false)
-                : (metrics?.bossKilled ?? false);
+          // 勝負以回合指標判定（bossKilled＋Result 場景）：持久 save 的 exCleared
+          // 首勝後恆為 true，多次執行會污染後續回合的通關率。
+          const won = scene !== 'Result' ? true : (metrics?.bossKilled ?? false);
           if (won) {
             result = 'cleared';
             break;
@@ -249,7 +241,7 @@ function standardMd(r) {
 }
 
 // ===== 探針包裝（門檻裁定引 SSOT）=====
-async function runProbe(page, name, level) {
+async function runProbe(page, name, level, overrides = {}) {
   if (name === 'jump') {
     const matrix = jumpFeasibilityMatrix(
       Object.fromEntries(
@@ -297,8 +289,8 @@ async function runProbe(page, name, level) {
   }
   if (name === 'swallow') {
     const result = await runSwallowProbe(page, {
-      runs: Number(opt('runs', '100')),
-      spinRuns: Number(opt('spin-runs', '30')),
+      runs: overrides.runs ?? Number(opt('runs', '100')),
+      spinRuns: overrides.spinRuns ?? Number(opt('spin-runs', '30')),
     });
     return {
       probe: 'swallow',
@@ -433,8 +425,8 @@ function baselineMd(rows, probes) {
     lines.push(
       '## #811 殼殼吞食成功率',
       '',
-      `- 正確時機（暈眩窗）：${Math.round((s.stunSuccessRate ?? 0) * 100)}%（${s.stunAttempts} 次）｜門檻 ≥60% → ${s.stunMeets ? '達標' : '未達標'}`,
-      `- 衝刺（縮殼旋轉）期：${Math.round((s.spinSuccessRate ?? 0) * 100)}%（${s.spinAttempts} 次）｜門檻 0% → ${s.spinMeets ? '達標' : '未達標'}`,
+      `- 正確時機（暈眩窗）：${Math.round((s.stunSuccessRate ?? 0) * 100)}%（${s.stunAttempts} 次）｜門檻 ≥${Math.round(AUDIT_THRESHOLDS.swallowStunMinRate * 100)}% → ${s.stunMeets ? '達標' : '未達標'}`,
+      `- 衝刺（縮殼旋轉）期：${Math.round((s.spinSuccessRate ?? 0) * 100)}%（${s.spinAttempts} 次）｜門檻 ≤${Math.round(AUDIT_THRESHOLDS.swallowSpinMaxRate * 100)}% → ${s.spinMeets ? '達標' : '未達標'}`,
       `- 暈眩窗實測：平均 ${s.avgWindowMs ?? '—'}ms｜成功吸入耗時：平均 ${s.avgReactToSwallowMs ?? '—'}ms`,
       '',
     );
@@ -444,7 +436,7 @@ function baselineMd(rows, probes) {
     lines.push(
       '## #812 星暴誤放恢復',
       '',
-      `- 全走動關恢復：p50 ${fmtSec(sb.globalP50Ms)}s｜p95 ${fmtSec(sb.globalP95Ms)}s｜45s 未恢復 ${sb.timeouts} 次｜門檻 p95 ≤10s → ${sb.meetsThreshold === null ? '—' : sb.meetsThreshold ? '達標' : '未達標'}`,
+      `- 全走動關恢復：p50 ${fmtSec(sb.globalP50Ms)}s｜p95 ${fmtSec(sb.globalP95Ms)}s｜45s 未恢復 ${sb.timeouts} 次｜門檻 p95 ≤${fmtSec(AUDIT_THRESHOLDS.starburstRecoveryP95Ms)}s → ${sb.meetsThreshold === null ? '—' : sb.meetsThreshold ? '達標' : '未達標'}`,
       '',
       '| 關 | 樣本 | p50 s | p95 s | 未恢復 |',
       '| -- | ---- | ----- | ----- | ------ |',
@@ -483,12 +475,7 @@ async function main() {
       const probes = {};
       probes.jump = await runProbe(page, 'jump', null);
       probes.telegraph = await runProbe(page, 'telegraph', null);
-      probes.swallow = await runSwallowProbe(page, { runs: 40, spinRuns: 15 }).then((r) => ({
-        probe: 'swallow',
-        ...r,
-        stunMeets: r.stunSuccessRate !== null ? r.stunSuccessRate >= 0.6 : null,
-        spinMeets: r.spinSuccessRate !== null ? r.spinSuccessRate <= 0 : null,
-      }));
+      probes.swallow = await runProbe(page, 'swallow', null, { runs: 40, spinRuns: 15 });
       probes.starburst = await runProbe(page, 'starburst', null);
       const name = `baseline-${baseSha}`;
       writeReport(name, { baseSha, rows, probes }, baselineMd(rows, probes));
@@ -524,10 +511,11 @@ async function main() {
     console.log(JSON.stringify(summary, null, 2));
   } finally {
     await browser.close();
-  }
-  if (errors.length > 0) {
-    console.error(`console errors ×${errors.length}：\n${errors.slice(0, 5).join('\n')}`);
-    process.exitCode = 1;
+    // console error 檢查置於 finally：--all/--probe 提前 return 也必經，確保非零退出。
+    if (errors.length > 0) {
+      console.error(`console errors ×${errors.length}：\n${errors.slice(0, 5).join('\n')}`);
+      process.exitCode = 1;
+    }
   }
 }
 

--- a/apps/starpuff/scripts/lib/audit-driver.mjs
+++ b/apps/starpuff/scripts/lib/audit-driver.mjs
@@ -103,6 +103,10 @@ export function installAuditDriver(opts) {
     lastMoveAt: 0,
     stop: false,
   };
+  // 暴露給 stopDriver：停 driver 時放開全部持鍵，避免殘留輸入影響後續量測。
+  d.releaseAll = () => {
+    for (const k of [...held]) release(k);
+  };
   window.__audit = d;
 
   const readSnap = () => {

--- a/apps/starpuff/scripts/lib/audit-session.mjs
+++ b/apps/starpuff/scripts/lib/audit-session.mjs
@@ -77,6 +77,7 @@ export async function stopDriver(page) {
       if (window.__audit) {
         window.__audit.stop = true;
         clearInterval(window.__audit.interval);
+        window.__audit.releaseAll?.();
       }
     })
     .catch(() => {});

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+5（reward 5、penalty 0、neutral 1）｜累計總分：+161
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+162
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-22
+- ID：reward-starpuff-835-audit-hotfix-review-blocking
+- 原因：#835 review 三項 Blocking——console error 於 --all/--probe 提前 return 跳過退出檢查、EX 勝負誤讀持久 save exCleared 污染多輪通關率、--all swallow 門檻硬編 0.6/0 漂移 SSOT
+- 解法：錯誤檢查移入 finally 必經、EX 勝負改回合指標 bossKilled＋Result、--all 改走 runProbe 引 AUDIT_THRESHOLDS，另補 stopDriver releaseAll 放鍵與 baselineMd 門檻文字插值
 
 - 日期：2026-07-22
 - ID：neutral-starpuff-t1-audit-cli-docs-sync


### PR DESCRIPTION
## 摘要

收斂已合併 #835（#818 難度量化 CLI）的 review Blocking 項目（雙審查席共識），並順帶修正兩項 trivial。不改變任何遊戲 runtime 行為，變更僅限稽核腳本與 002 記錄。

## Blocking 修復

1. **console error 退出碼**（`level-audit.mjs`）：`--all` 與 `--probe` 路徑在 try 內提前 `return`，尾端 `errors.length` 檢查被跳過。修法：檢查移入 `finally`，任何路徑（含提前 return）必經，browser console/pageerror 一律 `exitCode=1`。
2. **EX 通關率污染**（`level-audit.mjs` 原 L113–126）：EX 勝負原讀持久 save 的 `exCleared`，首勝後恆為 true，多輪執行會把後續失敗誤判 cleared。修法：改以回合指標判定——`metrics.bossKilled` ＋ Result 場景，與非 EX 同口徑。
3. **swallow 門檻 SSOT**（`level-audit.mjs` 原 L486–491）：`--all` 路徑硬編 `0.6`/`0`。修法：改走 `runProbe(page, 'swallow', null, { runs: 40, spinRuns: 15 })` 統一包裝，門檻一律引 `AUDIT_THRESHOLDS.swallowStunMinRate` / `swallowSpinMaxRate`。

## Trivial 順修

- `baselineMd()` 殼殼（≥60%/0%）與星暴（≤10s）門檻文字改由 `AUDIT_THRESHOLDS` 插值。
- `audit-driver.mjs` 暴露 `releaseAll`，`stopDriver()` 停止時放開全部合成持鍵，避免殘留輸入污染下一輪量測。
- 002 檔頭記分修正（#835 記分不一致 thread）：本批 +1（reward 1、penalty 0、neutral 0）、累計 +162（前值 +161 正確保留）。

## 驗證

- `pnpm --filter @app/starpuff test`：50 files / 692 tests passed
- `pnpm --filter @app/starpuff typecheck`：通過
- pre-push：typecheck + test + build:ratewise 全數通過

Refs #818；收斂 #835 review threads。

Made with [Cursor](https://cursor.com)