### PR TITLE
feat(starpuff): T5 W2 魔王主題化 Prismix/Syrona 招式 (#813)

### DIFF
--- a/apps/starpuff/docs/GAME_DESIGN.md
+++ b/apps/starpuff/docs/GAME_DESIGN.md
@@ -968,7 +968,9 @@ epic 資料夾（art-v8-ticket.md / run-art-v8.sh）。
 變化」迫使玩家切換單體集火與多目標處理。HP 80（階梯 60→52→80）、體傷 1、狂暴 ×1.15、
 每損 10 HP 掉補給（§26）。
 
-- 三階段（phase truth 全收斂 FSM；呈現層 systems/prismix.ts 接 BossHandle）：
+- 三階段（phase truth 全收斂 FSM；呈現層 systems/prismix.ts 接 BossHandle）
+  （v22 已由 §112 取代：固定循環改 `prismixMoveTable` 加權表選招，P2 追加鏡界反射與
+  鏡像殘影；招池數值與 telegraph 不變）：
   - P1 單體（總血 >66%）：`idle(1.5s) → 晶柱衝擊（地面尖晶 ×3，落點預警 0.95s）→ idle →
 折射光束（橫掃一次，預示線 0.5s）→ …`
   - 晶柱預警（#810 修復）：0.6s→0.95s——500ms 反應玩家迴避率 0%→88%（工具實測）；
@@ -1084,7 +1086,9 @@ epic 資料夾（art-v8-ticket.md / run-art-v8.sh）。
 王窯座（不追打），威脅來自「地形被改寫」：潮汐、噴泉、滴落把可站空間動態壓縮，
 考驗空間規劃。HP **90**（階梯 60→52→80→90）、體傷 1、狂暴 ×1.15、每損 10 HP 掉補給。
 
-- 三階段（phase truth 全收斂 FSM；呈現層 systems/syrona.ts 接 BossHandle）：
+- 三階段（phase truth 全收斂 FSM；呈現層 systems/syrona.ts 接 BossHandle）
+  （v22 已由 §112 取代：固定循環改 `syronaMoveTable` 加權表選招，糖漿波追加焦糖化；
+  招池數值與 telegraph 不變）：
   - P1（>66%）：`糖漿噴泉（地面點 ×3 順序噴發，冒泡 telegraph 0.8s）→ 散熱僵直 2.5s →
 焦糖射彈（拋物 ×3，舉臂 0.5s）→ 僵直 → …`
   - P2（66-33%）：**潮汐入場**（phase 事件觸發 startTide，沿 §71 管線）；循環
@@ -2099,3 +2103,47 @@ t2b-812-sb-l*.json`。
   僅月牙軌跡粒子可見；進出各 180ms fade 無跳變。
 - 反制（吸入第二用途）：按住吸入產生氣流擾動使輪廓顯形（alpha 0.06 → 0.5）；
   hooks `isPlayerInhaling` 由 bossFactory 接線 player.isInhaling()。
+
+## 112. v22 魔王主題化 W2——Prismix/Syrona 加權選招與主題招式（#813；T5 列車）
+
+取代標註：§68 P1-P3 固定循環由 `prismixMoveTable` 加權表取代、§74 三階段循環由
+`syronaMoveTable` 加權表取代（既有招池數值不變，僅選招機制升級＋主題招式擴池）；
+telegraph 窗全部維持現值不降（可讀性紅線）。基礎設施沿 §111.1 moveTable SSOT。
+
+### 112.1 加權選招接入（沿 §111.1，兩王 FSM 增 rng/setTargetDistance）
+
+- Prismix：P1 晶柱 3／光束 3；P2 夾擊 3／交錯光束 3／召喚 2／鏡界反射 2／鏡像殘影 1
+  （條件欄 `maxHpRatio: 0.5`——總血 ≤50% 深段才入池，HP 帶條件示例）；P3 彈幕 3／晶雨 3。
+- Syrona：P1 噴泉 3／射彈 3（條件欄 `band: 'far'`——貼身拋物不可讀，沿 Jellord dash
+  遠距帶理據）；P2 滴落 3／噴泉 3／召喚 2；P3 糖漿波 3／超載 3。
+- 換階段清空同招記錄；rng 注入同 seed 可重放（Syrona 與噴泉洗牌共用同一 rng）。
+- 條件熵驗收（#818 口徑，seed 13 × 60 招）：Prismix P1 0.90／P2 1.47（≤50% 深段 1.93）、
+  Syrona P1 0.90／P2 1.38／P3 0.90 bits，全數 ≥ `AUDIT_THRESHOLDS.moveEntropyMinBits`（0.5）。
+
+### 112.2 Prismix 主題招式「鏡界反射」（FSM 態內建）
+
+- P2 新招 `mirror`：單具開鏡 0.8s（銀白鏡光面板 telegraph，固定不隨狂暴縮放）；
+  開鏡側受擊零傷、FSM 回 `reflect` 事件，呈現層自該具生成折返彈射向玩家。
+- 反制（可學習）：開鏡窗內打另一具照常結算；折返彈帶 `inhalable` 標記——吸入中接觸
+  即回收為彈藥（免費彈藥＝獎勵理解，L9 mirri 已預教鏡性）；不吸則照常 1 傷。
+- 開鏡側由 rng 抽選（同 seed 可重放）；單側殘存防呆歸存活具。
+
+### 112.3 Prismix 主題招式「鏡像殘影」（logic/mirrorShadow.ts）
+
+- P2 深段（總血 ≤50%）低頻新招 `shadow`：玩家鏡影自 arena 中線鏡射位現身——
+  水平反向移動（玩家逐幀位移取負向套用）、垂直速度上限跟隨、觸傷 1、6s 壽命、
+  1 發星彈即破；單具重生刷新（不疊加）。
+- 反制（mirri 鏡性課）：反向移動特性＝向遠離殘影方向移動即以雙倍速率分離；
+  一發基礎星彈即可拆除（anti-softlock：基礎星彈恆可清）。
+- 工程接點：殘影 sprite 雙掛既有 `shields`（星彈可破）＋`shockwaves`（觸傷）群組，
+  BossHandle 零新選配；碎晶盾軌道迴圈以 `shadow` data 旗標跳過。
+
+### 112.4 Syrona 主題招式「焦糖化」（logic/caramel.ts + systems/caramelStatus.ts）
+
+- P3 糖漿波帶 `caramel` 旗標：沾身減速 30%/3s（琥珀色腳部沾糖粒子），重複沾波刷新
+  不疊加；狀態真值收斂 logic/caramel.ts，呈現編排收斂 systems/caramelStatus.ts
+  （守 GameScene 1200 行閘），移速與 buff 倍率單點合成注入 player（防互相覆寫）。
+- 反制（可學習）：乘噴口氣流吹乾即解除（`getVentLift` 供力當幀清除）；雷化放電瞬除
+  （volt 形態既免疫沾身也瞬除既有沾身——變身優勢解）；首次沾身浮字教學（session 一次）。
+- overlaps 接點：shockwave 命中玩家時讀 `caramel` data 旗標經 `applyCaramel` hook 結算，
+  傷害照常走 `damagePlayer` 單一入口。

--- a/apps/starpuff/src/game/logic/caramel.test.ts
+++ b/apps/starpuff/src/game/logic/caramel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CARAMEL,
+  CARAMEL_CLEAR,
+  applyCaramel,
+  caramelActive,
+  caramelSpeedMul,
+  tickCaramel,
+} from './caramel';
+
+describe('焦糖化（§5 W2）', () => {
+  it('規格定值：減速 30%（倍率 0.7）、持續 3s', () => {
+    expect(CARAMEL.slowMul).toBeCloseTo(0.7, 5);
+    expect(CARAMEL.durationMs).toBe(3000);
+  });
+
+  it('沾身滿窗、重複沾波刷新不疊加', () => {
+    const state = applyCaramel();
+    expect(state.remainingMs).toBe(CARAMEL.durationMs);
+    const half = tickCaramel(state, 1500);
+    expect(applyCaramel().remainingMs).toBe(CARAMEL.durationMs);
+    expect(half.remainingMs).toBe(1500);
+  });
+
+  it('倒數期滿自然解除；未沾身恆為非活', () => {
+    let state = applyCaramel();
+    state = tickCaramel(state, 2999);
+    expect(caramelActive(state)).toBe(true);
+    state = tickCaramel(state, 1);
+    expect(caramelActive(state)).toBe(false);
+    expect(caramelActive(CARAMEL_CLEAR)).toBe(false);
+  });
+
+  it('移速倍率：沾身期 0.7、解除後 1', () => {
+    expect(caramelSpeedMul(applyCaramel())).toBeCloseTo(CARAMEL.slowMul, 5);
+    expect(caramelSpeedMul(CARAMEL_CLEAR)).toBe(1);
+  });
+
+  it('tick 不產生負值', () => {
+    const state = tickCaramel(applyCaramel(), 99999);
+    expect(state.remainingMs).toBe(0);
+  });
+});

--- a/apps/starpuff/src/game/logic/caramel.ts
+++ b/apps/starpuff/src/game/logic/caramel.ts
@@ -1,0 +1,35 @@
+// 焦糖化純邏輯（GAME_DESIGN §5 / #813 W2）：Syrona 糖漿波沾身減速 30%/3s。
+// 反制：乘噴口氣流吹乾即解除；雷化放電瞬除（變身優勢解）。
+// 不 import phaser，vitest 對象；GameScene 持有狀態並與 buff 移速倍率疊乘注入。
+
+export const CARAMEL = {
+  // 減速 30%（§5 定值）：移速倍率 0.7。
+  slowMul: 0.7,
+  durationMs: 3000,
+  // 琥珀色（腳部沾糖視覺 tint）。
+  tint: 0xd98e2b,
+} as const;
+
+export interface CaramelState {
+  remainingMs: number;
+}
+
+export const CARAMEL_CLEAR: CaramelState = { remainingMs: 0 };
+
+// 沾身重置滿窗（重複沾波刷新，不疊加）。
+export function applyCaramel(): CaramelState {
+  return { remainingMs: CARAMEL.durationMs };
+}
+
+export function tickCaramel(state: CaramelState, deltaMs: number): CaramelState {
+  if (state.remainingMs <= 0) return state;
+  return { remainingMs: Math.max(0, state.remainingMs - deltaMs) };
+}
+
+export function caramelActive(state: CaramelState): boolean {
+  return state.remainingMs > 0;
+}
+
+export function caramelSpeedMul(state: CaramelState): number {
+  return caramelActive(state) ? CARAMEL.slowMul : 1;
+}

--- a/apps/starpuff/src/game/logic/mirrorShadow.test.ts
+++ b/apps/starpuff/src/game/logic/mirrorShadow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIRROR_SHADOW,
+  shadowActive,
+  shadowSpawnX,
+  stepShadowX,
+  stepShadowY,
+} from './mirrorShadow';
+
+describe('鏡像殘影（§5 W2）', () => {
+  it('規格定值：壽命 6s、觸傷 1、1 發即破', () => {
+    expect(MIRROR_SHADOW.lifespanMs).toBe(6000);
+    expect(MIRROR_SHADOW.touchDamage).toBe(1);
+    expect(MIRROR_SHADOW.hp).toBe(1);
+  });
+
+  it('生成位為 arena 中線鏡射', () => {
+    expect(shadowSpawnX(400, 100)).toBe(700);
+    expect(shadowSpawnX(400, 400)).toBe(400);
+    expect(shadowSpawnX(400, 650)).toBe(150);
+  });
+
+  it('水平反向移動：玩家位移取負向套用（遠離殘影＝加速分離）', () => {
+    // 玩家右移 10 → 殘影左移 10。
+    expect(stepShadowX(700, 10)).toBe(690);
+    // 玩家左移 10 → 殘影右移 10。
+    expect(stepShadowX(700, -10)).toBe(710);
+    // 玩家不動 → 殘影不動。
+    expect(stepShadowX(700, 0)).toBe(700);
+  });
+
+  it('分離律：玩家向遠離殘影方向移動時間距單調擴大', () => {
+    // 玩家 100（殘影 700 右側）向左走：間距擴大。
+    let playerX = 100;
+    let shadowX = 700;
+    let gap = Math.abs(shadowX - playerX);
+    for (let i = 0; i < 5; i += 1) {
+      playerX -= 8;
+      shadowX = stepShadowX(shadowX, -8);
+      const next = Math.abs(shadowX - playerX);
+      expect(next).toBeGreaterThan(gap);
+      gap = next;
+    }
+  });
+
+  it('垂直跟隨：速度上限逼近，不瞬移', () => {
+    // 16ms 幀最大步長 = 320 * 0.016 = 5.12px。
+    expect(stepShadowY(100, 300, 16)).toBeCloseTo(105.12, 2);
+    expect(stepShadowY(300, 100, 16)).toBeCloseTo(294.88, 2);
+    // 差距小於步長時直接貼齊。
+    expect(stepShadowY(100, 102, 16)).toBe(102);
+  });
+
+  it('壽命窗：6s 內存活、期滿消散、未生成（-1）恆為非活', () => {
+    expect(shadowActive(1000, 1000 + MIRROR_SHADOW.lifespanMs - 1)).toBe(true);
+    expect(shadowActive(1000, 1000 + MIRROR_SHADOW.lifespanMs)).toBe(false);
+    expect(shadowActive(-1, 5000)).toBe(false);
+  });
+});

--- a/apps/starpuff/src/game/logic/mirrorShadow.ts
+++ b/apps/starpuff/src/game/logic/mirrorShadow.ts
@@ -1,0 +1,36 @@
+// 鏡像殘影純邏輯（GAME_DESIGN §5 / #813 W2）：Prismix P2 生成玩家鏡影——
+// 水平反向移動、觸傷 1、6s 壽命、1 發星彈即破（mirri 鏡性課的魔王級運用）。
+// 不 import phaser，vitest 對象；呈現層（systems/prismix.ts）持有 sprite 與群組接線。
+
+export const MIRROR_SHADOW = {
+  // 壽命 6s（§5 定值）：期滿自然消散。
+  lifespanMs: 6000,
+  // 觸傷 1＝魔王體傷同級（走既有 shockwaves 觸傷管線）。
+  touchDamage: 1,
+  // 1 發星彈即破（走既有 shields 星彈屏障管線）。
+  hp: 1,
+  // 垂直跟隨平滑係數（px/s 上限）：殘影縱向逼近玩家高度，不瞬移。
+  followYMaxPxPerSec: 320,
+} as const;
+
+// 生成位：玩家鏡射於 arena 中線另一側（鏡像語彙；貼身直傷不可讀）。
+export function shadowSpawnX(arenaCenterX: number, playerX: number): number {
+  return 2 * arenaCenterX - playerX;
+}
+
+// 水平反向移動（§5）：玩家每幀位移取負向套用——向遠離殘影方向移動即加速分離。
+export function stepShadowX(shadowX: number, playerDeltaX: number): number {
+  return shadowX - playerDeltaX;
+}
+
+// 垂直跟隨：速度上限逼近玩家高度（連續移動，杜絕瞬移）。
+export function stepShadowY(shadowY: number, playerY: number, deltaMs: number): number {
+  const maxStep = (MIRROR_SHADOW.followYMaxPxPerSec * deltaMs) / 1000;
+  const diff = playerY - shadowY;
+  if (Math.abs(diff) <= maxStep) return playerY;
+  return shadowY + Math.sign(diff) * maxStep;
+}
+
+export function shadowActive(spawnAtMs: number, nowMs: number): boolean {
+  return spawnAtMs >= 0 && nowMs - spawnAtMs < MIRROR_SHADOW.lifespanMs;
+}

--- a/apps/starpuff/src/game/logic/prismixFsm.test.ts
+++ b/apps/starpuff/src/game/logic/prismixFsm.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { AUDIT_THRESHOLDS } from './difficulty';
+import { AUDIT_THRESHOLDS, sequenceEntropyBits } from './difficulty';
+import { createSeededRng } from './moveTable';
 import {
   EX_PRISMIX,
   PRISMIX,
   createPrismixFsm,
-  prismixAttackCycle,
+  prismixMoveTable,
   type PrismixCommand,
   type PrismixHitEvent,
 } from './prismixFsm';
@@ -19,49 +20,84 @@ function drain(fsm: ReturnType<typeof createPrismixFsm>, steps: number): Prismix
   return commands;
 }
 
+// 收集非 idle 指令直到數量滿足。
+function collectAttacks(fsm: ReturnType<typeof createPrismixFsm>, count: number): PrismixCommand[] {
+  const commands: PrismixCommand[] = [];
+  for (let i = 0; i < 5000 && commands.length < count; i += 1) {
+    const command = fsm.tick(50);
+    if (command && command.kind !== 'idle') commands.push(command);
+  }
+  return commands;
+}
+
+// 驅動至指定指令出現，回傳該指令；逾迭代上限回 null。
+function driveTo(
+  fsm: ReturnType<typeof createPrismixFsm>,
+  kind: PrismixCommand['kind'],
+): PrismixCommand | null {
+  for (let i = 0; i < 5000; i += 1) {
+    const command = fsm.tick(50);
+    if (command?.kind === kind) return command;
+  }
+  return null;
+}
+
 function eventKinds(events: PrismixHitEvent[]): string[] {
   return events.map((event) => event.kind);
 }
 
 // 造出 P2：自滿血打到分裂閾值以下。
-function splitFsm(): ReturnType<typeof createPrismixFsm> {
-  const fsm = createPrismixFsm();
+function splitFsm(seed = 1): ReturnType<typeof createPrismixFsm> {
+  const fsm = createPrismixFsm({ rng: createSeededRng(seed) });
   fsm.takeDamage(28);
   expect(fsm.phase).toBe('p2');
   return fsm;
 }
 
-describe('PRISMIX 常數與循環表（§68）', () => {
-  it('HP 階梯 80、telegraph 全數 ≥500ms、三階段循環表對表', () => {
+describe('PRISMIX 常數與加權表（§68/§112）', () => {
+  it('HP 階梯 80、telegraph 全數 ≥500ms、三階段招池對表', () => {
     expect(PRISMIX.maxHp).toBe(80);
     // #810：地面尖刺前搖須容納 500ms 反應玩家（下限對齊 AUDIT_THRESHOLDS.spikeTelegraphMinMs）。
     expect(PRISMIX.pillarTelegraphMs).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.spikeTelegraphMinMs);
     expect(PRISMIX.beamTelegraphMs).toBeGreaterThanOrEqual(500);
     expect(PRISMIX.pincerTelegraphMs).toBeGreaterThanOrEqual(500);
     expect(PRISMIX.rainTelegraphMs).toBeGreaterThanOrEqual(500);
-    expect(prismixAttackCycle('p1')).toEqual(['pillar', 'beam']);
-    expect(prismixAttackCycle('p2')).toEqual(['pincer', 'crossbeam', 'summon']);
-    expect(prismixAttackCycle('p3')).toEqual(['barrage', 'rain']);
+    expect(prismixMoveTable('p1').map((m) => m.action)).toEqual(['pillar', 'beam']);
+    expect(prismixMoveTable('p2').map((m) => m.action)).toEqual([
+      'pincer',
+      'crossbeam',
+      'summon',
+      'mirror',
+      'shadow',
+    ]);
+    expect(prismixMoveTable('p3').map((m) => m.action)).toEqual(['barrage', 'rain']);
+  });
+
+  it('鏡界反射開鏡窗 0.8s（≥600ms 可讀性紅線）；鏡像殘影為低頻＋HP 帶條件', () => {
+    expect(PRISMIX.mirrorDurationMs).toBe(800);
+    expect(PRISMIX.mirrorDurationMs).toBeGreaterThanOrEqual(600);
+    const table = prismixMoveTable('p2');
+    const shadow = table.find((m) => m.action === 'shadow');
+    expect(shadow).toBeDefined();
+    for (const move of table) {
+      if (move.action !== 'shadow') expect(move.weight).toBeGreaterThan(shadow?.weight ?? 0);
+    }
+    expect(shadow?.condition).toEqual({ maxHpRatio: 0.5 });
   });
 });
 
 describe('P1 單體（§68）', () => {
-  it('招式沿 pillar → idle → beam → idle 輪替且帶正確參數', () => {
-    const fsm = createPrismixFsm();
-    const commands = drain(fsm, 8);
-    expect(commands.map((c) => c.kind)).toEqual([
-      'pillar',
-      'idle',
-      'beam',
-      'idle',
-      'pillar',
-      'idle',
-      'beam',
-      'idle',
-    ]);
-    const pillar = commands[0];
-    if (pillar?.kind !== 'pillar') throw new Error('首招應為晶柱');
-    expect(pillar.count).toBe(PRISMIX.pillarCount);
+  it('首招屬 P1 招池且帶正確參數；攻擊期滿回 idle', () => {
+    const fsm = createPrismixFsm({ rng: createSeededRng(1) });
+    const commands = drain(fsm, 6);
+    const pool = ['pillar', 'beam'];
+    const attacks = commands.filter((c) => c.kind !== 'idle');
+    expect(attacks.length).toBeGreaterThan(0);
+    for (const attack of attacks) expect(pool).toContain(attack.kind);
+    const pillar = attacks.find((c) => c.kind === 'pillar');
+    if (pillar?.kind === 'pillar') expect(pillar.count).toBe(PRISMIX.pillarCount);
+    // 攻擊與 idle 交替：偶數位攻擊、奇數位 idle。
+    expect(commands.filter((c) => c.kind === 'idle').length).toBeGreaterThan(0);
   });
 
   it('每損 10 HP 掉補給小怪（§26 飢荒保證律）', () => {
@@ -71,7 +107,7 @@ describe('P1 單體（§68）', () => {
   });
 
   it('總血 ≤66% 觸發分裂：剩餘均分為雙獨立血條、循環切 P2', () => {
-    const fsm = createPrismixFsm();
+    const fsm = createPrismixFsm({ rng: createSeededRng(2) });
     const events = fsm.takeDamage(28);
     expect(eventKinds(events)).toEqual(['damaged', 'minionDrop', 'minionDrop', 'phase', 'split']);
     const split = events.find((e) => e.kind === 'split');
@@ -80,7 +116,8 @@ describe('P1 單體（§68）', () => {
     expect(Math.abs(split.hpA - split.hpB)).toBeLessThanOrEqual(1);
     expect(fsm.twins).toEqual({ a: 26, b: 26 });
     expect(fsm.hp).toBe(52);
-    expect(drain(fsm, 1)[0]?.kind).toBe('pincer');
+    const pool = prismixMoveTable('p2').map((m) => m.action);
+    expect(pool).toContain(drain(fsm, 1)[0]?.kind);
   });
 });
 
@@ -113,7 +150,10 @@ describe('P2 鏡像雙子（§68 獨立血條）', () => {
     expect(fsm.phase).toBe('p3');
     expect(fsm.hp).toBe(20);
     expect(fsm.twins).toBeNull();
-    expect(drain(fsm, 4).map((c) => c.kind)).toEqual(['barrage', 'idle', 'rain', 'idle']);
+    const pool = prismixMoveTable('p3').map((m) => m.action);
+    for (const command2 of drain(fsm, 4)) {
+      expect(['idle', ...pool]).toContain(command2.kind);
+    }
   });
 
   it('掙扎窗內補殺第二具＝雙子連破：跳過 P3 直接擊破', () => {
@@ -145,12 +185,82 @@ describe('P2 鏡像雙子（§68 獨立血條）', () => {
   });
 
   it('interruptSummon 僅召喚態可中斷（§58 雷化斷召慣例）', () => {
-    const fsm = splitFsm();
+    const fsm = splitFsm(3);
     expect(fsm.interruptSummon()).toBe(false);
-    drain(fsm, 5); // pincer idle crossbeam idle summon
+    expect(driveTo(fsm, 'summon')).not.toBeNull();
     expect(fsm.state).toBe('summon');
     expect(fsm.interruptSummon()).toBe(true);
     expect(fsm.state).toBe('idle');
+  });
+});
+
+describe('鏡界反射（§5 W2）', () => {
+  it('開鏡側受擊零傷折返 reflect 事件；另一具照常結算（反制）', () => {
+    const fsm = splitFsm(5);
+    const mirror = driveTo(fsm, 'mirror');
+    if (mirror?.kind !== 'mirror') throw new Error('未抽到開鏡');
+    expect(mirror.durationMs).toBe(PRISMIX.mirrorDurationMs);
+    expect(fsm.state).toBe('mirror');
+    const before = fsm.twins;
+    const reflected = fsm.takeDamage(5, mirror.side);
+    expect(reflected).toEqual([{ kind: 'reflect', side: mirror.side }]);
+    expect(fsm.twins).toEqual(before);
+    // 反制：窗內打另一具照常扣血。
+    const other = mirror.side === 'a' ? 'b' : 'a';
+    const events = fsm.takeDamage(5, other);
+    expect(eventKinds(events)).toContain('damaged');
+  });
+
+  it('開鏡窗期滿恢復可傷（0.8s 固定不隨狂暴縮放）', () => {
+    const fsm = splitFsm(5);
+    const mirror = driveTo(fsm, 'mirror');
+    if (mirror?.kind !== 'mirror') throw new Error('未抽到開鏡');
+    fsm.tick(PRISMIX.mirrorDurationMs);
+    expect(fsm.state).toBe('idle');
+    const events = fsm.takeDamage(5, mirror.side);
+    expect(eventKinds(events)).toContain('damaged');
+  });
+});
+
+describe('鏡像殘影（§5 W2 HP 帶條件）', () => {
+  it('總血 >50% 不入池；≤50% 深段抽得到 shadow 指令', () => {
+    // 分裂後 52/80 = 65% > 50%：長時序列不得出現 shadow。
+    const high = splitFsm(7);
+    const highKinds = collectAttacks(high, 40).map((c) => c.kind);
+    expect(highKinds).not.toContain('shadow');
+    // 打到 39/80 = 48.75% ≤ 50%：shadow 入池（低頻 w1，長序列必然出現）。
+    const low = splitFsm(7);
+    low.takeDamage(13, 'a');
+    const lowKinds = collectAttacks(low, 60).map((c) => c.kind);
+    expect(lowKinds).toContain('shadow');
+  });
+});
+
+describe('加權選招治理（§5 去背板）', () => {
+  it('同 seed 可完整重放；不同 seed 序列偏離', () => {
+    const run = (seed: number): string[] => {
+      const fsm = createPrismixFsm({ rng: createSeededRng(seed) });
+      return collectAttacks(fsm, 20).map((c) => c.kind);
+    };
+    expect(run(11)).toEqual(run(11));
+    // 舊固定循環：P1 pillar→beam 交替。
+    const legacy = Array.from({ length: 20 }, (_, i) => (i % 2 === 0 ? 'pillar' : 'beam'));
+    expect(run(11)).not.toEqual(legacy);
+  });
+
+  it('連續同招上限 2：長時序列無三連同招', () => {
+    const fsm = createPrismixFsm({ rng: createSeededRng(4) });
+    const kinds = collectAttacks(fsm, 60).map((c) => c.kind);
+    for (let i = 2; i < kinds.length; i += 1) {
+      expect(new Set(kinds.slice(i - 2, i + 1)).size).toBeGreaterThan(1);
+    }
+  });
+
+  it('招式序列條件熵 ≥ 門檻（#813；AUDIT_THRESHOLDS.moveEntropyMinBits 口徑）', () => {
+    const fsm = createPrismixFsm({ rng: createSeededRng(13) });
+    const kinds = collectAttacks(fsm, 60).map((c) => c.kind);
+    expect(kinds.length).toBeGreaterThanOrEqual(40);
+    expect(sequenceEntropyBits(kinds)).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.moveEntropyMinBits);
   });
 });
 

--- a/apps/starpuff/src/game/logic/prismixFsm.ts
+++ b/apps/starpuff/src/game/logic/prismixFsm.ts
@@ -1,7 +1,8 @@
 import type { BossPhase } from '../core/types';
 import { EX_MODS } from './bossFsm';
+import { distanceBandOf, pickMove, type WeightedMove } from './moveTable';
 
-// 稜晶雙子 Prismix FSM 純邏輯（GAME_DESIGN §68，不 import phaser），vitest 對象。
+// 稜晶雙子 Prismix FSM 純邏輯（GAME_DESIGN §68/§112，不 import phaser），vitest 對象。
 // 分裂型三段：P1 單體 → P2 鏡像雙子（獨立血條各半，單份指令左右鏡像執行）→
 // P3 裂核合體；掙扎窗內相繼擊破兩具＝雙子連破（跳過 P3，觸發 twin-finish 彩蛋）。
 // phase truth 全數收斂於此，禁止散落 scene（沿 bossFsm/noctraFsm 表驅動慣例）。
@@ -41,6 +42,11 @@ export const PRISMIX = {
   // #809：雙生夾擊為衝撞型前搖，對齊 ≥600ms 可讀性紅線（550→600）。
   pincerTelegraphMs: 600,
   rainTelegraphMs: 600,
+  // 鏡界反射（§5 #813 W2）：單具開鏡 0.8s（銀白鏡光 telegraph），射它的星彈折返；
+  // 開鏡窗固定不隨狂暴速率縮放（可讀性紅線），反制＝窗內打另一具。
+  mirrorDurationMs: 800,
+  // 鏡像殘影施放拍（§5 W2）：殘影本體規格見 logic/mirrorShadow.ts SSOT。
+  shadowCastMs: 900,
 } as const;
 
 // Prismix EX 專屬差分（§68）：分裂提前、掙扎窗收短、碎晶盾加密；
@@ -61,7 +67,9 @@ export type PrismixAction =
   | 'summon'
   | 'struggle'
   | 'barrage'
-  | 'rain';
+  | 'rain'
+  | 'mirror'
+  | 'shadow';
 
 export type PrismixSide = 'a' | 'b';
 
@@ -76,10 +84,12 @@ export type PrismixCommand =
   | { kind: 'summon'; cap: number }
   | { kind: 'barrage'; count: number }
   | { kind: 'rain'; count: number }
-  | { kind: 'merge'; coreHp: number; shards: number };
+  | { kind: 'merge'; coreHp: number; shards: number }
+  | { kind: 'mirror'; side: PrismixSide; durationMs: number }
+  | { kind: 'shadow' };
 
 // takeDamage 輸出的傷害驅動事件：split（P1→P2 分裂）、struggle（單具擊破入掙扎窗）、
-// twinFinish（窗內補殺雙子連破，跳過 P3）。
+// twinFinish（窗內補殺雙子連破，跳過 P3）、reflect（鏡界反射：開鏡側受擊零傷折返）。
 export type PrismixHitEvent =
   | { kind: 'damaged'; hp: number }
   | { kind: 'phase'; phase: BossPhase }
@@ -87,7 +97,8 @@ export type PrismixHitEvent =
   | { kind: 'struggle'; survivor: PrismixSide; windowMs: number }
   | { kind: 'twinFinish' }
   | { kind: 'minionDrop' }
-  | { kind: 'defeated' };
+  | { kind: 'defeated' }
+  | { kind: 'reflect'; side: PrismixSide };
 
 const SPEED_FACTORS: Record<BossPhase, number> = {
   p1: 1,
@@ -95,16 +106,29 @@ const SPEED_FACTORS: Record<BossPhase, number> = {
   p3: PRISMIX.enrageSpeedMultiplier,
 };
 
-// 三階段招式循環（§68）：P1 晶柱／折射光束；P2 雙生夾擊／交錯光束／召喚；
-// P3 全域折射彈幕／晶雨。
-export function prismixAttackCycle(phase: BossPhase): readonly PrismixAction[] {
+// 加權選招表（§5 #813 W2）：固定循環改權重＋條件驅動（沿 JELLORD_MOVES 慣例）。
+// P1 晶柱／折射光束；P2 雙生夾擊／交錯光束／召喚＋鏡界反射（開鏡）＋鏡像殘影
+//（低頻，總血 ≤50% 深段才入池——HP 帶條件欄）；P3 全域折射彈幕／晶雨。
+export function prismixMoveTable(phase: BossPhase): readonly WeightedMove<PrismixAction>[] {
   switch (phase) {
     case 'p1':
-      return ['pillar', 'beam'];
+      return [
+        { action: 'pillar', weight: 3 },
+        { action: 'beam', weight: 3 },
+      ];
     case 'p2':
-      return ['pincer', 'crossbeam', 'summon'];
+      return [
+        { action: 'pincer', weight: 3 },
+        { action: 'crossbeam', weight: 3 },
+        { action: 'summon', weight: 2 },
+        { action: 'mirror', weight: 2 },
+        { action: 'shadow', weight: 1, condition: { maxHpRatio: 0.5 } },
+      ];
     case 'p3':
-      return ['barrage', 'rain'];
+      return [
+        { action: 'barrage', weight: 3 },
+        { action: 'rain', weight: 3 },
+      ];
     default: {
       const unhandled: never = phase;
       throw new Error(`未知階段：${String(unhandled)}`);
@@ -126,14 +150,19 @@ export interface PrismixFsm {
   takeDamage(amount: number, side?: PrismixSide): PrismixHitEvent[];
   // 雷化鏈電中斷召喚（§58 慣例）：僅召喚態可中斷，成功回 true。
   interruptSummon(): boolean;
+  // 距離帶餵送（§5 條件欄）：呈現層逐幀回報與玩家距離；未餵送視為 far。
+  setTargetDistance(distancePx: number | null): void;
 }
 
 export interface PrismixFsmOptions {
   ex?: boolean;
+  // 加權選招亂數注入（§5：同 seed 可重放；缺省 Math.random）。
+  rng?: () => number;
 }
 
 export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
   const ex = options.ex === true;
+  const rng = options.rng ?? Math.random;
   const maxHp = Math.round(PRISMIX.maxHp * (ex ? EX_MODS.hpMul : 1));
   const splitRatio = ex ? EX_PRISMIX.splitHpRatio : PRISMIX.splitHpRatio;
   const struggleMs = ex ? EX_PRISMIX.struggleMs : PRISMIX.struggleMs;
@@ -141,8 +170,11 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
 
   let phase: BossPhase = 'p1';
   let state: PrismixAction = 'idle';
-  let lastAttack: PrismixAction | null = null;
-  let cycleIndex = 0;
+  // 近兩次出招（§5 連續同招上限 2）。
+  let recentAttacks: PrismixAction[] = [];
+  let distancePx: number | null = null;
+  // 鏡界反射開鏡側：僅 state === 'mirror' 期間有效。
+  let mirrorSide: PrismixSide = 'a';
   let timerMs: number = PRISMIX.idleMs;
   let damageSinceDrop = 0;
   let defeated = false;
@@ -176,6 +208,11 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
       // 掙扎窗為固定時長（不隨速率縮放：窗長即彩蛋判定窗）。
       case 'struggle':
         return struggleMs;
+      // 開鏡窗固定 0.8s（可讀性紅線）：不隨狂暴速率縮放。
+      case 'mirror':
+        return PRISMIX.mirrorDurationMs;
+      case 'shadow':
+        return PRISMIX.shadowCastMs / speedFactor();
       default: {
         const unhandled: never = action;
         throw new Error(`未知招式：${String(unhandled)}`);
@@ -202,6 +239,10 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
         return { kind: 'barrage', count: PRISMIX.radialCount };
       case 'rain':
         return { kind: 'rain', count: PRISMIX.rainCount };
+      case 'mirror':
+        return { kind: 'mirror', side: mirrorSide, durationMs: PRISMIX.mirrorDurationMs };
+      case 'shadow':
+        return { kind: 'shadow' };
       default: {
         const unhandled: never = action;
         throw new Error(`未知招式：${String(unhandled)}`);
@@ -251,17 +292,25 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
         hpA = 0;
         hpB = 0;
         state = 'idle';
-        lastAttack = null;
-        cycleIndex = 0;
+        recentAttacks = [];
         timerMs = durationMs('idle');
         return { kind: 'merge', coreHp: hp, shards };
       }
       if (state === 'idle') {
-        const cycle = prismixAttackCycle(phase);
-        const index = lastAttack === null ? 0 : (cycleIndex + 1) % cycle.length;
-        state = cycle[index] ?? 'idle';
-        cycleIndex = index;
-        lastAttack = state;
+        // 加權選招（§5）：權重＋條件（HP 帶/距離帶）＋連續同招上限 2。
+        state = pickMove(
+          prismixMoveTable(phase),
+          { hpRatio: totalHp() / maxHp, distanceBand: distanceBandOf(distancePx) },
+          recentAttacks,
+          rng,
+        );
+        recentAttacks = [...recentAttacks.slice(-1), state];
+        // 鏡界反射開鏡側：雙具存活時 rng 抽側（同 seed 可重放），單側殘存防呆歸存活具。
+        if (state === 'mirror') {
+          if (hpA <= 0) mirrorSide = 'b';
+          else if (hpB <= 0) mirrorSide = 'a';
+          else mirrorSide = rng() < 0.5 ? 'a' : 'b';
+        }
       } else {
         state = 'idle';
       }
@@ -273,6 +322,11 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
       if (defeated || amount <= 0) return [];
       const events: PrismixHitEvent[] = [];
       if (phase === 'p2') {
+        // 鏡界反射（§5 W2）：開鏡側受擊零傷、折返事件由呈現層生成折返彈；
+        // 反制＝窗內打另一具（另一側照常結算）。
+        if (state === 'mirror' && side === mirrorSide) {
+          return [{ kind: 'reflect', side }];
+        }
         // 掙扎窗內僅存活具可傷；平時對已死側傷害忽略（呈現層防呆）。
         const target: PrismixSide = state === 'struggle' ? survivor : side;
         if (target === 'a' && hpA <= 0) return [];
@@ -310,8 +364,7 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
         hpB = hp - hpA;
         hp = 0;
         state = 'idle';
-        lastAttack = null;
-        cycleIndex = 0;
+        recentAttacks = [];
         timerMs = durationMs('idle');
         events.push({ kind: 'phase', phase: 'p2' }, { kind: 'split', hpA, hpB });
       }
@@ -322,6 +375,9 @@ export function createPrismixFsm(options: PrismixFsmOptions = {}): PrismixFsm {
       state = 'idle';
       timerMs = durationMs('idle');
       return true;
+    },
+    setTargetDistance(next: number | null): void {
+      distancePx = next;
     },
   };
 }

--- a/apps/starpuff/src/game/logic/syronaFsm.test.ts
+++ b/apps/starpuff/src/game/logic/syronaFsm.test.ts
@@ -1,42 +1,73 @@
 import { describe, expect, it } from 'vitest';
 import { EX_MODS } from './bossFsm';
-import { EX_SYRONA, SYRONA, createSyronaFsm, isCrownHit, syronaAttackCycle } from './syronaFsm';
+import { AUDIT_THRESHOLDS, sequenceEntropyBits } from './difficulty';
+import { createSeededRng } from './moveTable';
+import {
+  EX_SYRONA,
+  SYRONA,
+  createSyronaFsm,
+  isCrownHit,
+  syronaMoveTable,
+  type SyronaCommand,
+} from './syronaFsm';
 
-// 熔糖窯后 Syrona FSM（GAME_DESIGN §74）：場控型三階段——本體半定點，威脅來自
+// 熔糖窯后 Syrona FSM（GAME_DESIGN §74/§112）：場控型三階段——本體半定點，威脅來自
 // 地形改寫（潮汐/噴泉/滴落）；hit window = 招式後 idle 僵直（散熱/吟唱/波後）。
 
-const drain = (fsm: ReturnType<typeof createSyronaFsm>, ms: number) => {
-  const commands = [];
-  let left = ms;
-  while (left > 0) {
-    const step = Math.min(50, left);
-    const command = fsm.tick(step);
-    if (command) commands.push(command);
-    left -= step;
+// 驅動至指定指令出現，回傳該指令；逾迭代上限回 null。
+const driveTo = (
+  fsm: ReturnType<typeof createSyronaFsm>,
+  kind: SyronaCommand['kind'],
+): SyronaCommand | null => {
+  for (let i = 0; i < 5000; i += 1) {
+    const command = fsm.tick(50);
+    if (command?.kind === kind) return command;
+  }
+  return null;
+};
+
+// 收集非 idle 指令直到數量滿足。
+const collectAttacks = (fsm: ReturnType<typeof createSyronaFsm>, count: number) => {
+  const commands: SyronaCommand[] = [];
+  for (let i = 0; i < 8000 && commands.length < count; i += 1) {
+    const command = fsm.tick(50);
+    if (command && command.kind !== 'idle') commands.push(command);
   }
   return commands;
 };
 
-describe('Syrona 三階段循環（§74）', () => {
-  it('HP 90 階梯（60→52→80→90）；P1 循環為噴泉→射彈', () => {
+describe('Syrona 三階段加權表（§74/§112）', () => {
+  it('HP 90 階梯（60→52→80→90）；三階段招池對表', () => {
     const fsm = createSyronaFsm();
     expect(fsm.maxHp).toBe(90);
     expect(SYRONA.maxHp).toBeGreaterThan(80);
-    expect(syronaAttackCycle('p1')).toEqual(['fountain', 'lob']);
-    expect(syronaAttackCycle('p2')).toEqual(['drip', 'summon', 'fountain']);
-    expect(syronaAttackCycle('p3')).toEqual(['wave', 'overload']);
+    expect(syronaMoveTable('p1').map((m) => m.action)).toEqual(['fountain', 'lob']);
+    expect(syronaMoveTable('p2').map((m) => m.action)).toEqual(['drip', 'fountain', 'summon']);
+    expect(syronaMoveTable('p3').map((m) => m.action)).toEqual(['wave', 'overload']);
   });
 
-  it('P1 首循環：idle 期滿出噴泉指令（固定升序），再 idle 後出射彈', () => {
-    const fsm = createSyronaFsm();
-    const commands = drain(fsm, 10000);
-    const kinds = commands.map((c) => c.kind);
-    expect(kinds[0]).toBe('fountain');
-    const fountain = commands[0];
-    if (fountain?.kind === 'fountain') {
-      expect(fountain.order).toEqual([0, 1, 2]);
-    }
-    expect(kinds).toContain('lob');
+  it('射彈限遠距帶（§5 條件欄：貼身拋物不可讀）；近距帶只出噴泉', () => {
+    const lob = syronaMoveTable('p1').find((m) => m.action === 'lob');
+    expect(lob?.condition).toEqual({ band: 'far' });
+    // 近距帶：lob 被條件剔除，序列僅剩噴泉。
+    const fsm = createSyronaFsm({ rng: createSeededRng(1) });
+    fsm.setTargetDistance(120);
+    const kinds = collectAttacks(fsm, 8).map((c) => c.kind);
+    expect(kinds).not.toContain('lob');
+    // 未餵送距離視為 far：lob 可入池。
+    const farFsm = createSyronaFsm({ rng: createSeededRng(1) });
+    const farKinds = collectAttacks(farFsm, 12).map((c) => c.kind);
+    expect(farKinds).toContain('lob');
+  });
+
+  it('P1 招池指令：噴泉固定升序（可背板）、射彈帶 count', () => {
+    const fsm = createSyronaFsm({ rng: createSeededRng(2) });
+    const fountain = driveTo(fsm, 'fountain');
+    if (fountain?.kind === 'fountain') expect(fountain.order).toEqual([0, 1, 2]);
+    const lob = driveTo(fsm, 'lob');
+    if (lob?.kind === 'lob') expect(lob.count).toBe(SYRONA.lobCount);
+    expect(fountain).not.toBeNull();
+    expect(lob).not.toBeNull();
   });
 
   it('傷害驅動 P1→P2（≤66%）與 P2→P3（≤33%）；phase 事件依序帶出', () => {
@@ -49,16 +80,20 @@ describe('Syrona 三階段循環（§74）', () => {
     expect(events.some((e) => e.kind === 'phase' && e.phase === 'p3')).toBe(true);
   });
 
-  it('P2 循環出滴落→召喚→加密噴泉；召喚上限 2', () => {
-    const fsm = createSyronaFsm();
+  it('P2 招池出滴落/召喚/加密噴泉；召喚上限 2', () => {
+    const fsm = createSyronaFsm({ rng: createSeededRng(3) });
     fsm.takeDamage(31);
-    const commands = drain(fsm, 14000);
-    const kinds = commands.map((c) => c.kind);
+    const kinds = collectAttacks(fsm, 30).map((c) => c.kind);
     expect(kinds).toContain('drip');
     expect(kinds).toContain('summon');
-    const summon = commands.find((c) => c.kind === 'summon');
+    expect(kinds).toContain('fountain');
+    const fsm2 = createSyronaFsm({ rng: createSeededRng(3) });
+    fsm2.takeDamage(31);
+    const summon = driveTo(fsm2, 'summon');
     if (summon?.kind === 'summon') expect(summon.cap).toBe(SYRONA.summonCap);
-    const fountain = commands.find((c) => c.kind === 'fountain');
+    const fsm3 = createSyronaFsm({ rng: createSeededRng(3) });
+    fsm3.takeDamage(31);
+    const fountain = driveTo(fsm3, 'fountain');
     if (fountain?.kind === 'fountain') {
       expect(fountain.order.length).toBe(SYRONA.fountainDenseCount);
     }
@@ -108,17 +143,43 @@ describe('Syrona 三階段循環（§74）', () => {
     expect(firstCommandAt).toBeLessThanOrEqual(SYRONA.idleMs.p2 + 100);
   });
 
-  it('P3 自然循環：糖漿波與噴口超載依序出現（審查修復）', () => {
-    const fsm = createSyronaFsm();
+  it('P3 招池：糖漿波（焦糖化載體）與噴口超載均可抽出（審查修復）', () => {
+    const fsm = createSyronaFsm({ rng: createSeededRng(4) });
     fsm.takeDamage(31);
     fsm.takeDamage(30);
     expect(fsm.phase).toBe('p3');
-    const commands = drain(fsm, 16000);
-    const kinds = commands.map((c) => c.kind);
-    expect(kinds).toContain('wave');
-    expect(kinds).toContain('overload');
-    const overload = commands.find((c) => c.kind === 'overload');
+    expect(driveTo(fsm, 'wave')).not.toBeNull();
+    const overload = driveTo(fsm, 'overload');
+    expect(overload).not.toBeNull();
     if (overload?.kind === 'overload') expect(overload.durationMs).toBeGreaterThan(0);
+  });
+});
+
+describe('加權選招治理（§5 去背板）', () => {
+  it('同 seed 可完整重放；不同於舊固定循環', () => {
+    const run = (seed: number): string[] => {
+      const fsm = createSyronaFsm({ rng: createSeededRng(seed) });
+      return collectAttacks(fsm, 16).map((c) => c.kind);
+    };
+    expect(run(9)).toEqual(run(9));
+    // 舊固定循環：P1 fountain→lob 交替。
+    const legacy = Array.from({ length: 16 }, (_, i) => (i % 2 === 0 ? 'fountain' : 'lob'));
+    expect(run(9)).not.toEqual(legacy);
+  });
+
+  it('連續同招上限 2：長時序列無三連同招', () => {
+    const fsm = createSyronaFsm({ rng: createSeededRng(6) });
+    const kinds = collectAttacks(fsm, 40).map((c) => c.kind);
+    for (let i = 2; i < kinds.length; i += 1) {
+      expect(new Set(kinds.slice(i - 2, i + 1)).size).toBeGreaterThan(1);
+    }
+  });
+
+  it('招式序列條件熵 ≥ 門檻（#813；AUDIT_THRESHOLDS.moveEntropyMinBits 口徑）', () => {
+    const fsm = createSyronaFsm({ rng: createSeededRng(13) });
+    const kinds = collectAttacks(fsm, 60).map((c) => c.kind);
+    expect(kinds.length).toBeGreaterThanOrEqual(40);
+    expect(sequenceEntropyBits(kinds)).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.moveEntropyMinBits);
   });
 });
 
@@ -134,21 +195,15 @@ describe('皇冠弱點帶（§74 isCrownHit，審查修復）', () => {
 
 describe('噴泉洗牌 seed 注入（§74 EX 質性差分）', () => {
   it('一般模式噴泉恆為固定升序（讀招可背板）', () => {
-    const fsm = createSyronaFsm({ rng: () => 0.99 });
-    const commands = drain(fsm, 10000);
-    const fountain = commands.find((c) => c.kind === 'fountain');
+    const fsm = createSyronaFsm({ rng: createSeededRng(2) });
+    const fountain = driveTo(fsm, 'fountain');
+    expect(fountain?.kind).toBe('fountain');
     if (fountain?.kind === 'fountain') expect(fountain.order).toEqual([0, 1, 2]);
   });
 
   it('EX 模式每循環洗牌出序（同 seed 可重現、非恆升序）', () => {
-    let calls = 0;
-    const rng = () => {
-      calls += 1;
-      return (calls * 0.37) % 1;
-    };
-    const fsm = createSyronaFsm({ ex: true, rng });
-    const commands = drain(fsm, 12000);
-    const fountain = commands.find((c) => c.kind === 'fountain');
+    const fsm = createSyronaFsm({ ex: true, rng: createSeededRng(8) });
+    const fountain = driveTo(fsm, 'fountain');
     expect(fountain?.kind).toBe('fountain');
     if (fountain?.kind === 'fountain') {
       // EX 噴泉 ×5；洗牌序為 0..4 的全排列。

--- a/apps/starpuff/src/game/logic/syronaFsm.ts
+++ b/apps/starpuff/src/game/logic/syronaFsm.ts
@@ -1,5 +1,6 @@
 import type { BossPhase } from '../core/types';
 import { EX_MODS } from './bossFsm';
+import { distanceBandOf, pickMove, type WeightedMove } from './moveTable';
 
 // 熔糖窯后 Syrona FSM 純邏輯（GAME_DESIGN §74，不 import phaser），vitest 對象。
 // 場控型三段：本體半定點（中後方王窯座），威脅來自地形改寫（潮汐/噴泉/滴落）——
@@ -92,15 +93,27 @@ export function isCrownHit(hitY: number, bodyTopY: number): boolean {
   return hitY <= bodyTopY + CROWN_BAND_PX;
 }
 
-// 三階段招式循環（§74）：P1 噴泉/射彈；P2 滴落/召喚/加密噴泉；P3 糖漿波/噴口超載。
-export function syronaAttackCycle(phase: BossPhase): readonly SyronaAction[] {
+// 加權選招表（§5 #813 W2）：固定循環改權重＋條件驅動（沿 JELLORD_MOVES 慣例）。
+// P1 噴泉/射彈（射彈限遠距帶——貼身拋物不可讀，沿 Jellord dash 遠距帶理據）；
+// P2 滴落/召喚/加密噴泉；P3 糖漿波（焦糖化載體）/噴口超載。
+export function syronaMoveTable(phase: BossPhase): readonly WeightedMove<SyronaAction>[] {
   switch (phase) {
     case 'p1':
-      return ['fountain', 'lob'];
+      return [
+        { action: 'fountain', weight: 3 },
+        { action: 'lob', weight: 3, condition: { band: 'far' } },
+      ];
     case 'p2':
-      return ['drip', 'summon', 'fountain'];
+      return [
+        { action: 'drip', weight: 3 },
+        { action: 'fountain', weight: 3 },
+        { action: 'summon', weight: 2 },
+      ];
     case 'p3':
-      return ['wave', 'overload'];
+      return [
+        { action: 'wave', weight: 3 },
+        { action: 'overload', weight: 3 },
+      ];
     default: {
       const unhandled: never = phase;
       throw new Error(`未知階段：${String(unhandled)}`);
@@ -119,11 +132,13 @@ export interface SyronaFsm {
   takeDamage(amount: number): SyronaHitEvent[];
   // 雷化鏈電中斷召喚（§58 慣例）：僅召喚態可中斷，成功回 true。
   interruptSummon(): boolean;
+  // 距離帶餵送（§5 條件欄）：呈現層逐幀回報與玩家距離；未餵送視為 far。
+  setTargetDistance(distancePx: number | null): void;
 }
 
 export interface SyronaFsmOptions {
   ex?: boolean;
-  // 噴泉洗牌亂數注入（EX 質性差分可測；缺省 Math.random）。
+  // 亂數注入（噴泉洗牌與加權選招共用；同 seed 可重放；缺省 Math.random）。
   rng?: () => number;
 }
 
@@ -149,8 +164,9 @@ export function createSyronaFsm(options: SyronaFsmOptions = {}): SyronaFsm {
   let hp = maxHp;
   let phase: BossPhase = 'p1';
   let state: SyronaAction = 'idle';
-  let lastAttack: SyronaAction | null = null;
-  let cycleIndex = 0;
+  // 近兩次出招（§5 連續同招上限 2）。
+  let recentAttacks: SyronaAction[] = [];
+  let distancePx: number | null = null;
   let timerMs: number = SYRONA.idleMs.p1;
   let damageSinceDrop = 0;
   let defeated = false;
@@ -218,8 +234,7 @@ export function createSyronaFsm(options: SyronaFsmOptions = {}): SyronaFsm {
   const enterPhase = (next: BossPhase, events: SyronaHitEvent[]): void => {
     phase = next;
     state = 'idle';
-    lastAttack = null;
-    cycleIndex = 0;
+    recentAttacks = [];
     timerMs = durationMs('idle');
     events.push({ kind: 'phase', phase: next });
   };
@@ -248,11 +263,14 @@ export function createSyronaFsm(options: SyronaFsmOptions = {}): SyronaFsm {
       timerMs -= deltaMs;
       if (timerMs > 0) return null;
       if (state === 'idle') {
-        const cycle = syronaAttackCycle(phase);
-        const index = lastAttack === null ? 0 : (cycleIndex + 1) % cycle.length;
-        state = cycle[index] ?? 'idle';
-        cycleIndex = index;
-        lastAttack = state;
+        // 加權選招（§5）：權重＋條件（HP 帶/距離帶）＋連續同招上限 2。
+        state = pickMove(
+          syronaMoveTable(phase),
+          { hpRatio: hp / maxHp, distanceBand: distanceBandOf(distancePx) },
+          recentAttacks,
+          rng,
+        );
+        recentAttacks = [...recentAttacks.slice(-1), state];
       } else {
         state = 'idle';
       }
@@ -285,6 +303,9 @@ export function createSyronaFsm(options: SyronaFsmOptions = {}): SyronaFsm {
       state = 'idle';
       timerMs = durationMs('idle');
       return true;
+    },
+    setTargetDistance(next: number | null): void {
+      distancePx = next;
     },
   };
 }

--- a/apps/starpuff/src/game/scenes/GameScene.ts
+++ b/apps/starpuff/src/game/scenes/GameScene.ts
@@ -31,6 +31,7 @@ import {
   type BuffId,
   type BuffState,
 } from '../logic/buffs';
+import { createCaramelStatus, type CaramelStatus } from '../systems/caramelStatus';
 import {
   carryKillsOnDeath,
   checkpointRespawnX,
@@ -154,6 +155,7 @@ export class GameScene extends Phaser.Scene {
   private buff: BuffState = createBuffState();
   // e2e 觀測（§69）：本局累計增益拾取數——護盾可能拾取後旋即格擋消耗，快照式觀測會漏。
   private buffPickups = 0;
+  private caramel!: CaramelStatus;
   private unbinders: (() => void)[] = [];
   private terrainGround: Phaser.GameObjects.Rectangle | null = null;
   // 地形單向平台（§77）：交 stage 統一下穿裁決（與 elements oneway 同權）。
@@ -234,6 +236,12 @@ export class GameScene extends Phaser.Scene {
     this.controls = createControls(this);
     this.buff = createBuffState();
     this.buffPickups = 0;
+    this.caramel = createCaramelStatus({
+      player: () => this.player,
+      fx: () => this.fx,
+      toast: (message) => this.toasts.flavor(message),
+      buffMods: () => [buffSpeedMul(this.buff), buffAccelMul(this.buff)] as const,
+    });
     // 前室魔王關（§69）：自廊道起點入場；一般魔王關維持 arena 中央。
     const startX = this.level.boss
       ? this.level.anteroomPx !== undefined
@@ -415,6 +423,7 @@ export class GameScene extends Phaser.Scene {
       bossTouchDamage: () => this.bossTouchDamage,
       damagePlayer: (damage, sourceX) => this.damagePlayer(damage, sourceX),
       damageBossAt: (amount, x, y, source) => this.damageBossAt(amount, x, y, source),
+      applyCaramel: () => this.caramel.apply(),
       isSettled: () => this.finished || this.transitioning,
       isBossDown: () => this.bossDown,
       now: () => this.time.now,
@@ -476,6 +485,7 @@ export class GameScene extends Phaser.Scene {
       for (const room of this.eliteRooms) room.update();
       this.bossRoom?.update();
       this.advanceBuff(deltaMs);
+      this.caramel.update(deltaMs);
       this.starSteering.update(deltaMs);
       this.advanceMercy(deltaMs);
       // 側風推移（§52）：委派 enemies 系統結算；迴旋星驅動已內建於 player.update。
@@ -672,14 +682,18 @@ export class GameScene extends Phaser.Scene {
       deltaMs,
       body.blocked.up,
     );
-    if (lifted !== null) body.setVelocityY(lifted);
+    if (lifted !== null) {
+      body.setVelocityY(lifted);
+      // 焦糖化反制（§5 W2）：乘噴口氣流吹乾即解除減速。
+      this.caramel.clear();
+    }
   }
 
   // 短期增益（§69）：拾取單點——同時僅存一個、後拾覆蓋；移動倍率同步注入 player。
   private applyBuff(id: BuffId): void {
     this.buff = pickupBuff(this.buff, id);
     this.buffPickups += 1;
-    this.player.setBuffMoveMods(buffSpeedMul(this.buff), buffAccelMul(this.buff));
+    this.caramel.sync();
     this.toasts.flavor(`${BUFF_SPECS[id].nameZh}！短暫強化`);
   }
 
@@ -690,7 +704,7 @@ export class GameScene extends Phaser.Scene {
     }
     const result = tickBuff(this.buff, deltaMs);
     this.buff = result.state;
-    if (result.expired) this.player.setBuffMoveMods(1, 1);
+    if (result.expired) this.caramel.sync();
     this.bossRoom?.updateBuffHud(this.buff);
   }
 

--- a/apps/starpuff/src/game/systems/caramelStatus.test.ts
+++ b/apps/starpuff/src/game/systems/caramelStatus.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CARAMEL } from '../logic/caramel';
+import { createCaramelStatus, type CaramelStatusDeps } from './caramelStatus';
+import type { FxSystem } from './fx';
+import type { PlayerHandle } from './player';
+
+// 焦糖化呈現層行為測試（#813 W2 審查補強）：apply/update/clear/sync 契約——
+// 雷化免疫與瞬除、vent 反制清除、再沾波僅刷新計時（FX/浮字防轟炸）。
+
+function makeHarness(): {
+  status: ReturnType<typeof createCaramelStatus>;
+  spies: {
+    setBuffMoveMods: ReturnType<typeof vi.fn>;
+    burstSmall: ReturnType<typeof vi.fn>;
+    toast: ReturnType<typeof vi.fn>;
+  };
+  setForm: (form: string | null) => void;
+  setBuffMods: (mods: readonly [number, number]) => void;
+} {
+  let form: string | null = null;
+  let buffMods: readonly [number, number] = [1, 1];
+  const setBuffMoveMods = vi.fn();
+  const burstSmall = vi.fn();
+  const toast = vi.fn();
+  const player = {
+    sprite: { x: 100, y: 300 },
+    getTransformState: () => ({ form, remainingMs: 0 }),
+    setBuffMoveMods,
+  } as unknown as PlayerHandle;
+  const deps: CaramelStatusDeps = {
+    player: () => player,
+    fx: () => ({ burstSmall }) as unknown as FxSystem,
+    toast,
+    buffMods: () => buffMods,
+  };
+  return {
+    status: createCaramelStatus(deps),
+    spies: { setBuffMoveMods, burstSmall, toast },
+    setForm: (next) => {
+      form = next;
+    },
+    setBuffMods: (mods) => {
+      buffMods = mods;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('apply（沾身）', () => {
+  it('套用減速倍率＋沾身爆點＋首次教學浮字', () => {
+    const { status, spies } = makeHarness();
+    status.apply();
+    expect(spies.setBuffMoveMods).toHaveBeenCalledWith(CARAMEL.slowMul, 1);
+    expect(spies.burstSmall).toHaveBeenCalledWith(100, 318, CARAMEL.tint);
+    expect(spies.toast).toHaveBeenCalledTimes(1);
+  });
+
+  it('雷化免疫：volt 態沾波零副作用（不沾糖）', () => {
+    const { status, spies, setForm } = makeHarness();
+    setForm('volt');
+    status.apply();
+    expect(spies.setBuffMoveMods).not.toHaveBeenCalled();
+    expect(spies.burstSmall).not.toHaveBeenCalled();
+    expect(spies.toast).not.toHaveBeenCalled();
+  });
+
+  it('沾身中再沾波：僅刷新計時，不再爆點/浮字（防重疊波逐幀轟炸）', () => {
+    const { status, spies } = makeHarness();
+    status.apply();
+    // 300ms < 粒子節拍 400ms：期間無 drip burst，計數只含沾身爆點。
+    status.update(300);
+    status.apply();
+    expect(spies.burstSmall).toHaveBeenCalledTimes(1);
+    expect(spies.toast).toHaveBeenCalledTimes(1);
+    // 刷新驗證：自再沾波起算滿窗仍存活，過窗才解除。
+    spies.setBuffMoveMods.mockClear();
+    status.update(CARAMEL.durationMs - 50);
+    expect(spies.setBuffMoveMods).not.toHaveBeenCalledWith(1, 1);
+    status.update(100);
+    expect(spies.setBuffMoveMods).toHaveBeenCalledWith(1, 1);
+  });
+
+  it('解除後再沾身：教學浮字不重播、爆點重播', () => {
+    const { status, spies } = makeHarness();
+    status.apply();
+    status.clear();
+    status.apply();
+    expect(spies.toast).toHaveBeenCalledTimes(1);
+    expect(spies.burstSmall).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('update（計時與反制）', () => {
+  it('未沾身：純 no-op', () => {
+    const { status, spies } = makeHarness();
+    status.update(1000);
+    expect(spies.setBuffMoveMods).not.toHaveBeenCalled();
+    expect(spies.burstSmall).not.toHaveBeenCalled();
+  });
+
+  it('計時期滿自然解除：倍率回 1', () => {
+    const { status, spies } = makeHarness();
+    status.apply();
+    status.update(CARAMEL.durationMs);
+    expect(spies.setBuffMoveMods).toHaveBeenLastCalledWith(1, 1);
+  });
+
+  it('雷化放電瞬除：沾身中變身 volt 當幀清除', () => {
+    const { status, spies, setForm } = makeHarness();
+    status.apply();
+    setForm('volt');
+    status.update(16);
+    expect(spies.setBuffMoveMods).toHaveBeenLastCalledWith(1, 1);
+    // 已清除：後續 update 不再結算。
+    spies.setBuffMoveMods.mockClear();
+    status.update(1000);
+    expect(spies.setBuffMoveMods).not.toHaveBeenCalled();
+  });
+
+  it('腳部沾糖粒子低頻節拍：累積滿 400ms 才補一發', () => {
+    const { status, spies } = makeHarness();
+    status.apply();
+    spies.burstSmall.mockClear();
+    status.update(200);
+    expect(spies.burstSmall).not.toHaveBeenCalled();
+    status.update(200);
+    expect(spies.burstSmall).toHaveBeenCalledTimes(1);
+    expect(spies.burstSmall).toHaveBeenCalledWith(100, 320, CARAMEL.tint);
+  });
+});
+
+describe('clear（vent 反制）與 sync（倍率合成）', () => {
+  it('vent 清除路徑：沾身中 clear 即回 1；未沾身 clear 零副作用', () => {
+    const { status, spies } = makeHarness();
+    status.clear();
+    expect(spies.setBuffMoveMods).not.toHaveBeenCalled();
+    status.apply();
+    status.clear();
+    expect(spies.setBuffMoveMods).toHaveBeenLastCalledWith(1, 1);
+  });
+
+  it('sync：焦糖倍率與 buff 倍率單點疊乘注入', () => {
+    const { status, spies, setBuffMods } = makeHarness();
+    setBuffMods([1.3, 0.8]);
+    status.apply();
+    expect(spies.setBuffMoveMods).toHaveBeenLastCalledWith(1.3 * CARAMEL.slowMul, 0.8);
+    status.clear();
+    expect(spies.setBuffMoveMods).toHaveBeenLastCalledWith(1.3, 0.8);
+  });
+});

--- a/apps/starpuff/src/game/systems/caramelStatus.ts
+++ b/apps/starpuff/src/game/systems/caramelStatus.ts
@@ -1,0 +1,91 @@
+import {
+  CARAMEL,
+  CARAMEL_CLEAR,
+  applyCaramel,
+  caramelActive,
+  caramelSpeedMul,
+  tickCaramel,
+  type CaramelState,
+} from '../logic/caramel';
+import type { FxSystem } from './fx';
+import type { PlayerHandle } from './player';
+
+// 焦糖化狀態呈現層（§5 Syrona W2）：糖漿波沾身減速 30%/3s、琥珀腳部沾糖粒子與
+// 反制解除（乘噴口氣流吹乾／雷化放電瞬除）；狀態真值收斂 logic/caramel.ts，
+// 移速倍率於 sync 與 buff 倍率單點合成後注入 player（防互相覆寫）。
+
+// 首次沾身反制教學浮字（每 session 一次）：沿 noctra taughtCloakReveal 慣例。
+let taughtCaramelClear = false;
+
+// 腳部沾糖粒子節拍。
+const DRIP_FX_INTERVAL_MS = 400;
+
+export interface CaramelStatusDeps {
+  player(): PlayerHandle;
+  fx(): FxSystem;
+  toast(message: string): void;
+  // buff 移速/加減速倍率讀取（§69）：與焦糖倍率合成後注入。
+  buffMods(): readonly [number, number];
+}
+
+export interface CaramelStatus {
+  apply(): void;
+  update(deltaMs: number): void;
+  clear(): void;
+  // 倍率重注（buff 拾取/過期時由 GameScene 呼叫）。
+  sync(): void;
+}
+
+export function createCaramelStatus(deps: CaramelStatusDeps): CaramelStatus {
+  let state: CaramelState = CARAMEL_CLEAR;
+  let fxAccMs = 0;
+
+  const sync = (): void => {
+    const [speedMul, rateMul] = deps.buffMods();
+    deps.player().setBuffMoveMods(speedMul * caramelSpeedMul(state), rateMul);
+  };
+
+  const clear = (): void => {
+    if (!caramelActive(state)) return;
+    state = CARAMEL_CLEAR;
+    sync();
+  };
+
+  return {
+    apply() {
+      // 雷化免疫（§5 反制：放電瞬除語義——帶電體不沾糖）。
+      if (deps.player().getTransformState().form === 'volt') return;
+      state = applyCaramel();
+      fxAccMs = 0;
+      sync();
+      const sprite = deps.player().sprite;
+      deps.fx().burstSmall(sprite.x, sprite.y + 18, CARAMEL.tint);
+      if (!taughtCaramelClear) {
+        taughtCaramelClear = true;
+        deps.toast('焦糖黏身！乘噴口氣流吹乾');
+      }
+    },
+    update(deltaMs: number) {
+      if (!caramelActive(state)) return;
+      // 雷化放電瞬除（§5 反制：變身優勢解）。
+      if (deps.player().getTransformState().form === 'volt') {
+        clear();
+        return;
+      }
+      state = tickCaramel(state, deltaMs);
+      if (!caramelActive(state)) {
+        sync();
+        return;
+      }
+      // 琥珀色腳部沾糖視覺：低頻粒子跟隨腳邊。
+      fxAccMs += deltaMs;
+      if (fxAccMs >= DRIP_FX_INTERVAL_MS) {
+        fxAccMs = 0;
+        const sprite = deps.player().sprite;
+        deps.fx().burstSmall(sprite.x, sprite.y + 20, CARAMEL.tint);
+      }
+    },
+    clear,
+    sync,
+  };
+}

--- a/apps/starpuff/src/game/systems/caramelStatus.ts
+++ b/apps/starpuff/src/game/systems/caramelStatus.ts
@@ -14,9 +14,6 @@ import type { PlayerHandle } from './player';
 // 反制解除（乘噴口氣流吹乾／雷化放電瞬除）；狀態真值收斂 logic/caramel.ts，
 // 移速倍率於 sync 與 buff 倍率單點合成後注入 player（防互相覆寫）。
 
-// 首次沾身反制教學浮字（每 session 一次）：沿 noctra taughtCloakReveal 慣例。
-let taughtCaramelClear = false;
-
 // 腳部沾糖粒子節拍。
 const DRIP_FX_INTERVAL_MS = 400;
 
@@ -39,6 +36,8 @@ export interface CaramelStatus {
 export function createCaramelStatus(deps: CaramelStatusDeps): CaramelStatus {
   let state: CaramelState = CARAMEL_CLEAR;
   let fxAccMs = 0;
+  // 首次沾身反制教學浮字（每戰一次）：收斂 closure，避免模組級狀態跨測試/場景殘留。
+  let taughtCaramelClear = false;
 
   const sync = (): void => {
     const [speedMul, rateMul] = deps.buffMods();
@@ -55,9 +54,12 @@ export function createCaramelStatus(deps: CaramelStatusDeps): CaramelStatus {
     apply() {
       // 雷化免疫（§5 反制：放電瞬除語義——帶電體不沾糖）。
       if (deps.player().getTransformState().form === 'volt') return;
+      // 沾身中再沾波：僅刷新計時（重疊 shockwave 逐幀觸發，防 FX/浮字轟炸）。
+      const refreshOnly = caramelActive(state);
       state = applyCaramel();
-      fxAccMs = 0;
       sync();
+      if (refreshOnly) return;
+      fxAccMs = 0;
       const sprite = deps.player().sprite;
       deps.fx().burstSmall(sprite.x, sprite.y + 18, CARAMEL.tint);
       if (!taughtCaramelClear) {

--- a/apps/starpuff/src/game/systems/overlaps.test.ts
+++ b/apps/starpuff/src/game/systems/overlaps.test.ts
@@ -56,6 +56,7 @@ interface HarnessConfig {
   bossActive?: boolean;
   settled?: boolean;
   reflectForm?: boolean;
+  inhaling?: boolean;
 }
 
 function makeHarness(config: HarnessConfig = {}): {
@@ -72,6 +73,7 @@ function makeHarness(config: HarnessConfig = {}): {
     trySlamStun: ReturnType<typeof vi.fn>;
     onSlamBounce: ReturnType<typeof vi.fn>;
     applyCaramel: ReturnType<typeof vi.fn>;
+    grantStar: ReturnType<typeof vi.fn>;
   };
   groups: {
     stars: object;
@@ -100,12 +102,14 @@ function makeHarness(config: HarnessConfig = {}): {
   const shatter = vi.fn();
   const trySlamStun = vi.fn(() => false);
   const onSlamBounce = vi.fn();
+  const grantStar = vi.fn();
   const player = {
     sprite: playerSprite,
     getStars: () => stars,
     getInhaleZone: () => inhaleZone,
     onStarHit,
-    isInhaling: () => false,
+    grantStar,
+    isInhaling: () => config.inhaling ?? false,
     getFacing: () => 1,
     isSlamming: () => false,
     onSlamBounce,
@@ -189,6 +193,7 @@ function makeHarness(config: HarnessConfig = {}): {
       trySlamStun,
       onSlamBounce,
       applyCaramel,
+      grantStar,
     },
     groups: { stars, enemyGroup, hazards, inhaleZone, playerSprite, projectiles, shockwaves },
   };
@@ -337,6 +342,57 @@ describe('關鍵回調結算路徑', () => {
     expect(harness.spies.trySlamStun).toHaveBeenCalledTimes(1);
     expect(harness.spies.onSlamBounce).toHaveBeenCalledTimes(1);
     expect(harness.spies.damagePlayer).not.toHaveBeenCalled();
+  });
+
+  it('折返彈吸入回收（§5 W2）：inhalable＋吸入中 → grantStar 免傷；未吸入照常結算', () => {
+    const inhaling = makeHarness({ inhaling: true });
+    wireCombatOverlaps(inhaling.scene, inhaling.hooks);
+    const wiring = inhaling.wirings.find(
+      (w) => w.a === inhaling.groups.playerSprite && w.b === inhaling.groups.projectiles,
+    );
+    const makeProjectile = () => ({
+      active: true,
+      x: 150,
+      getData: (key: string) => (key === 'inhalable' ? true : undefined),
+      disableBody: vi.fn(),
+    });
+    const recycled = makeProjectile();
+    wiring?.callback?.({}, recycled);
+    expect(inhaling.spies.grantStar).toHaveBeenCalledWith('jelly');
+    expect(inhaling.spies.damagePlayer).not.toHaveBeenCalled();
+    expect(recycled.disableBody).toHaveBeenCalledWith(true, true);
+
+    // 負例：未吸入 → inhalable 彈照常 1 傷路徑（bossTouchDamage）。
+    const idle = makeHarness({});
+    wireCombatOverlaps(idle.scene, idle.hooks);
+    const idleWiring = idle.wirings.find(
+      (w) => w.a === idle.groups.playerSprite && w.b === idle.groups.projectiles,
+    );
+    idleWiring?.callback?.({}, makeProjectile());
+    expect(idle.spies.grantStar).not.toHaveBeenCalled();
+    expect(idle.spies.damagePlayer).toHaveBeenCalledWith(2, 150);
+  });
+
+  it('糖漿波焦糖化（§5 W2）：caramel 旗標 → applyCaramel＋傷害照常；無旗標不沾糖', () => {
+    const { scene, wirings, hooks, spies, groups } = makeHarness({});
+    wireCombatOverlaps(scene, hooks);
+    const wiring = wirings.find((w) => w.a === groups.playerSprite && w.b === groups.shockwaves);
+    const caramelWave = {
+      active: true,
+      x: 220,
+      getData: (key: string) => (key === 'caramel' ? true : undefined),
+    };
+    wiring?.callback?.({}, caramelWave);
+    expect(spies.applyCaramel).toHaveBeenCalledTimes(1);
+    expect(spies.damagePlayer).toHaveBeenCalledWith(2, 220);
+
+    // 負例：一般衝擊波僅結算傷害，不套焦糖。
+    spies.applyCaramel.mockClear();
+    spies.damagePlayer.mockClear();
+    const plainWave = { active: true, x: 220, getData: () => undefined };
+    wiring?.callback?.({}, plainWave);
+    expect(spies.applyCaramel).not.toHaveBeenCalled();
+    expect(spies.damagePlayer).toHaveBeenCalledWith(2, 220);
   });
 
   it('隕星命中玩家：先碎裂再走 damagePlayer 單一入口', () => {

--- a/apps/starpuff/src/game/systems/overlaps.test.ts
+++ b/apps/starpuff/src/game/systems/overlaps.test.ts
@@ -71,6 +71,7 @@ function makeHarness(config: HarnessConfig = {}): {
     moveTo: ReturnType<typeof vi.fn>;
     trySlamStun: ReturnType<typeof vi.fn>;
     onSlamBounce: ReturnType<typeof vi.fn>;
+    applyCaramel: ReturnType<typeof vi.fn>;
   };
   groups: {
     stars: object;
@@ -92,6 +93,7 @@ function makeHarness(config: HarnessConfig = {}): {
   const shockwaves = { name: 'shockwaves' };
   const shields = config.shields ? { name: 'shields', getChildren: () => config.shields! } : null;
   const damagePlayer = vi.fn();
+  const applyCaramel = vi.fn();
   const damageBossAt = vi.fn();
   const onStarHit = vi.fn();
   const enemyDamage = vi.fn(() => 'hurt');
@@ -171,6 +173,7 @@ function makeHarness(config: HarnessConfig = {}): {
     isSettled: () => config.settled ?? false,
     isBossDown: () => false,
     now: () => 10_000,
+    applyCaramel,
   };
   return {
     scene,
@@ -185,6 +188,7 @@ function makeHarness(config: HarnessConfig = {}): {
       moveTo,
       trySlamStun,
       onSlamBounce,
+      applyCaramel,
     },
     groups: { stars, enemyGroup, hazards, inhaleZone, playerSprite, projectiles, shockwaves },
   };

--- a/apps/starpuff/src/game/systems/overlaps.ts
+++ b/apps/starpuff/src/game/systems/overlaps.ts
@@ -39,6 +39,8 @@ export interface CombatOverlapHooks {
   bossTouchDamage(): number;
   damagePlayer(damage: number, sourceX: number): void;
   damageBossAt(amount: number, x: number, y: number, source?: BossDamageSource): void;
+  // 焦糖化（§5 Syrona W2）：帶 caramel 旗標的糖漿波沾身時套用減速（GameScene 單一真值）。
+  applyCaramel(): void;
   // 勝敗轉場窗（finished || transitioning）：期間傷害結算靜默。
   isSettled(): boolean;
   isBossDown(): boolean;
@@ -259,6 +261,13 @@ export function wireCombatOverlaps(scene: Phaser.Scene, hooks: CombatOverlapHook
     const projectile = asSprite(ball);
     if (!projectile.active || hooks.isSettled()) return;
     if (projectile.getData('reflected') === true) return;
+    // 鏡界反射折返彈（§5 Prismix W2）：吸入中接觸即回收為彈藥（免費彈藥獎勵理解）。
+    if (projectile.getData('inhalable') === true && hooks.player().isInhaling()) {
+      projectile.disableBody(true, true);
+      hooks.player().grantStar('jelly');
+      playSfx('swallow');
+      return;
+    }
     // 殼化反彈（§57/§58）：彈幕不傷身，反向射回最近存活本體（§68 多本體）。
     if (hooks.combat().playerFormSpec()?.reflectProjectiles) {
       projectile.setData('reflected', true);
@@ -290,6 +299,8 @@ export function wireCombatOverlaps(scene: Phaser.Scene, hooks: CombatOverlapHook
   scene.physics.add.overlap(hooks.player().sprite, hooks.boss().getShockwaves(), (_p, wave) => {
     const shockwave = asSprite(wave);
     if (!shockwave.active || hooks.isSettled()) return;
+    // 焦糖化（§5 Syrona W2）：糖漿波沾身先套減速，傷害照常結算。
+    if (shockwave.getData('caramel') === true) hooks.applyCaramel();
     hooks.damagePlayer(hooks.bossTouchDamage(), shockwave.x);
   });
 

--- a/apps/starpuff/src/game/systems/prismix.ts
+++ b/apps/starpuff/src/game/systems/prismix.ts
@@ -465,6 +465,10 @@ export function createPrismix(
   // 殘核掙扎（§68）：擊破側碎裂消散；存活側體色轉暗＋搖擺（telegraph）。
   const doStruggle = (survivor: PrismixSide) => {
     struggleSide = survivor;
+    // 掙扎中斷鏡界（FSM 已離開 mirror）：殘留鏡光面板即時銷毀，防視覺誤導。
+    mirrorPane?.destroy();
+    mirrorPane = null;
+    mirrorTwin = null;
     const dead = sideSprite(survivor === 'a' ? 'b' : 'a');
     playSfx('break');
     scene.tweens.add({

--- a/apps/starpuff/src/game/systems/prismix.ts
+++ b/apps/starpuff/src/game/systems/prismix.ts
@@ -8,6 +8,7 @@ import {
   type PrismixCommand,
   type PrismixSide,
 } from '../logic/prismixFsm';
+import { shadowActive, shadowSpawnX, stepShadowX, stepShadowY } from '../logic/mirrorShadow';
 import { playSfx } from '../audio/sfx';
 import type { BossDamageSource, BossHandle } from './boss';
 import { spawnTelegraph } from './fx';
@@ -50,6 +51,12 @@ const SHARD_SPIN_RAD_PER_MS = 0.0012;
 const BARRAGE_WINDUP_MS = 600;
 const CRYSTAL_TINT = 0xc5a8e8;
 const CORE_TINT = 0x9a7ad0;
+// 鏡界反射（§5 W2）：銀白鏡光與折返彈速度；折返彈可再吸入（免費彈藥獎勵理解）。
+const MIRROR_TINT = 0xf0f4ff;
+const REFLECT_SHOT_SPEED = 200;
+// 鏡像殘影（§5 W2）：玩家鏡影視覺——暗銀紫剪影。
+const SHADOW_TINT = 0x6a5a8e;
+const SHADOW_SIZE = 48;
 
 // 入場運鏡（§17 慣例）：黑幕淡入 → 推近王殿 → 稜晶自天緩降落定 → 稜光共鳴 → 復位開戰。
 const INTRO_FADE_MS = 280;
@@ -114,6 +121,13 @@ export function createPrismix(
   // 雙子期間主本體隱藏停用；damage number 錨點跟隨最後受擊側。
   let twinsAlive = false;
   let struggleSide: PrismixSide | null = null;
+  // 鏡界反射（§5 W2）：開鏡側鏡光面板隨本體逐幀貼合。
+  let mirrorPane: Phaser.GameObjects.Rectangle | null = null;
+  let mirrorTwin: Phaser.Physics.Arcade.Sprite | null = null;
+  // 鏡像殘影（§5 W2）：單具重生刷新；水平反向步進依玩家逐幀位移。
+  let shadow: Phaser.Physics.Arcade.Sprite | null = null;
+  let shadowSpawnAtMs = -1;
+  let prevTargetX: number | null = null;
 
   const viewW = () => scene.scale.width;
   const arenaLeft = () => options.arenaLeft();
@@ -363,6 +377,67 @@ export function createPrismix(
     }
   };
 
+  // 鏡界反射（§5 W2）：單具開鏡 0.8s——銀白鏡光面板即 telegraph；窗內射它的
+  // 星彈折返（FSM reflect 事件），反制＝打另一具。
+  const doMirror = (side: PrismixSide, durationMs: number) => {
+    const twin = sideSprite(side);
+    mirrorTwin = twin;
+    mirrorPane?.destroy();
+    mirrorPane = scene.add
+      .rectangle(twin.x, twin.y, TWIN_W * 0.94, TWIN_H * 1.06, MIRROR_TINT, 0.28)
+      .setStrokeStyle(3, MIRROR_TINT, 0.95)
+      .setDepth(59);
+    scene.tweens.add({
+      targets: mirrorPane,
+      alpha: { from: 1, to: 0.45 },
+      duration: 160,
+      yoyo: true,
+      repeat: -1,
+    });
+    playSfx('reveal', 1.1);
+    delay(durationMs, () => {
+      mirrorPane?.destroy();
+      mirrorPane = null;
+      mirrorTwin = null;
+    });
+  };
+
+  // 折返彈（§5 W2）：自開鏡具射回玩家；帶 inhalable 標記——吸入中接觸即回收為彈藥。
+  const spawnReflectShot = (side: PrismixSide) => {
+    const twin = sideSprite(side);
+    const shot = spawnShot(twin.x, twin.y);
+    if (!shot) return;
+    shot.setTint(MIRROR_TINT);
+    shot.setData('inhalable', true);
+    const to = target ?? { x: arenaCx(), y: GROUND_TOP - 40 };
+    scene.physics.moveTo(shot, to.x, to.y, REFLECT_SHOT_SPEED);
+    playSfx('metal', 1.15);
+  };
+
+  // 鏡像殘影（§5 W2）：玩家鏡影自 arena 中線鏡射位現身——水平反向移動、觸傷 1、
+  // 6s 壽命、1 發即破；群組雙掛沿既有管線（shockwaves 觸傷／shields 星彈可破）。
+  const doShadow = () => {
+    if (!shadow) {
+      const texture = scene.textures.exists('hero-idle') ? 'hero-idle' : '__WHITE';
+      shadow = scene.physics.add.sprite(arenaCx(), TWIN_STAND_Y, texture);
+      shadow.setDisplaySize(SHADOW_SIZE, SHADOW_SIZE);
+      shadow.setTint(SHADOW_TINT).setAlpha(0.78).setDepth(56);
+      shadow.setData('shadow', true);
+      const body = shadow.body as Phaser.Physics.Arcade.Body;
+      body.setAllowGravity(false);
+      body.setSize(shadow.width * 0.8, shadow.height * 0.8);
+      shockwaves.add(shadow);
+      shields.add(shadow);
+    }
+    const spawnX = clampArenaX(shadowSpawnX(arenaCx(), target?.x ?? arenaCx()), 40);
+    shadow.enableBody(true, spawnX, target?.y ?? TWIN_STAND_Y, true, true);
+    shadow.setDisplaySize(SHADOW_SIZE, SHADOW_SIZE).setTint(SHADOW_TINT).setAlpha(0.78);
+    (shadow.body as Phaser.Physics.Arcade.Body).setAllowGravity(false);
+    shadowSpawnAtMs = scene.time.now;
+    prevTargetX = target?.x ?? null;
+    playSfx('reveal', 0.8);
+  };
+
   // P2 分裂演出（§68）：主本體隱沒，雙子自中心彈出左右鏡像位。
   const doSplit = () => {
     twinsAlive = true;
@@ -481,6 +556,12 @@ export function createPrismix(
       case 'merge':
         doMerge(command.coreHp, command.shards);
         return;
+      case 'mirror':
+        doMirror(command.side, command.durationMs);
+        return;
+      case 'shadow':
+        doShadow();
+        return;
       default: {
         const unhandled: never = command;
         throw new Error(`未知指令：${String(unhandled)}`);
@@ -496,6 +577,10 @@ export function createPrismix(
   const dieSequence = () => {
     dying = true;
     active = false;
+    mirrorPane?.destroy();
+    mirrorPane = null;
+    mirrorTwin = null;
+    shadowSpawnAtMs = -1;
     [core, twinA, twinB].forEach((sprite) => scene.tweens.killTweensOf(sprite));
     projectiles.getMatching('active', true).forEach(killProjectile);
     shockwaves.getMatching('active', true).forEach(killProjectile);
@@ -559,6 +644,10 @@ export function createPrismix(
           break;
         case 'twinFinish':
           hooks.onTwinFinish();
+          break;
+        case 'reflect':
+          // 鏡界反射（§5 W2）：開鏡側受擊零傷、生成折返彈（可再吸入）。
+          spawnReflectShot(event.side);
           break;
         case 'minionDrop':
           minionHandlers.forEach((handler) => handler());
@@ -652,8 +741,40 @@ export function createPrismix(
     },
     update(deltaMs: number) {
       if (!active || dying) return;
+      // 距離帶餵送（§5 條件欄）：取最近存活本體與玩家距離。
+      const focus = target;
+      if (focus) {
+        const alive = twinsAlive ? [twinA, twinB].filter((twin) => twin.visible) : [core];
+        const dist = Math.min(
+          ...alive.map((body) => Phaser.Math.Distance.Between(body.x, body.y, focus.x, focus.y)),
+        );
+        fsm.setTargetDistance(Number.isFinite(dist) ? dist : null);
+      } else {
+        fsm.setTargetDistance(null);
+      }
       const command = fsm.tick(deltaMs);
       if (command) runCommand(command);
+      // 鏡光面板逐幀貼合開鏡具（雙子浮動不脫錨）。
+      if (mirrorPane && mirrorTwin) mirrorPane.setPosition(mirrorTwin.x, mirrorTwin.y);
+      // 鏡像殘影（§5 W2）：水平反向步進＋垂直速度上限跟隨；壽命期滿消散。
+      if (shadow && shadowSpawnAtMs >= 0 && shadow.active) {
+        if (!shadowActive(shadowSpawnAtMs, scene.time.now)) {
+          shadowSpawnAtMs = -1;
+          const expiring = shadow;
+          scene.tweens.add({
+            targets: expiring,
+            alpha: 0,
+            duration: 240,
+            onComplete: () => expiring.disableBody(true, true),
+          });
+        } else if (target) {
+          const playerDx = prevTargetX === null ? 0 : target.x - prevTargetX;
+          shadow.x = clampArenaX(stepShadowX(shadow.x, playerDx), 24);
+          shadow.y = stepShadowY(shadow.y, target.y, deltaMs);
+          shadow.setFlipX((target.x ?? 0) < shadow.x);
+        }
+      }
+      prevTargetX = target?.x ?? null;
       if (steering) {
         hoverMs += deltaMs * fsm.speedFactor;
         const bob = Math.sin(hoverMs * 0.003) * 6;
@@ -677,6 +798,8 @@ export function createPrismix(
       const shardCount = ex ? EX_PRISMIX.shardOrbitCount : PRISMIX.shardOrbitCount;
       shields.getMatching('active', true).forEach((obj) => {
         const shard = obj as Phaser.Physics.Arcade.Sprite;
+        // 鏡像殘影雙掛 shields（星彈可破）：不參與碎晶盾軌道。
+        if (shard.getData('shadow') === true) return;
         const index = (shard.getData('orbitIndex') as number) ?? 0;
         const angle = orbitBase + (Math.PI * 2 * index) / shardCount;
         shard.setPosition(
@@ -700,6 +823,8 @@ export function createPrismix(
     },
     destroy() {
       timers.forEach((timer) => timer.remove(false));
+      mirrorPane?.destroy();
+      mirrorPane = null;
       [core, twinA, twinB].forEach((sprite) => {
         scene.tweens.killTweensOf(sprite);
         sprite.destroy();

--- a/apps/starpuff/src/game/systems/syrona.ts
+++ b/apps/starpuff/src/game/systems/syrona.ts
@@ -292,6 +292,8 @@ export function createSyrona(
       if (!wave) return;
       wave.enableBody(true, startX, GROUND_TOP - WAVE_H / 2, true, true);
       wave.setDisplaySize(WAVE_W, WAVE_H).setTint(DEEP_TINT).setAlpha(0.92);
+      // 焦糖化（§5 W2）：糖漿波沾身減速 30%/3s——旗標由 overlaps 層讀取結算。
+      wave.setData('caramel', true);
       (wave.body as Phaser.Physics.Arcade.Body).setVelocityX(dir * WAVE_SPEED);
       // 壽命 = 橫越全場時間＋緩衝（逾時必回收 §56）。
       delay((viewW() / WAVE_SPEED) * 1000 + 400, () => wave.disableBody(true, true));
@@ -507,6 +509,10 @@ export function createSyrona(
     update(deltaMs: number) {
       if (!active || dying) return;
       elapsedMs += deltaMs;
+      // 距離帶餵送（§5 條件欄）。
+      fsm.setTargetDistance(
+        target ? Phaser.Math.Distance.Between(body.x, body.y, target.x, target.y) : null,
+      );
       const command = fsm.tick(deltaMs);
       if (command) runCommand(command);
       // 半定點浮動（場控型不追打）；散熱僵直期輕微前傾露芯。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+179
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+180
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-23
+- ID：reward-starpuff-t5-w2-review-shouldfix-convergence
+- 原因：#813 W2 雙席審查 should-fix——掙扎中斷後鏡光面板殘留、caramel 再沾波 FX/浮字轟炸、overlaps/caramelStatus 新行為缺測試覆蓋
+- 解法：doStruggle 即時銷毀 mirrorPane、apply() 以 caramelActive guard 收斂為僅刷新計時＋taughtCaramelClear 入 closure，補 caramelStatus 10 測與 overlaps 吸入回收/焦糖旗標行為測試（含負例），vitest 796 全綠
 
 - 日期：2026-07-23
 - ID：reward-starpuff-t5-w2-prismix-syrona-theme-moves

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+0（reward 0、penalty 0、neutral 1）｜累計總分：+178
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+179
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-23
+- ID：reward-starpuff-t5-w2-prismix-syrona-theme-moves
+- 原因：#813 W2——Prismix/Syrona 仍為固定循環可背板，且缺 PRD §5 主題招式（鏡界反射/鏡像殘影/焦糖化）與可學習反制
+- 解法：兩 FSM 接入 moveTable 加權表（條件欄＋seed 重放＋同招上限 2）並新增 mirror/shadow/caramel 招式與純邏輯模組，殘影雙掛 shields/shockwaves 零 BossHandle 新選配，vitest 784 全綠、L12/L16 各階段條件熵 0.90–1.93 bits ≥ 門檻
 
 - 日期：2026-07-23
 - ID：neutral-starpuff-t5-w1-review-shouldfix


### PR DESCRIPTION
## Summary
- Prismix：鏡界反射（0.8s 折返＋可吸入回收）＋鏡像殘影（P2 深段 HP≤50%）
- Syrona：焦糖化（30%/3s）＋噴口吹乾／雷化瞬除反制
- 兩王 moveTable 加權選招接入；熵探針 L12/L16 全過門檻
- 雙席 APPROVE 後 Should-fix 收斂：mirrorPane 殘留、overlaps/caramelStatus 測試、FX spam 防護

## Test plan
- [x] PM 親跑 `pnpm --filter @app/starpuff typecheck`
- [x] PM 親跑 vitest 796/796 綠
- [ ] CI Quality Checks
- [ ] release PR → 生產切版


Made with [Cursor](https://cursor.com)