### PR TITLE
refactor(starpuff): T7-B 物理視覺解耦通道 visualScale

### DIFF
--- a/apps/starpuff/docs/GAME_DESIGN.md
+++ b/apps/starpuff/docs/GAME_DESIGN.md
@@ -1164,6 +1164,11 @@ epic 資料夾（art-v8-ticket.md / run-art-v8.sh）。
 
 ### 77.1 站台「下＋跳」穿落回歸根修（補訂 §29/§44）
 
+> 2026-07-26 取代注記（§117）：本節根因鏈第 1 點「擠壓縮小 body」的耦合已由
+> visualScale 物理/視覺解耦通道根治——物理箱永不隨美術縮放，`LANDING_SQUASH_MIN_VY`
+> 門檻補丁退場；`recentlyGroundedMs`／`restingOnOneWay`／`oneWayLandBand` 屬獨立
+> 語意修正（coyote 收斂、旗標抖動免疫、下砸防隧穿），維持有效。
+
 **根因鏈**（worldstep 逐步 trace 實證）：
 
 1. 落地擠壓 `squashStretch(1.25, 0.75)` 於每次「重新接觸」觸發——擠壓縮小 body
@@ -2403,3 +2408,28 @@ W3 合議收斂：補齊 §8.2 表前二王真 P4（stub 落地）＋Syrona 暴�
   機械化）；乘流中節拍仍由 §116.3 共鳴解鎖制收斂。
 - anti-softlock 複核：噴口恆噴保證可乘、持鍵＝基礎輸入、彈盡可落地吃補給怪
   再返場——基礎星彈恆可通關不變式成立；無計時失敗、沸騰不淹保底高台照舊。
+
+## 117. 物理/視覺縮放解耦 visualScale（#819 子項 3；T7-B 列車）
+
+§77 型缺陷家族的架構級根治：Phaser 4 Arcade `Body.updateBounds` 每物理步以
+`sourceWidth × |scale|` 重算碰撞箱（官方 API 文檔＋Body.js 原始碼實證，無凍結旗標），
+且 TweenManager 與物理 world 同掛 `SceneEvents.UPDATE`——任何直接 tween sprite scale
+的視覺效果都會在同幀被物理讀到，衍生落地擠壓迴圈、腳底離台、穿台與 overlap 漏檢。
+
+### 117.1 通道架構（systems/visualScale.ts，場景鍵入單例）
+
+- 沿 §77.2 蹲姿／§45 走 bob 已驗證的 PRE/POST_UPDATE 視覺通道模式全遊戲統一：
+  `PRE_UPDATE` 還原物理基準（物理步只見基準）、`POST_UPDATE` 套用
+  `base × fx × mod`（渲染見形變）；tween 一律以 fx 代理為標的，物理永不見瞬態縮放。
+- 三層語意：`base`＝物理基準（精英體型、鑽地鰭、半潛、縮殼、月牙縮體、裸核、
+  texture 切換後 rebase）；`fx`＝tween 代理（squash/stretch、popIn、wobble、翼拍、
+  怒吼脈動、死亡收縮）；`mod`＝逐幀直寫（idle 呼吸、蹲縮），擁有者每幀維護。
+- 覆蓋面：玩家（擠壓/呼吸/蹲縮/受擊）、18 怪（popIn/wobble/呼吸/死亡/狀態造型）、
+  五王（wobble/翼拍/攻擊擠壓/怒吼/碎裂/死亡/相位縮體）。柱/爪/糖泉等升起中的
+  危害判定屬蓄意成長 hitbox，維持直接縮放不遷移。
+- 補丁退場：`LANDING_SQUASH_MIN_VY`（§77.1 單案例門檻）刪除——擠壓不再縮物理箱，
+  任意著地皆可安全觸發；碰撞箱不再隨 wobble 每拍脈動（怪 ±8%、魔王 ±5-7%）、
+  popIn 生成期物理箱不再僅 30%。
+- 行為錨：visualScale.test 鎖住「動畫期間物理讀取窗 scale 恆為基準」契約與
+  池重用重錨、shutdown 清理語意；行為零改變由全量 vitest＋e2e 全套＋
+  level-audit L1/L14/L16 EX 對比 base 佐證。

--- a/apps/starpuff/src/game/systems/boss.ts
+++ b/apps/starpuff/src/game/systems/boss.ts
@@ -5,6 +5,7 @@ import { BOSS, createBossFsm, type BossCommand } from '../logic/bossFsm';
 import { JELLY_PATCH, jellyBounceVy, prunePatches, type JellyPatch } from '../logic/jellyPatch';
 import { playSfx } from '../audio/sfx';
 import { burstSmall, landingDust, spawnTelegraph } from './fx';
+import { getVisualScale } from './visualScale';
 
 // EX 變體選項與擊破分裂 hook（§58）：分裂生成走 GameScene 正式 spawn 管線。
 export interface BossOptions {
@@ -138,8 +139,11 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
 
   const sprite = scene.physics.add.sprite(sideX('right'), -BOSS_H, 'boss-idle');
   sprite.setDisplaySize(BOSS_W, BOSS_H);
-  const baseScaleX = sprite.scaleX;
-  const baseScaleY = sprite.scaleY;
+  // 物理/視覺縮放解耦（§77 根治）：wobble/擠壓/怒吼脈動/死亡收縮全走 fx 代理，
+  // 物理箱恆為基準；texture 切換後 rebase 重錨。
+  const vscale = getVisualScale(scene);
+  vscale.register(sprite);
+  const fxScale = vscale.fx(sprite);
   const body = sprite.body as Phaser.Physics.Arcade.Body;
   body.setAllowGravity(false);
   body.setImmovable(true);
@@ -151,11 +155,11 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
     timers.push(scene.time.delayedCall(ms, fn));
   };
 
-  // 常駐果凍 wobble；slam / dash 期間暫停避免 scale 衝突。
+  // 常駐果凍 wobble（fx 代理，物理箱不動）；slam / dash 期間暫停避免 fx 衝突。
   const wobble = scene.tweens.add({
-    targets: sprite,
-    scaleX: sprite.scaleX * 1.05,
-    scaleY: sprite.scaleY * 0.94,
+    targets: fxScale,
+    sx: 1.05,
+    sy: 0.94,
     duration: 620,
     yoyo: true,
     repeat: -1,
@@ -192,6 +196,7 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
 
   const startEnrage = () => {
     sprite.setTexture('boss-enraged').setDisplaySize(BOSS_W, BOSS_H);
+    vscale.rebase(sprite);
     startTintCycle({ r: 255, g: 255, b: 255 }, ENRAGE_TINT, 700);
   };
 
@@ -206,6 +211,7 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
   };
   const startFrenzy = () => {
     sprite.setTexture('boss-enraged').setDisplaySize(BOSS_W, BOSS_H);
+    vscale.rebase(sprite);
     startTintCycle({ r: 255, g: 176, b: 208 }, { r: 255, g: 120, b: 168 }, 360);
     playSfx('boss-roar', 1.3);
     scene.cameras.main.flash(320, 255, 176, 208);
@@ -222,6 +228,7 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
   // P3 進場演出（§30）：皇冠射出星環衝擊波（金色擴散環 + 星火），時停 0.3s 由 GameScene 接線。
   const startP3 = () => {
     sprite.setTexture('boss-enraged').setDisplaySize(BOSS_W, BOSS_H);
+    vscale.rebase(sprite);
     startTintCycle(P3_GOLD, P3_PURPLE, P3_FLICKER_MS);
     const crownX = sprite.x;
     const crownY = sprite.y - BOSS_H * 0.55;
@@ -354,9 +361,9 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
     sprite.setTint(SLAM_WINDUP_TINT);
     playSfx('boss-slam');
     scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX * 1.18,
-      scaleY: baseScaleY * 0.8,
+      targets: fxScale,
+      sx: 1.18,
+      sy: 0.8,
       duration: SLAM_WINDUP_MS,
       ease: 'Quad.easeOut',
     });
@@ -364,21 +371,31 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
       if (dying) return;
       if (enrageTween) enrageTween.resume();
       else sprite.clearTint();
+      // 位移走 sprite、擠壓走 fx 代理（§77 解耦）：起跳期回復基準、著地擠壓回彈。
+      scene.tweens.add({
+        targets: fxScale,
+        sx: 1,
+        sy: 1,
+        duration: 300 / sf,
+        ease: 'Quad.easeOut',
+      });
       scene.tweens.chain({
         targets: sprite,
         tweens: [
-          {
-            y: STAND_Y - 170,
-            scaleX: baseScaleX,
-            scaleY: baseScaleY,
-            duration: 300 / sf,
-            ease: 'Quad.easeOut',
-          },
+          { y: STAND_Y - 170, duration: 300 / sf, ease: 'Quad.easeOut' },
           { y: STAND_Y, duration: 180 / sf, ease: 'Quad.easeIn' },
-          { scaleX: baseScaleX * 1.22, scaleY: baseScaleY * 0.78, duration: 90, yoyo: true },
         ],
         onComplete: () => {
-          wobble.resume();
+          scene.tweens.add({
+            targets: fxScale,
+            sx: 1.22,
+            sy: 0.78,
+            duration: 90,
+            yoyo: true,
+            onComplete: () => {
+              wobble.resume();
+            },
+          });
         },
       });
     });
@@ -416,14 +433,23 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
     });
     delay(DASH_WINDUP_MS, () => {
       if (dying) return;
-      scene.tweens.chain({
+      scene.tweens.add({
         targets: sprite,
-        tweens: [
-          { x: targetX, duration: 550 / fsm.speedFactor, ease: 'Sine.easeIn' },
-          { scaleX: baseScaleX * 1.28, scaleY: baseScaleY * 0.76, duration: 110, yoyo: true },
-        ],
+        x: targetX,
+        duration: 550 / fsm.speedFactor,
+        ease: 'Sine.easeIn',
         onComplete: () => {
-          wobble.resume();
+          // 到位擠壓走 fx 代理（§77 解耦）。
+          scene.tweens.add({
+            targets: fxScale,
+            sx: 1.28,
+            sy: 0.76,
+            duration: 110,
+            yoyo: true,
+            onComplete: () => {
+              wobble.resume();
+            },
+          });
         },
       });
     });
@@ -458,19 +484,14 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
     dying = true;
     active = false;
     scene.tweens.killTweensOf(sprite);
+    vscale.killFxTweens(sprite);
     projectiles.getMatching('active', true).forEach(killProjectile);
     shockwaves.getMatching('active', true).forEach(killProjectile);
     emitGameEvent(scene.events, GameEvents.BOSS_DEFEATED, { x: sprite.x, y: sprite.y });
     // 慢動作與星爆統一由 fx 系統的 BOSS_DEFEATED 監聽處理（單一權責）；600ms 對齊 fx slowMo 結束後淡出。
     delay(600, () => {
-      scene.tweens.add({
-        targets: sprite,
-        scaleX: 0,
-        scaleY: 0,
-        alpha: 0,
-        duration: 420,
-        ease: 'Back.easeIn',
-      });
+      scene.tweens.add({ targets: fxScale, sx: 0, sy: 0, duration: 420, ease: 'Back.easeIn' });
+      scene.tweens.add({ targets: sprite, alpha: 0, duration: 420, ease: 'Back.easeIn' });
     });
   };
 
@@ -480,9 +501,9 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
     scene.cameras.main.shake(150, shakeIntensity);
     if (!withSquash) return;
     scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX * 1.2,
-      scaleY: baseScaleY * 0.78,
+      targets: fxScale,
+      sx: 1.2,
+      sy: 0.78,
       duration: 90,
       yoyo: true,
       ease: 'Quad.easeOut',
@@ -524,9 +545,9 @@ export function createBoss(scene: Phaser.Scene, options: BossOptions = {}): Boss
       ease: 'Sine.easeInOut',
     });
     scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX * 1.14,
-      scaleY: baseScaleY * 1.1,
+      targets: fxScale,
+      sx: 1.14,
+      sy: 1.1,
       duration: 170,
       yoyo: true,
       repeat: 1,

--- a/apps/starpuff/src/game/systems/enemies.test.ts
+++ b/apps/starpuff/src/game/systems/enemies.test.ts
@@ -15,6 +15,20 @@ vi.mock('phaser', () => ({
 }));
 vi.mock('../audio/sfx', () => ({ playSfx: vi.fn(), stopSfx: vi.fn() }));
 vi.mock('./fx', () => ({ popIn: vi.fn(), spawnTelegraph: vi.fn() }));
+// visualScale 通道替身：本檔僅驗 aliveInhalableCount 純邏輯，不需要真實 scene 事件。
+vi.mock('./visualScale', () => ({
+  getVisualScale: () => ({
+    register: vi.fn(),
+    rebase: vi.fn(),
+    setBase: vi.fn(),
+    fx: () => ({ sx: 1, sy: 1 }),
+    mod: () => ({ sx: 1, sy: 1 }),
+    killFxTweens: vi.fn(),
+    resetFx: vi.fn(),
+    isFxTweening: () => false,
+    unregister: vi.fn(),
+  }),
+}));
 
 interface FakeFoe {
   active: boolean;

--- a/apps/starpuff/src/game/systems/enemies.ts
+++ b/apps/starpuff/src/game/systems/enemies.ts
@@ -39,6 +39,7 @@ import {
   type EnemyUpdateContext,
 } from './enemyUpdates';
 import { popIn } from './fx';
+import { getVisualScale } from './visualScale';
 
 export interface EnemyTarget {
   x: number;
@@ -257,6 +258,9 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
   });
   let target: EnemyTarget | null = null;
   let elapsedMs = 0;
+  // 物理/視覺縮放解耦（§77 根治）：popIn/wobble/死亡壓縮走 fx 代理、呼吸走 mod、
+  // 狀態性造型（縮殼/鑽地鰭/半潛/精英體型）走 setBase——物理箱恆為狀態基準。
+  const vscale = getVisualScale(scene);
 
   // 無 target 時的朝向啟發改讀當前鏡頭中心（§28 動態視寬，禁硬編 854）。
   const viewCenterX = () => scene.cameras.main.scrollX + scene.scale.width / 2;
@@ -479,10 +483,12 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
     body.stop();
     body.enable = false;
     sprite.setActive(false);
+    // 死亡壓縮走 fx 代理（§77 解耦）：自當前形變接續壓至零高。
+    vscale.killFxTweens(sprite);
     scene.tweens.add({
-      targets: sprite,
-      scaleX: sprite.scaleX * 1.5,
-      scaleY: 0,
+      targets: vscale.fx(sprite),
+      sx: 1.5,
+      sy: 0,
       duration: 150,
       ease: 'Quad.easeIn',
       onComplete: () => sprite.setVisible(false),
@@ -497,7 +503,8 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
     sprite.setData('stateMs', 0);
     const bsx = sprite.getData('baseSX') as number;
     const bsy = sprite.getData('baseSY') as number;
-    sprite.setScale(bsx * SHELLY_SHELL_SCALE, bsy * SHELLY_SHELL_SCALE);
+    // 縮殼為狀態性造型：走物理基準（§77 解耦），旋轉期碰撞體同步縮小。
+    vscale.setBase(sprite, bsx * SHELLY_SHELL_SCALE, bsy * SHELLY_SHELL_SCALE);
     const direction = target && target.x < sprite.x ? -1 : 1;
     (sprite.body as Phaser.Physics.Arcade.Body).setVelocityX(SHELLY_SPIN_SPEED * direction);
   }
@@ -506,6 +513,7 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
   // hazards/回收管線以回呼銜接。
   const updateCtx: EnemyUpdateContext = {
     scene,
+    vscale,
     get target() {
       return target;
     },
@@ -530,12 +538,14 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
     const sprite = group.get(x, y, TEXTURES[kind]) as Phaser.Physics.Arcade.Sprite | null;
     if (!sprite) return null;
 
-    // 池重用防護：死亡 squash tween 可能仍在播放，先清除再重設外觀。
+    // 池重用防護：死亡壓縮/popIn tween 可能仍在播放，先清除再重設外觀。
     scene.tweens.killTweensOf(sprite);
     (sprite.getData('warnRing') as Phaser.GameObjects.Arc | undefined)?.destroy();
     sprite.setActive(true).setVisible(true);
     sprite.setTexture(TEXTURES[kind]);
     sprite.setDisplaySize(ENEMY_SIZE, ENEMY_SIZE);
+    // 冪等註冊（§77 解耦）：重錨物理基準並復位 fx/mod 與殘留 fx tween。
+    vscale.register(sprite);
     sprite.setRotation(0);
     sprite.setAlpha(1);
     sprite.clearTint();
@@ -619,16 +629,16 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
     else if (kind === 'shelly') body.setVelocity(SHELLY_WALK_SPEED * inward, 0);
     else body.setVelocity(0, 0);
 
-    // 生成彈入；wobble 延後啟動避免同時操作 scale。
+    // 生成彈入；wobble 延後啟動避免同時操作 fx。
     popIn(scene, sprite);
 
-    // wobble idle：果凍感擠壓拉伸；chompy/shelly/drilly/spora 的 scale 由各自狀態機控制，
-    // 不掛 wobble。
+    // wobble idle：果凍感擠壓拉伸（fx 代理，物理箱不動）；chompy/shelly/drilly/spora
+    // 的造型由各自狀態機控制，不掛 wobble。
     if (kind !== 'chompy' && kind !== 'shelly' && kind !== 'drilly' && kind !== 'spora') {
       scene.tweens.add({
-        targets: sprite,
-        scaleX: sprite.scaleX * 1.08,
-        scaleY: sprite.scaleY * 0.92,
+        targets: vscale.fx(sprite),
+        sx: 1.08,
+        sy: 0.92,
         duration: 360,
         yoyo: true,
         repeat: -1,
@@ -700,6 +710,8 @@ export function createEnemySystem(scene: Phaser.Scene): EnemySystem {
       if (!sprite) return null;
       scene.tweens.killTweensOf(sprite);
       sprite.setDisplaySize(ENEMY_SIZE * opts.scale, ENEMY_SIZE * opts.scale);
+      // 精英體型為狀態性造型：重新註冊重錨物理基準（§77 解耦），並清掉 spawn 的 fx tween。
+      vscale.register(sprite);
       sprite.setTint(opts.tint);
       sprite.setData('hp', opts.hp);
       sprite.setData('elite', true);

--- a/apps/starpuff/src/game/systems/enemyUpdates.ts
+++ b/apps/starpuff/src/game/systems/enemyUpdates.ts
@@ -36,6 +36,7 @@ import {
 import { playSfx } from '../audio/sfx';
 import { spawnTelegraph } from './fx';
 import type { EnemyTarget } from './enemies';
+import type { VisualScaleChannel } from './visualScale';
 
 // 小怪 per-kind 逐幀 AI（GAME_DESIGN §16/§30/§47/§48）：自 enemies.ts 機械式搬移，
 // 行為零改變；生成/傷害/回收與 hazards 池仍由 enemies.ts 持有，經 ctx 回呼銜接。
@@ -184,6 +185,8 @@ function clearWindupRing(sprite: Phaser.Physics.Arcade.Sprite): void {
 // AI 對外依賴最小面：target/elapsedMs 為即時值（getter），其餘為 enemies.ts 內部管線回呼。
 export interface EnemyUpdateContext {
   scene: Phaser.Scene;
+  // 物理/視覺縮放解耦通道（§77）：狀態性造型走 setBase、瞬態演出走 fx/mod。
+  vscale: VisualScaleChannel;
   readonly target: EnemyTarget | null;
   readonly elapsedMs: number;
   viewCenterX(): number;
@@ -233,7 +236,8 @@ function updateShelly(
     sprite.setRotation(0);
     const bsx = sprite.getData('baseSX') as number;
     const bsy = sprite.getData('baseSY') as number;
-    sprite.setScale(bsx, bsy);
+    // 縮殼復原（§77 解耦）：造型回種基準走物理基準。
+    ctx.vscale.setBase(sprite, bsx, bsy);
     return;
   }
   switch (tick.state) {
@@ -296,7 +300,7 @@ function updateDrilly(
     spawnTelegraph(ctx.scene, sprite.x, sprite.y + DRILLY_TELEGRAPH_OFFSET_Y, 500);
   } else if (tick.entered === 'surfaced') {
     playSfx('pop');
-    sprite.setScale(bsx, bsy);
+    ctx.vscale.setBase(sprite, bsx, bsy);
     sprite.setAlpha(1);
     body.setVelocity(0, DRILLY_EMERGE_VY);
   } else if (tick.entered === 'burrow') {
@@ -304,8 +308,9 @@ function updateDrilly(
   }
   switch (tick.state) {
     case 'burrow': {
-      // 僅露鰭：壓扁貼地半透明，朝玩家 x 潛行。
-      sprite.setScale(bsx * DRILLY_FIN_SCALE_X, bsy * DRILLY_FIN_SCALE_Y);
+      // 僅露鰭：壓扁貼地半透明（狀態性造型走物理基準——碰撞體同步壓扁貼地），
+      // 朝玩家 x 潛行。
+      ctx.vscale.setBase(sprite, bsx * DRILLY_FIN_SCALE_X, bsy * DRILLY_FIN_SCALE_Y);
       sprite.setAlpha(0.85);
       if (body.blocked.down) {
         const direction = ctx.target && ctx.target.x < sprite.x ? -1 : 1;
@@ -396,11 +401,11 @@ function updateSpora(
   }
   clearWindupRing(sprite);
   sprite.clearTint();
-  // idle 呼吸：定點輕微擠壓律動（scale 由本狀態機持有，不掛 wobble tween）。
-  const bsx = sprite.getData('baseSX') as number;
-  const bsy = sprite.getData('baseSY') as number;
+  // idle 呼吸：定點輕微擠壓律動（mod 逐幀直寫，物理箱不動；不掛 wobble tween）。
   const breath = Math.sin(ctx.elapsedMs * 0.003);
-  sprite.setScale(bsx * (1 + breath * 0.04), bsy * (1 - breath * 0.03));
+  const breathMod = ctx.vscale.mod(sprite);
+  breathMod.sx = 1 + breath * 0.04;
+  breathMod.sy = 1 - breath * 0.03;
 }
 
 // 風飄鳥（§52）：四態時序由 enemyFsm 決策；drift 水平漂移＋正弦浮動、windup 懸停
@@ -655,14 +660,15 @@ function updateBubbla(
   const baseY = sprite.getData('baseY') as number;
   if (tick.entered === 'leap') {
     playSfx('pop', 0.85);
-    sprite.setScale(bsx, bsy);
+    ctx.vscale.setBase(sprite, bsx, bsy);
     sprite.setAlpha(1);
   } else if (tick.entered === 'submerged') {
     body.setVelocity(0, 0);
   }
   switch (tick.state) {
     case 'submerged': {
-      sprite.setScale(bsx * BUBBLA_SUNK_SCALE_X, bsy * BUBBLA_SUNK_SCALE_Y);
+      // 半潛壓扁為狀態性造型：走物理基準（§77 解耦）。
+      ctx.vscale.setBase(sprite, bsx * BUBBLA_SUNK_SCALE_X, bsy * BUBBLA_SUNK_SCALE_Y);
       sprite.setAlpha(0.85);
       body.setVelocity(0, 0);
       break;
@@ -926,8 +932,6 @@ function updateChompy(
   const state = sprite.getData('state') as ChompyState;
   const stateMs = (sprite.getData('stateMs') as number) + deltaMs;
   sprite.setData('stateMs', stateMs);
-  const bsx = sprite.getData('baseSX') as number;
-  const bsy = sprite.getData('baseSY') as number;
   // 精英倍率（§48）：前搖/冷卻縮時提升攻速。
   const mul = (sprite.getData('eliteMul') as number) ?? 1;
   switch (state) {
@@ -939,12 +943,12 @@ function updateChompy(
       ) {
         sprite.setData('state', 'windup');
         sprite.setData('stateMs', 0);
-        ctx.scene.tweens.killTweensOf(sprite);
-        // 張嘴 squash 蓄力。
+        // 張嘴 squash 蓄力（fx 代理，物理箱不動）。
+        ctx.vscale.resetFx(sprite);
         ctx.scene.tweens.add({
-          targets: sprite,
-          scaleX: bsx * 1.2,
-          scaleY: bsy * 0.78,
+          targets: ctx.vscale.fx(sprite),
+          sx: 1.2,
+          sy: 0.78,
           duration: CHOMPY_WINDUP_MS / mul,
           ease: 'Quad.easeIn',
         });
@@ -956,12 +960,12 @@ function updateChompy(
       sprite.setData('state', 'bite');
       sprite.setData('stateMs', 0);
       playSfx('chomp');
-      ctx.scene.tweens.killTweensOf(sprite);
-      sprite.setScale(bsx, bsy);
+      // 咬合回彈（fx 代理）：先復位再彈（物理箱不動）。
+      ctx.vscale.resetFx(sprite);
       ctx.scene.tweens.add({
-        targets: sprite,
-        scaleX: bsx * 0.9,
-        scaleY: bsy * 1.22,
+        targets: ctx.vscale.fx(sprite),
+        sx: 0.9,
+        sy: 1.22,
         duration: 100,
         yoyo: true,
         ease: 'Back.easeOut',

--- a/apps/starpuff/src/game/systems/fx.ts
+++ b/apps/starpuff/src/game/systems/fx.ts
@@ -34,7 +34,6 @@ export interface FxSystem {
   hitStop(durationMs: number): void;
   shake(intensityPx: number): void;
   flashWhite(target: Phaser.GameObjects.GameObject): void;
-  squashStretch(target: Scalable, intensity?: number): void;
   startInhale(mouth: Phaser.Types.Math.Vector2Like): void;
   stopInhale(): void;
   attachTrail(target: Phaser.Types.Math.Vector2Like, opts?: TrailOptions): TrailHandle;
@@ -348,24 +347,6 @@ export function createFx(scene: Phaser.Scene): FxSystem {
     scene.tweens.add({ targets: target, alpha: 0.25, duration: 60, yoyo: true, repeat: 1 });
   }
 
-  // 進行中不重複觸發：避免以壓扁中的 scale 為基準疊乘造成漂移。
-  const squashTweens = new WeakMap<Scalable, Phaser.Tweens.Tween>();
-
-  function squashStretch(target: Scalable, intensity = 0.22): void {
-    if (squashTweens.get(target)?.isPlaying()) return;
-    squashTweens.set(
-      target,
-      scene.tweens.add({
-        targets: target,
-        scaleX: target.scaleX * (1 + intensity),
-        scaleY: target.scaleY * (1 - intensity),
-        duration: 90,
-        yoyo: true,
-        ease: 'Quad.easeOut',
-      }),
-    );
-  }
-
   function damageNumber(x: number, y: number, amount: number): void {
     if (damageNumberCount >= 12) return;
     damageNumberCount++;
@@ -512,12 +493,10 @@ export function createFx(scene: Phaser.Scene): FxSystem {
     unbinders.push(() => offGameEvent(bus, event, handler));
   }
 
+  // 受擊擠壓已遷入 player.takeDamage（§77 解耦，走 visualScale fx 代理）。
   bind(GameEvents.PLAYER_DAMAGED, () => {
     shake(4);
-    if (playerRef?.scene) {
-      flashWhite(playerRef);
-      squashStretch(playerRef as unknown as Scalable, 0.28);
-    }
+    if (playerRef?.scene) flashWhite(playerRef);
   });
   bind(GameEvents.ENEMY_KILLED, ({ x, y }) => puff(x, y));
   bind(GameEvents.BOSS_SPAWNED, () => shake(6));
@@ -557,7 +536,6 @@ export function createFx(scene: Phaser.Scene): FxSystem {
     hitStop,
     shake,
     flashWhite,
-    squashStretch,
     startInhale(mouth) {
       mouthRef = mouth;
       inhaleEmitter.start();

--- a/apps/starpuff/src/game/systems/fx.ts
+++ b/apps/starpuff/src/game/systems/fx.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GameEvents, onGameEvent, offGameEvent, type GameEventName } from '../core/events';
 import { playSfx } from '../audio/sfx';
+import { getVisualScale, type ScalableSprite } from './visualScale';
 
 export const FX_TEXTURES = {
   dot: 'fx-dot',
@@ -11,10 +12,6 @@ export const FX_TEXTURES = {
 const PASTELS = [0xffb3c7, 0xcbb7f0, 0xd9f29b, 0xffd966, 0xbff3e0];
 
 type FxTarget = Phaser.GameObjects.GameObject & { x: number; y: number };
-interface Scalable {
-  scaleX: number;
-  scaleY: number;
-}
 interface Tintable {
   setTint(color: number): unknown;
   setTintMode(mode: number): unknown;
@@ -109,17 +106,20 @@ function canTint(go: object): go is Tintable {
   return 'setTint' in go && 'setTintMode' in go && 'clearTint' in go;
 }
 
-// 生成彈入：自 30% 縮放淡入回彈至原尺寸；供 enemies 等系統於 spawn 時直接呼叫。
+// 生成彈入（§77 解耦）：fx 代理自 30% 回彈至基準＋sprite 淡入；物理箱不隨演出縮放。
+// 前置：sprite 已註冊 visualScale 通道。
 export function popIn(
   scene: Phaser.Scene,
-  target: Scalable & { alpha: number },
+  sprite: ScalableSprite & { alpha: number },
   durationMs = 260,
 ): void {
+  const fx = getVisualScale(scene).fx(sprite);
+  fx.sx = 0.3;
+  fx.sy = 0.3;
+  scene.tweens.add({ targets: fx, sx: 1, sy: 1, duration: durationMs, ease: 'Back.easeOut' });
   scene.tweens.add({
-    targets: target,
-    scaleX: { from: target.scaleX * 0.3, to: target.scaleX },
-    scaleY: { from: target.scaleY * 0.3, to: target.scaleY },
-    alpha: { from: 0, to: target.alpha },
+    targets: sprite,
+    alpha: { from: 0, to: sprite.alpha },
     duration: durationMs,
     ease: 'Back.easeOut',
   });

--- a/apps/starpuff/src/game/systems/noctra.ts
+++ b/apps/starpuff/src/game/systems/noctra.ts
@@ -7,6 +7,7 @@ import { NOCTRA_FLIGHT, approachPoint, hoverPatternPoint } from '../logic/noctra
 import { playSfx } from '../audio/sfx';
 import type { BossDamageSource, BossHandle } from './boss';
 import { spawnTelegraph } from './fx';
+import { getVisualScale } from './visualScale';
 
 // 暗月蝠王 Noctra 呈現層（GAME_DESIGN §54）：與 systems/boss.ts 同 BossHandle 介面，
 // GameScene 依 level.boss 品種擇一建立，事件契約（BOSS_*）完全共用。
@@ -110,8 +111,11 @@ export function createNoctra(
 
   const sprite = scene.physics.add.sprite(arenaCx(), -BODY_H, 'boss-noctra');
   sprite.setDisplaySize(BODY_W, BODY_H);
-  const baseScaleX = sprite.scaleX;
-  const baseScaleY = sprite.scaleY;
+  // 物理/視覺縮放解耦（§77 根治）：翼拍/蓄勢/怒吼/死亡收縮走 fx 代理；
+  // 暗月月牙縮體屬狀態性造型，setDisplaySize 後 rebase 重錨物理基準。
+  const vscale = getVisualScale(scene);
+  vscale.register(sprite);
+  const fxScale = vscale.fx(sprite);
   const body = sprite.body as Phaser.Physics.Arcade.Body;
   body.setAllowGravity(false);
   body.setImmovable(true);
@@ -125,11 +129,11 @@ export function createNoctra(
     timers.push(scene.time.delayedCall(ms, fn));
   };
 
-  // 常駐翼拍律動；dive/sweep 期間暫停避免 scale 衝突。
+  // 常駐翼拍律動（fx 代理，物理箱不動）；dive/sweep 期間暫停避免 fx 衝突。
   const wingbeat = scene.tweens.add({
-    targets: sprite,
-    scaleX: sprite.scaleX * 1.07,
-    scaleY: sprite.scaleY * 0.92,
+    targets: fxScale,
+    sx: 1.07,
+    sy: 0.92,
     duration: 480,
     yoyo: true,
     repeat: -1,
@@ -256,9 +260,9 @@ export function createNoctra(
     flashWhite();
     playSfx('charge');
     scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX * 1.15,
-      scaleY: baseScaleY * 1.1,
+      targets: fxScale,
+      sx: 1.15,
+      sy: 1.1,
       duration: 200,
       yoyo: true,
       ease: 'Sine.easeInOut',
@@ -315,7 +319,11 @@ export function createNoctra(
     // 暗月月牙變細（§8.2 W3 EX P4）：掠行判定帶與本體縱向縮細（telegraph
     // 時長不縮——可讀性紅線只縮體不縮窗）。
     const crescentMul = fsm.phase === 'p4' ? EX_NOCTRA.darkSweepScaleMul : 1;
-    if (crescentMul !== 1) sprite.setDisplaySize(BODY_W, BODY_H * crescentMul);
+    if (crescentMul !== 1) {
+      // 月牙縮體為狀態性造型：rebase 讓判定帶同步縮細（只縮體不縮窗）。
+      sprite.setDisplaySize(BODY_W, BODY_H * crescentMul);
+      vscale.rebase(sprite);
+    }
     const band = scene.add
       .rectangle(arenaCx(), SWEEP_Y, viewW(), BODY_H * 0.7 * crescentMul, 0x9f8fe8, 0.16)
       .setDepth(58);
@@ -351,6 +359,7 @@ export function createNoctra(
         onComplete: () => {
           // 掠行結束復原本體尺寸（暗月縮體僅限月牙航跡期間）。
           sprite.setDisplaySize(BODY_W, BODY_H);
+          vscale.rebase(sprite);
           steering = true;
           wingbeat.resume();
         },
@@ -454,17 +463,12 @@ export function createNoctra(
     cloakStartMs = -1;
     sprite.setAlpha(1);
     scene.tweens.killTweensOf(sprite);
+    vscale.killFxTweens(sprite);
     projectiles.getMatching('active', true).forEach(killProjectile);
     emitGameEvent(scene.events, GameEvents.BOSS_DEFEATED, { x: sprite.x, y: sprite.y });
     delay(600, () => {
-      scene.tweens.add({
-        targets: sprite,
-        scaleX: 0,
-        scaleY: 0,
-        alpha: 0,
-        duration: 420,
-        ease: 'Back.easeIn',
-      });
+      scene.tweens.add({ targets: fxScale, sx: 0, sy: 0, duration: 420, ease: 'Back.easeIn' });
+      scene.tweens.add({ targets: sprite, alpha: 0, duration: 420, ease: 'Back.easeIn' });
     });
   };
 
@@ -492,9 +496,9 @@ export function createNoctra(
       ease: 'Sine.easeInOut',
     });
     scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX * 1.16,
-      scaleY: baseScaleY * 1.12,
+      targets: fxScale,
+      sx: 1.16,
+      sy: 1.12,
       duration: 170,
       yoyo: true,
       repeat: 1,
@@ -539,7 +543,8 @@ export function createNoctra(
         playSfx('break');
         shake();
         scene.tweens.killTweensOf(sprite);
-        sprite.setScale(baseScaleX, baseScaleY);
+        // 蓄勢脈動中斷復位（§77 解耦）：fx 回 1，物理基準不動。
+        vscale.resetFx(sprite);
       }
       for (const event of fsm.takeDamage(amount)) {
         switch (event.kind) {

--- a/apps/starpuff/src/game/systems/player.test.ts
+++ b/apps/starpuff/src/game/systems/player.test.ts
@@ -240,7 +240,7 @@ function makeHarness(): {
         },
       },
     },
-    events: { on: vi.fn(), off: vi.fn(), emit },
+    events: { on: vi.fn(), once: vi.fn(), off: vi.fn(), emit },
     tweens: { add: vi.fn(), killTweensOf: vi.fn(), isTweening: () => false },
     time: { now: 0 },
     cameras: { main: { worldView: { x: 0, right: 854 } } },

--- a/apps/starpuff/src/game/systems/player.ts
+++ b/apps/starpuff/src/game/systems/player.ts
@@ -90,6 +90,7 @@ import { playSfx } from '../audio/sfx';
 import { createChargedStar } from './chargedStar';
 import type { ControlsState } from './controls';
 import { FX_TEXTURES, attachTrail, burstSmall, ensureFxTextures, type TrailHandle } from './fx';
+import { getVisualScale } from './visualScale';
 
 // 星彈命中結果：pierce 依剩餘穿透數決定續飛；absorb 一律回收（魔王或未死目標吃彈）。
 export type StarHitMode = 'pierce' | 'absorb';
@@ -162,11 +163,8 @@ const WIND_TRAIL_LIFESPAN_MS = TRAIL_LIFESPAN_MS * 1.6;
 const BOOM_SPIN_RAD = 0.02;
 // 殼化護體窗（§57）：減傷池實扣 0 時的短無敵，防同一接觸逐幀重複結算。
 const SHELL_GUARD_MS = 400;
-// 落地擠壓最低著地速度（§77）：微速重新接觸（擠壓迴圈回落 15-30）不再觸發擠壓，
-// 切斷「落地擠壓 → 身體縮小 → 離台 → 再落地」的自持迴圈。
-const LANDING_SQUASH_MIN_VY = 120;
-// 蹲姿視覺（§77）：橫向外擴＋縱向壓扁＋輕微下沉；走 POST_UPDATE 視覺通道，
-// PRE_UPDATE 還原——物理永不見蹲縮，杜絕擠壓迴圈同型問題。
+// 蹲姿視覺（§77）：橫向外擴＋縱向壓扁＋輕微下沉；scale 走 visualScale 視覺通道，
+// 物理永不見蹲縮。
 const CROUCH_SQUASH_X = 0.14;
 const CROUCH_SQUASH_Y = 0.22;
 const CROUCH_SINK_PX = 3;
@@ -188,8 +186,12 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
   const sprite = scene.physics.add.sprite(x, y, tex('hero-idle'));
   sprite.setDisplaySize(PLAYER_SIZE, PLAYER_SIZE);
   sprite.setCollideWorldBounds(true);
-  const baseScaleX = sprite.scaleX;
-  const baseScaleY = sprite.scaleY;
+  // 物理/視覺縮放解耦（§77 根治）：物理基準錨定於此；擠壓/呼吸/蹲縮全走視覺通道，
+  // 物理箱恆為基準尺寸，不再有擠壓迴圈與腳底離台。
+  const vscale = getVisualScale(scene);
+  vscale.register(sprite);
+  const fxScale = vscale.fx(sprite);
+  const modScale = vscale.mod(sprite);
 
   // 剪影逐幀鏡像本體（POST_UPDATE，含 bob 偏移後座標）：貼圖/位置/翻面/縮放/透明全同步。
   const syncSilhouette = () => {
@@ -274,27 +276,18 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
 
   // 走路 bob 視覺 y 偏移（US-022 / recon 硬規則 10）：不動 displayOrigin、不污染物理。
   // POST_UPDATE（物理回寫後）套用偏移供渲染，下一幀 PRE_UPDATE（物理讀取前）復原。
-  // 蹲姿（§77）同走此通道：乘算擠壓疊加當幀既有 scale（落地擠壓/呼吸不衝突），
-  // 還原以套用當下的比例快照為準，物理 updateBounds 永遠讀到未蹲縮的 scale。
+  // 蹲姿 scale 已遷入 visualScale mod 乘子（§77 解耦）；此處僅餘 y 偏移（bob＋下沉）。
   let bobOffset = 0;
   let crouch = 0;
-  const crouchApplied = { sx: 1, sy: 1, sink: 0 };
+  let appliedSink = 0;
   const applyBob = () => {
     sprite.y -= bobOffset;
-    crouchApplied.sx = 1 + CROUCH_SQUASH_X * crouch;
-    crouchApplied.sy = 1 - CROUCH_SQUASH_Y * crouch;
-    crouchApplied.sink = CROUCH_SINK_PX * crouch;
-    if (crouch > 0) {
-      sprite.setScale(sprite.scaleX * crouchApplied.sx, sprite.scaleY * crouchApplied.sy);
-      sprite.y += crouchApplied.sink;
-    }
+    appliedSink = CROUCH_SINK_PX * crouch;
+    sprite.y += appliedSink;
   };
   const revertBob = () => {
     sprite.y += bobOffset;
-    if (crouchApplied.sink > 0 || crouchApplied.sx !== 1) {
-      sprite.setScale(sprite.scaleX / crouchApplied.sx, sprite.scaleY / crouchApplied.sy);
-      sprite.y -= crouchApplied.sink;
-    }
+    sprite.y -= appliedSink;
   };
   scene.events.on(Phaser.Scenes.Events.POST_UPDATE, applyBob);
   scene.events.on(Phaser.Scenes.Events.PRE_UPDATE, revertBob);
@@ -307,17 +300,12 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
     sprite.setTexture(tex(next));
   };
 
-  // squash/stretch：先瞬間變形，再 tween 回基準比例。
+  // squash/stretch（§77 解耦）：fx 代理瞬間變形再 tween 回 1；物理箱恆為基準不動。
   const squashStretch = (sx: number, sy: number) => {
-    scene.tweens.killTweensOf(sprite);
-    sprite.setScale(baseScaleX * sx, baseScaleY * sy);
-    scene.tweens.add({
-      targets: sprite,
-      scaleX: baseScaleX,
-      scaleY: baseScaleY,
-      duration: 160,
-      ease: 'Back.easeOut',
-    });
+    vscale.resetFx(sprite);
+    fxScale.sx = sx;
+    fxScale.sy = sy;
+    scene.tweens.add({ targets: fxScale, sx: 1, sy: 1, duration: 160, ease: 'Back.easeOut' });
   };
 
   // 落地塵埃圈：腳邊白描邊橢圓擴散淡出（graphics 組合，不依賴 fx.ts）。
@@ -670,8 +658,9 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
       }
       jumpBufferMs = tickTimer(jumpBufferMs, deltaMs);
       if (onGround && !wasOnGround) {
-        // §77：僅真實落地（下砸或帶速著地）擠壓；微速重新接觸不觸發，防自持迴圈。
-        if (slamming || lastVy > LANDING_SQUASH_MIN_VY) squashStretch(1.25, 0.75);
+        // 落地擠壓（§77 已由 visualScale 解耦根治）：擠壓不再縮物理箱，任何著地
+        // 皆可安全觸發；最低著地速度門檻補丁退場。
+        squashStretch(1.25, 0.75);
         // 風化落地滾翻（§110）：落地瞬間自動免傷窗，與受擊 i-frame 取較大值。
         if (formSpec && formSpec.landingRollMs > 0) {
           invulnerableMs = Math.max(invulnerableMs, formSpec.landingRollMs);
@@ -886,15 +875,9 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
 
       // 走動手感（§45）：速度驅動步頻——相位導出 bob（視覺 y 偏移，PRE/POST_UPDATE
       // 掛鉤）與前傾＋搖擺角；落腳拍點觸發腳塵與步伐音。空中依 vy 前後傾姿態；
-      // 地面靜止走 idle 呼吸（scale 通道，squash tween 進行中讓位）。
-      // 呼吸殘留復位：離開 idle 後 scale 回基準（squash tween 進行中讓 tween 主導）。
-      const normalizeBreath = (): void => {
-        if (!scene.tweens.isTweening(sprite) && sprite.scaleY !== baseScaleY) {
-          sprite.setScale(baseScaleX, baseScaleY);
-        }
-      };
+      // 地面靜止走 idle 呼吸（visualScale mod 乘子，squash tween 進行中讓位）。
+      let breathY = 0;
       if (onGround && body.velocity.x !== 0) {
-        normalizeBreath();
         const speedRatio = Math.abs(body.velocity.x) / PLAYER.moveSpeed;
         const tick = advanceStride(stridePhase, speedRatio, deltaMs);
         stridePhase = tick.phase;
@@ -905,7 +888,6 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
         sprite.setRotation(facing * strideTilt(stridePhase, speedRatio));
         bobOffset = strideBob(stridePhase, speedRatio);
       } else if (!onGround) {
-        normalizeBreath();
         stridePhase = 0;
         bobOffset = 0;
         sprite.setRotation(facing * airTilt(body.velocity.y));
@@ -915,10 +897,11 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
           sprite.setRotation(0);
           bobOffset = 0;
         }
-        if (!scene.tweens.isTweening(sprite)) {
-          sprite.setScale(baseScaleX, baseScaleY * (1 + idleBreath(scene.time.now)));
-        }
+        if (!vscale.isFxTweening(sprite)) breathY = idleBreath(scene.time.now);
       }
+      // 蹲縮＋呼吸逐幀寫入 mod 視覺乘子（§77 解耦）：物理箱不受影響。
+      modScale.sx = 1 + CROUCH_SQUASH_X * crouch;
+      modScale.sy = (1 - CROUCH_SQUASH_Y * crouch) * (1 + breathY);
       // 滾殼衝撞旋轉呈現（§110）：覆蓋走動傾角，沿殼刃自旋角速度。
       if (chargeMs > 0) sprite.rotation += facing * BOOM_SPIN_RAD * deltaMs;
       lastVy = body.velocity.y;
@@ -1010,6 +993,8 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
       hp = result.hp;
       invulnerableMs = result.invulnerableMs;
       hurtLockMs = FORGIVENESS.hurtLockMs;
+      // 受擊擠壓（§18 回饋）：自 fx 系統遷入受擊結算單點（§77 解耦，走 fx 代理）。
+      squashStretch(1.28, 0.72);
       const kb = knockbackVelocity(sprite.x, sourceX, KNOCKBACK_SPEED, KNOCKBACK_LIFT);
       sprite.setVelocity(kb.x, kb.y);
       // 雷化受擊放電反擊（§110）：實扣傷害瞬間放電，世界結算交 GameScene（每形態期 2 次）。
@@ -1180,6 +1165,7 @@ export function createPlayer(scene: Phaser.Scene, x: number, y: number): PlayerH
       scene.events.off(Phaser.Scenes.Events.PRE_UPDATE, revertBob);
       scene.events.off(Phaser.Scenes.Events.POST_UPDATE, syncSilhouette);
       scene.tweens.killTweensOf(sprite);
+      vscale.unregister(sprite);
       footDust.destroy();
       chargedStar.destroy();
       shieldGfx.destroy();

--- a/apps/starpuff/src/game/systems/prismix.test.ts
+++ b/apps/starpuff/src/game/systems/prismix.test.ts
@@ -22,6 +22,20 @@ vi.mock('phaser', () => ({
 }));
 vi.mock('../audio/sfx', () => ({ playSfx: vi.fn(), stopSfx: vi.fn() }));
 vi.mock('./fx', () => ({ ensureFxTextures: vi.fn(), spawnTelegraph: vi.fn() }));
+// visualScale 通道替身：本檔驗 FSM 接線與雙子邏輯，不需要真實 scene 事件。
+vi.mock('./visualScale', () => ({
+  getVisualScale: () => ({
+    register: vi.fn(),
+    rebase: vi.fn(),
+    setBase: vi.fn(),
+    fx: () => ({ sx: 1, sy: 1 }),
+    mod: () => ({ sx: 1, sy: 1 }),
+    killFxTweens: vi.fn(),
+    resetFx: vi.fn(),
+    isFxTweening: () => false,
+    unregister: vi.fn(),
+  }),
+}));
 
 interface FakeSprite {
   x: number;

--- a/apps/starpuff/src/game/systems/prismix.ts
+++ b/apps/starpuff/src/game/systems/prismix.ts
@@ -13,6 +13,7 @@ import { shadowActive, shadowSpawnX, stepShadowX, stepShadowY } from '../logic/m
 import { playSfx } from '../audio/sfx';
 import type { BossDamageSource, BossHandle } from './boss';
 import { spawnTelegraph } from './fx';
+import { getVisualScale } from './visualScale';
 
 // 稜晶雙子 Prismix 呈現層（GAME_DESIGN §68）：與 boss/noctra 共用 BossHandle 介面。
 // 分裂型三段：P1 合體單體 → P2 鏡像雙子（雙本體、獨立血條）→ P3 裂核＋碎晶盾。
@@ -141,6 +142,11 @@ export function createPrismix(
 
   const core = scene.physics.add.sprite(arenaCx(), -BODY_H, 'boss-prismix');
   core.setDisplaySize(BODY_W, BODY_H);
+  // 物理/視覺縮放解耦（§77 根治）：重構彈入/怒吼脈動/雙子碎裂/死亡收縮走 fx 代理，
+  // 核體與雙子物理箱恆為基準。
+  const vscale = getVisualScale(scene);
+  vscale.register(core);
+  const coreFx = vscale.fx(core);
   const coreBody = core.body as Phaser.Physics.Arcade.Body;
   coreBody.setAllowGravity(false);
   coreBody.setImmovable(true);
@@ -149,6 +155,7 @@ export function createPrismix(
   const makeTwin = (tint: number): Phaser.Physics.Arcade.Sprite => {
     const twin = scene.physics.add.sprite(arenaCx(), TWIN_STAND_Y, 'boss-prismix');
     twin.setDisplaySize(TWIN_W, TWIN_H);
+    vscale.register(twin);
     twin.setTint(tint);
     const body = twin.body as Phaser.Physics.Arcade.Body;
     body.setAllowGravity(false);
@@ -449,10 +456,12 @@ export function createPrismix(
     coreBody.enable = true;
     core.setTintMode(Phaser.TintModes.MULTIPLY);
     core.setTint(REBIRTH_TINT);
+    // 重構彈入走 fx 代理（§77 解耦）：物理箱不隨演出縮放。
+    vscale.resetFx(core);
     scene.tweens.add({
-      targets: core,
-      scaleX: { from: core.scaleX * 0.3, to: core.scaleX },
-      scaleY: { from: core.scaleY * 0.3, to: core.scaleY },
+      targets: coreFx,
+      sx: { from: 0.3, to: 1 },
+      sy: { from: 0.3, to: 1 },
       duration: 420,
       ease: 'Back.easeOut',
     });
@@ -539,6 +548,9 @@ export function createPrismix(
       twin.setPosition(cx + dir * 30, TWIN_STAND_Y);
       twin.setVisible(true).setAlpha(1).setAngle(0);
       twin.setDisplaySize(TWIN_W, TWIN_H);
+      // 前次碎裂殘留 fx 復位並重錨基準（§77 解耦）。
+      vscale.resetFx(twin);
+      vscale.rebase(twin);
       (twin.body as Phaser.Physics.Arcade.Body).enable = true;
       scene.tweens.add({
         targets: twin,
@@ -559,11 +571,11 @@ export function createPrismix(
     mirrorTwin = null;
     const dead = sideSprite(survivor === 'a' ? 'b' : 'a');
     playSfx('break');
+    // 碎裂縮小走 fx 代理（§77 解耦）；淡出與傾角照走 sprite。
+    scene.tweens.add({ targets: vscale.fx(dead), sx: 0.2, sy: 0.2, duration: 260 });
     scene.tweens.add({
       targets: dead,
       alpha: 0,
-      scaleX: dead.scaleX * 0.2,
-      scaleY: dead.scaleY * 0.2,
       angle: 40,
       duration: 260,
       ease: 'Quad.easeIn',
@@ -686,7 +698,10 @@ export function createPrismix(
     mirrorPane = null;
     mirrorTwin = null;
     shadowSpawnAtMs = -1;
-    [core, twinA, twinB].forEach((sprite) => scene.tweens.killTweensOf(sprite));
+    [core, twinA, twinB].forEach((sprite) => {
+      scene.tweens.killTweensOf(sprite);
+      vscale.killFxTweens(sprite);
+    });
     projectiles.getMatching('active', true).forEach(killProjectile);
     shockwaves.getMatching('active', true).forEach(killProjectile);
     shields.getMatching('active', true).forEach(killProjectile);
@@ -696,13 +711,13 @@ export function createPrismix(
       [core, twinA, twinB].forEach((sprite) => {
         if (!sprite.visible) return;
         scene.tweens.add({
-          targets: sprite,
-          scaleX: 0,
-          scaleY: 0,
-          alpha: 0,
+          targets: vscale.fx(sprite),
+          sx: 0,
+          sy: 0,
           duration: 420,
           ease: 'Back.easeIn',
         });
+        scene.tweens.add({ targets: sprite, alpha: 0, duration: 420, ease: 'Back.easeIn' });
       });
     });
   };
@@ -793,9 +808,9 @@ export function createPrismix(
     emitGameEvent(scene.events, GameEvents.BOSS_SPAWNED, { maxHp: fsm.maxHp });
     playSfx('boss-roar');
     scene.tweens.add({
-      targets: core,
-      scaleX: core.scaleX * 1.12,
-      scaleY: core.scaleY * 1.1,
+      targets: coreFx,
+      sx: 1.12,
+      sy: 1.1,
       duration: 170,
       yoyo: true,
       repeat: 1,
@@ -1002,7 +1017,9 @@ export function createPrismix(
       steering = true;
       // 中斷演出殘留復位：barrage 蓄能白閃/rebirth 縮放 tween 若中斷須回段位相。
       scene.tweens.killTweensOf(core);
+      vscale.resetFx(core);
       core.setDisplaySize(BODY_W, BODY_H);
+      vscale.rebase(core);
       core.setVisible(true).setAlpha(1);
       core.setTintMode(Phaser.TintModes.MULTIPLY);
       core.setTint(segment === 'p4' ? REBIRTH_TINT : CORE_TINT);

--- a/apps/starpuff/src/game/systems/syrona.test.ts
+++ b/apps/starpuff/src/game/systems/syrona.test.ts
@@ -23,6 +23,20 @@ vi.mock('./fx', () => ({
   spawnTelegraph: vi.fn(),
   FX_TEXTURES: { dot: 'fx-dot', star: 'fx-star' },
 }));
+// visualScale 通道替身：本檔驗 FSM 接線與皇冠帶邏輯，不需要真實 scene 事件。
+vi.mock('./visualScale', () => ({
+  getVisualScale: () => ({
+    register: vi.fn(),
+    rebase: vi.fn(),
+    setBase: vi.fn(),
+    fx: () => ({ sx: 1, sy: 1 }),
+    mod: () => ({ sx: 1, sy: 1 }),
+    killFxTweens: vi.fn(),
+    resetFx: vi.fn(),
+    isFxTweening: () => false,
+    unregister: vi.fn(),
+  }),
+}));
 
 type Chainable = Record<string, (...args: unknown[]) => unknown>;
 

--- a/apps/starpuff/src/game/systems/syrona.ts
+++ b/apps/starpuff/src/game/systems/syrona.ts
@@ -20,6 +20,7 @@ import {
 import { playSfx } from '../audio/sfx';
 import type { BossDamageSource, BossHandle } from './boss';
 import { FX_TEXTURES, ensureFxTextures, spawnTelegraph } from './fx';
+import { getVisualScale } from './visualScale';
 
 // 熔糖窯后 Syrona 呈現層（GAME_DESIGN §74）：與 boss/noctra/prismix 共用 BossHandle。
 // 場控型：本體半定點於右側王窯座，威脅來自地形改寫（潮汐/噴泉/滴落/糖漿波）；
@@ -135,6 +136,10 @@ export function createSyrona(
 
   const body = scene.physics.add.sprite(arenaX(THRONE_X_RATIO), -BODY_H, 'boss-syrona');
   body.setDisplaySize(BODY_W, BODY_H);
+  // 物理/視覺縮放解耦（§77 根治）：怒吼脈動/死亡收縮走 fx 代理，物理箱恆為基準。
+  const vscale = getVisualScale(scene);
+  vscale.register(body);
+  const fxScale = vscale.fx(body);
   const physBody = body.body as Phaser.Physics.Arcade.Body;
   physBody.setAllowGravity(false);
   physBody.setImmovable(true);
@@ -368,15 +373,15 @@ export function createSyrona(
     dying = true;
     active = false;
     scene.tweens.killTweensOf(body);
+    vscale.killFxTweens(body);
     projectiles.getMatching('active', true).forEach(killProjectile);
     shockwaves.getMatching('active', true).forEach(killProjectile);
     ventParticles.forEach((emitter) => emitter.stop());
     emitGameEvent(scene.events, GameEvents.BOSS_DEFEATED, { x: body.x, y: body.y });
     delay(600, () => {
+      scene.tweens.add({ targets: fxScale, sx: 0, sy: 0, duration: 420, ease: 'Back.easeIn' });
       scene.tweens.add({
         targets: body,
-        scaleX: 0,
-        scaleY: 0,
         alpha: 0,
         duration: 420,
         ease: 'Back.easeIn',
@@ -499,9 +504,9 @@ export function createSyrona(
     emitGameEvent(scene.events, GameEvents.BOSS_SPAWNED, { maxHp: fsm.maxHp });
     playSfx('boss-roar');
     scene.tweens.add({
-      targets: body,
-      scaleX: body.scaleX * 1.12,
-      scaleY: body.scaleY * 1.1,
+      targets: fxScale,
+      sx: 1.12,
+      sy: 1.1,
       duration: 170,
       yoyo: true,
       repeat: 1,

--- a/apps/starpuff/src/game/systems/visualScale.test.ts
+++ b/apps/starpuff/src/game/systems/visualScale.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type Phaser from 'phaser';
+import { getVisualScale, type ScalableSprite } from './visualScale';
+
+// §77 缺陷家族行為錨（v19 #819 子項 3）：squash/wobble/popIn 等瞬態縮放動畫期間，
+// 物理步（PRE_UPDATE 還原後、Body.updateBounds 讀取窗）所見 scale 必須恆為基準——
+// 碰撞箱不隨美術縮放，落地/站台/overlap 判定在動畫期間穩定不漂。
+
+vi.mock('phaser', () => ({
+  default: {
+    Scenes: {
+      Events: { PRE_UPDATE: 'preupdate', POST_UPDATE: 'postupdate', SHUTDOWN: 'shutdown' },
+    },
+  },
+}));
+
+interface FakeScene {
+  scene: Phaser.Scene;
+  // 模擬 Systems.step 順序：PRE_UPDATE →（物理讀取窗）→ scene.update → POST_UPDATE。
+  emit(event: string): void;
+  tweenTargets: object[];
+  killed: object[];
+}
+
+function makeScene(): FakeScene {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  const tweenTargets: object[] = [];
+  const killed: object[] = [];
+  const on = (event: string, handler: (...args: unknown[]) => void) => {
+    listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+  };
+  const scene = {
+    events: {
+      on,
+      once: on,
+      off: (event: string, handler: (...args: unknown[]) => void) => {
+        listeners.set(
+          event,
+          (listeners.get(event) ?? []).filter((h) => h !== handler),
+        );
+      },
+    },
+    tweens: {
+      add: (config: { targets: object }) => {
+        tweenTargets.push(config.targets);
+        return {};
+      },
+      killTweensOf: (target: object) => {
+        killed.push(target);
+      },
+      isTweening: (target: object) => tweenTargets.includes(target) && !killed.includes(target),
+    },
+  } as unknown as Phaser.Scene;
+  return {
+    scene,
+    emit(event: string) {
+      for (const handler of listeners.get(event) ?? []) handler();
+    },
+    tweenTargets,
+    killed,
+  };
+}
+
+function makeSprite(scaleX = 1, scaleY = 1): ScalableSprite {
+  const sprite: ScalableSprite = {
+    scaleX,
+    scaleY,
+    scene: {},
+    setScale(x: number, y?: number) {
+      sprite.scaleX = x;
+      sprite.scaleY = y ?? x;
+      return sprite;
+    },
+  };
+  return sprite;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('visualScale 物理/視覺解耦通道', () => {
+  it('squash 動畫期間物理讀取窗所見 scale 恆為基準（§77 落地擠壓迴圈斷根錨）', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(0.5, 0.5);
+    channel.register(sprite);
+
+    // 模擬落地擠壓：fx 瞬間形變（tween 只寫代理，不碰 sprite）。
+    const fx = channel.fx(sprite);
+    fx.sx = 1.25;
+    fx.sy = 0.75;
+
+    // 幀序：PRE_UPDATE 還原 → 物理讀取（updateBounds 以此 scale 算 body）。
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(0.5);
+    expect(sprite.scaleY).toBe(0.5);
+
+    // POST_UPDATE 才套視覺形變（渲染見擠壓）。
+    world.emit('postupdate');
+    expect(sprite.scaleX).toBeCloseTo(0.5 * 1.25);
+    expect(sprite.scaleY).toBeCloseTo(0.5 * 0.75);
+
+    // 次幀物理讀取窗仍是基準：站台/overlap 判定在整段動畫期間穩定。
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(0.5);
+    expect(sprite.scaleY).toBe(0.5);
+  });
+
+  it('mod 逐幀直寫（呼吸/蹲姿）與 fx 乘算疊加，物理窗一樣不見', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(2, 2);
+    channel.register(sprite);
+    channel.fx(sprite).sy = 0.8;
+    channel.mod(sprite).sy = 1.018;
+
+    world.emit('postupdate');
+    expect(sprite.scaleY).toBeCloseTo(2 * 0.8 * 1.018);
+    world.emit('preupdate');
+    expect(sprite.scaleY).toBe(2);
+  });
+
+  it('setBase/rebase：狀態性造型（鑽地鰭/精英/phase 縮體）進物理基準', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+
+    // 狀態機直接指定基準（鑽地鰭壓扁）：物理窗所見＝新基準。
+    channel.setBase(sprite, 1.4, 0.3);
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(1.4);
+    expect(sprite.scaleY).toBe(0.3);
+
+    // rebase：setDisplaySize 後以 sprite 當前 scale 重錨。
+    sprite.setScale(0.6, 0.6);
+    channel.rebase(sprite);
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(0.6);
+  });
+
+  it('register 冪等（物件池重用）：重錨基準並復位 fx/mod 與殘留 tween', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+    const fx = channel.fx(sprite);
+    fx.sx = 1.5;
+    fx.sy = 0;
+    channel.mod(sprite).sx = 1.1;
+
+    sprite.setScale(0.9, 0.9);
+    channel.register(sprite);
+    expect(channel.fx(sprite)).toBe(fx);
+    expect(fx.sx).toBe(1);
+    expect(fx.sy).toBe(1);
+    expect(channel.mod(sprite).sx).toBe(1);
+    expect(world.killed).toContain(fx);
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(0.9);
+  });
+
+  it('resetFx 終止 tween 並復位；killFxTweens 保留當前形變（死亡壓縮接續）', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+    const fx = channel.fx(sprite);
+    fx.sx = 1.08;
+    channel.killFxTweens(sprite);
+    expect(fx.sx).toBe(1.08);
+    channel.resetFx(sprite);
+    expect(fx.sx).toBe(1);
+    expect(world.killed.filter((t) => t === fx)).toHaveLength(2);
+  });
+
+  it('isFxTweening 以 fx 代理判定（idle 呼吸讓位 squash 的依據）', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+    expect(channel.isFxTweening(sprite)).toBe(false);
+    world.tweenTargets.push(channel.fx(sprite));
+    expect(channel.isFxTweening(sprite)).toBe(true);
+  });
+
+  it('scene 鍵入單例：同 scene 回傳同通道；shutdown 清理後重建', () => {
+    const world = makeScene();
+    const first = getVisualScale(world.scene);
+    expect(getVisualScale(world.scene)).toBe(first);
+    world.emit('shutdown');
+    expect(getVisualScale(world.scene)).not.toBe(first);
+  });
+
+  it('已銷毀 sprite（scene 為空）跳過套用，不噴錯', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+    sprite.scene = undefined;
+    expect(() => {
+      world.emit('preupdate');
+      world.emit('postupdate');
+    }).not.toThrow();
+  });
+
+  it('unregister 後不再管理該 sprite', () => {
+    const world = makeScene();
+    const channel = getVisualScale(world.scene);
+    const sprite = makeSprite(1, 1);
+    channel.register(sprite);
+    channel.fx(sprite).sx = 2;
+    channel.unregister(sprite);
+    sprite.setScale(3, 3);
+    world.emit('preupdate');
+    expect(sprite.scaleX).toBe(3);
+    expect(() => channel.fx(sprite)).toThrow();
+  });
+});

--- a/apps/starpuff/src/game/systems/visualScale.ts
+++ b/apps/starpuff/src/game/systems/visualScale.ts
@@ -1,0 +1,156 @@
+// 物理/視覺縮放解耦通道（v19 #819 子項 3，根治 GAME_DESIGN §77 型缺陷家族）。
+// Phaser 4 Arcade Body 每物理步經 updateBounds 以 sourceWidth × |scale| 重算碰撞箱
+//（Body.js updateBounds；官方無凍結旗標，syncBounds 只會更強耦合），且 TweenManager
+// 與物理 world 同掛 SceneEvents.UPDATE——直接 tween sprite scale 會在同幀被物理讀到，
+// 形成落地擠壓迴圈、腳底離台、穿台與 overlap 漏檢。
+// 本通道把蹲姿/走 bob 已驗證的「PRE_UPDATE 還原、POST_UPDATE 套用」視覺通道模式
+// 全遊戲統一：物理步只見基準 scale，渲染見 基準×fx×mod；瞬態縮放永不進物理。
+// - base：物理基準 scale（精英體型、鑽地鰭、縮殼、魔王 phase 縮體等狀態性造型）。
+// - fx：tween 標的代理（squash/stretch、popIn、wobble、死亡壓縮）。
+// - mod：逐幀直寫代理（idle 呼吸、蹲姿壓扁），由擁有者每幀維護。
+import Phaser from 'phaser';
+
+export interface VisualScaleProxy {
+  sx: number;
+  sy: number;
+}
+
+// 結構性最小面：單元測試可用替身 sprite，不依賴完整 Arcade.Sprite。
+export interface ScalableSprite {
+  scaleX: number;
+  scaleY: number;
+  setScale(x: number, y?: number): unknown;
+  scene?: unknown;
+}
+
+interface Entry {
+  sprite: ScalableSprite;
+  baseX: number;
+  baseY: number;
+  fx: VisualScaleProxy;
+  mod: VisualScaleProxy;
+}
+
+export interface VisualScaleChannel {
+  // 註冊（冪等）：以 sprite 當前 scale 為物理基準；重複註冊＝rebase＋fx/mod 全復位
+  //（物件池重用單點）。
+  register(sprite: ScalableSprite): void;
+  // 以 sprite 當前 scale 重錨基準：setDisplaySize 等「狀態性造型」變更後呼叫。
+  rebase(sprite: ScalableSprite): void;
+  // 直接指定物理基準：狀態機逐幀維持造型（鑽地鰭/半潛/縮殼）用。
+  setBase(sprite: ScalableSprite, sx: number, sy: number): void;
+  fx(sprite: ScalableSprite): VisualScaleProxy;
+  mod(sprite: ScalableSprite): VisualScaleProxy;
+  // 終止 fx tween（保留當前 fx 值，死亡壓縮自當前形變接續用）。
+  killFxTweens(sprite: ScalableSprite): void;
+  // 終止 fx tween 並復位為 1（squash 重觸發、演出中斷復位用）。
+  resetFx(sprite: ScalableSprite): void;
+  isFxTweening(sprite: ScalableSprite): boolean;
+  unregister(sprite: ScalableSprite): void;
+}
+
+const channels = new WeakMap<Phaser.Scene, VisualScaleChannel>();
+
+function createChannel(scene: Phaser.Scene): VisualScaleChannel {
+  const entries = new Map<ScalableSprite, Entry>();
+
+  const entryOf = (sprite: ScalableSprite): Entry => {
+    const entry = entries.get(sprite);
+    if (!entry) throw new Error('visualScale：sprite 未註冊');
+    return entry;
+  };
+
+  // 物理讀取前還原基準：本幀 tween/狀態機寫入的一切視覺形變不進 updateBounds。
+  const restoreBase = () => {
+    for (const entry of entries.values()) {
+      if (!entry.sprite.scene) continue;
+      entry.sprite.setScale(entry.baseX, entry.baseY);
+    }
+  };
+  // 物理回寫後套用視覺：渲染見 基準×fx×mod。
+  const applyVisual = () => {
+    for (const entry of entries.values()) {
+      if (!entry.sprite.scene) continue;
+      entry.sprite.setScale(
+        entry.baseX * entry.fx.sx * entry.mod.sx,
+        entry.baseY * entry.fx.sy * entry.mod.sy,
+      );
+    }
+  };
+  scene.events.on(Phaser.Scenes.Events.PRE_UPDATE, restoreBase);
+  scene.events.on(Phaser.Scenes.Events.POST_UPDATE, applyVisual);
+  scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+    scene.events.off(Phaser.Scenes.Events.PRE_UPDATE, restoreBase);
+    scene.events.off(Phaser.Scenes.Events.POST_UPDATE, applyVisual);
+    entries.clear();
+    channels.delete(scene);
+  });
+
+  const killFxTweens = (sprite: ScalableSprite) => {
+    scene.tweens.killTweensOf(entryOf(sprite).fx);
+  };
+
+  return {
+    register(sprite) {
+      const existing = entries.get(sprite);
+      if (existing) {
+        scene.tweens.killTweensOf(existing.fx);
+        existing.baseX = sprite.scaleX;
+        existing.baseY = sprite.scaleY;
+        existing.fx.sx = 1;
+        existing.fx.sy = 1;
+        existing.mod.sx = 1;
+        existing.mod.sy = 1;
+        return;
+      }
+      entries.set(sprite, {
+        sprite,
+        baseX: sprite.scaleX,
+        baseY: sprite.scaleY,
+        fx: { sx: 1, sy: 1 },
+        mod: { sx: 1, sy: 1 },
+      });
+    },
+    rebase(sprite) {
+      const entry = entryOf(sprite);
+      entry.baseX = sprite.scaleX;
+      entry.baseY = sprite.scaleY;
+    },
+    setBase(sprite, sx, sy) {
+      const entry = entryOf(sprite);
+      entry.baseX = sx;
+      entry.baseY = sy;
+    },
+    fx(sprite) {
+      return entryOf(sprite).fx;
+    },
+    mod(sprite) {
+      return entryOf(sprite).mod;
+    },
+    killFxTweens,
+    resetFx(sprite) {
+      killFxTweens(sprite);
+      const { fx } = entryOf(sprite);
+      fx.sx = 1;
+      fx.sy = 1;
+    },
+    isFxTweening(sprite) {
+      return scene.tweens.isTweening(entryOf(sprite).fx);
+    },
+    unregister(sprite) {
+      const entry = entries.get(sprite);
+      if (!entry) return;
+      scene.tweens.killTweensOf(entry.fx);
+      entries.delete(sprite);
+    },
+  };
+}
+
+// 場景鍵入惰性單例：模組各自取用免穿線；scene restart 由 shutdown 清理後自然重建。
+export function getVisualScale(scene: Phaser.Scene): VisualScaleChannel {
+  const existing = channels.get(scene);
+  if (existing) return existing;
+  const channel = createChannel(scene);
+  channels.set(scene, channel);
+  return channel;
+}

--- a/apps/starpuff/src/game/systems/voidra.test.ts
+++ b/apps/starpuff/src/game/systems/voidra.test.ts
@@ -18,6 +18,20 @@ vi.mock('phaser', () => ({
 }));
 vi.mock('../audio/sfx', () => ({ playSfx: vi.fn(), stopSfx: vi.fn() }));
 vi.mock('./fx', () => ({ ensureFxTextures: vi.fn(), spawnTelegraph: vi.fn() }));
+// visualScale 通道替身：本檔驗 FSM 接線與彈幕邏輯，不需要真實 scene 事件。
+vi.mock('./visualScale', () => ({
+  getVisualScale: () => ({
+    register: vi.fn(),
+    rebase: vi.fn(),
+    setBase: vi.fn(),
+    fx: () => ({ sx: 1, sy: 1 }),
+    mod: () => ({ sx: 1, sy: 1 }),
+    killFxTweens: vi.fn(),
+    resetFx: vi.fn(),
+    isFxTweening: () => false,
+    unregister: vi.fn(),
+  }),
+}));
 
 type Chainable = Record<string, (...args: unknown[]) => unknown>;
 

--- a/apps/starpuff/src/game/systems/voidra.ts
+++ b/apps/starpuff/src/game/systems/voidra.ts
@@ -8,6 +8,7 @@ import { EX_VOIDRA, VOIDRA, createVoidraFsm, type VoidraCommand } from '../logic
 import { playSfx } from '../audio/sfx';
 import type { BossDamageSource, BossHandle } from './boss';
 import { ensureFxTextures, spawnTelegraph } from './fx';
+import { getVisualScale } from './visualScale';
 
 // 蝕星魔核 Voidra 呈現層（GAME_DESIGN §82）：與 boss/noctra/prismix/syrona 共用
 // BossHandle。場控收束型：核心懸浮不落地，位置一律以 approachPoint 逼近錨點
@@ -142,6 +143,11 @@ export function createVoidra(
 
   const body = scene.physics.add.sprite(arenaCx(), -BODY_SIZE, 'boss-voidra');
   body.setDisplaySize(BODY_SIZE, BODY_SIZE);
+  // 物理/視覺縮放解耦（§77 根治）：怒吼脈動/死亡收縮走 fx 代理；
+  // P4 裸核縮體屬狀態性造型，setDisplaySize 後 rebase 重錨物理基準。
+  const vscale = getVisualScale(scene);
+  vscale.register(body);
+  const fxScale = vscale.fx(body);
   const physBody = body.body as Phaser.Physics.Arcade.Body;
   physBody.setAllowGravity(false);
   physBody.setImmovable(true);
@@ -521,6 +527,7 @@ export function createVoidra(
     dying = true;
     active = false;
     scene.tweens.killTweensOf(body);
+    vscale.killFxTweens(body);
     clearOrdnance();
     clearShards();
     siphonUntilMs = 0;
@@ -529,10 +536,9 @@ export function createVoidra(
     hooks.setGravityScale(null);
     emitGameEvent(scene.events, GameEvents.BOSS_DEFEATED, { x: body.x, y: body.y });
     delay(600, () => {
+      scene.tweens.add({ targets: fxScale, sx: 0, sy: 0, duration: 420, ease: 'Back.easeIn' });
       scene.tweens.add({
         targets: body,
-        scaleX: 0,
-        scaleY: 0,
         alpha: 0,
         duration: 420,
         ease: 'Back.easeIn',
@@ -568,6 +574,8 @@ export function createVoidra(
               BODY_SIZE * EX_VOIDRA.innerScaleMul,
               BODY_SIZE * EX_VOIDRA.innerScaleMul,
             );
+            // 裸核縮體為狀態性造型：rebase 讓碰撞體同步縮小（§77 解耦）。
+            vscale.rebase(body);
             body.setTint(INNER_CORE_TINT);
             playSfx('break', 1.2);
             playSfx('boss-roar', 1.1);
@@ -664,9 +672,9 @@ export function createVoidra(
     emitGameEvent(scene.events, GameEvents.BOSS_SPAWNED, { maxHp: fsm.maxHp });
     playSfx('boss-roar');
     scene.tweens.add({
-      targets: body,
-      scaleX: body.scaleX * 1.12,
-      scaleY: body.scaleY * 1.1,
+      targets: fxScale,
+      sx: 1.12,
+      sy: 1.1,
       duration: 170,
       yoyo: true,
       repeat: 1,

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+221
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+222
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-26
+- ID：reward-starpuff-t7b-visual-scale-channel
+- 原因：Phaser 4 Arcade Body 每物理步以 sourceWidth×|scale| 重算碰撞箱且 TweenManager 與物理同掛 UPDATE 事件（官方文檔＋Body.js 實證），sprite scale 瞬態視覺效果（squash/wobble/popIn/呼吸）直接縮放物理箱形成 §77 型缺陷家族（腳底離台、重複落地、穿台、overlap 漏檢），現行僅有落地速度門檻單案例補丁
+- 解法：新增 systems/visualScale.ts 解耦通道（PRE_UPDATE 還原物理基準、POST_UPDATE 套用 base×fx×mod，tween 一律以 fx 代理為標的），沿蹲姿/走 bob 已驗證模式全遊戲統一，附 9 條行為錨測試鎖住「動畫期間物理所見 scale 恆為基準」契約
 
 - 日期：2026-07-25
 - ID：reward-starpuff-t6-w3-jellord-noctra-p4-checkpoint

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+222
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+223
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-26
+- ID：reward-starpuff-t7b-player-scale-migration
+- 原因：玩家擠壓/呼吸/落地 squash 直接寫 sprite scale 連動物理箱，須靠 LANDING_SQUASH_MIN_VY 門檻補丁壓制擠壓迴圈（§77.1 單案例修法，家族未根治）
+- 解法：player 全數 scale 效果遷入 visualScale 通道（squash→fx tween、呼吸/蹲縮→mod 乘子、受擊擠壓自 fx 系統遷入 takeDamage 單點），刪除落地速度門檻補丁；vitest 886 綠＋hotfix.spec 9/9 綠
 
 - 日期：2026-07-26
 - ID：reward-starpuff-t7b-visual-scale-channel

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+224
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+225
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-26
+- ID：reward-starpuff-t7b-bosses-scale-migration
+- 原因：五王常駐 wobble/翼拍與擠壓/怒吼/死亡收縮 tween 直接寫 sprite scale——魔王碰撞箱持續脈動（jellord ±5%/620ms、noctra ±7%/480ms），頭頂 hit window 與觸碰判定隨美術漂移（§77 家族）
+- 解法：五王瞬態演出全遷 fx 代理（wobble/翼拍/slam/dash/蓄勢/怒吼/碎裂/死亡），狀態性造型（noctra 月牙縮體、voidra 裸核、texture 切換）走 rebase 重錨；vitest 886 綠＋e2e v13 EX 7/7 綠
 
 - 日期：2026-07-26
 - ID：reward-starpuff-t7b-enemies-scale-migration

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+223
+> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+224
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-26
+- ID：reward-starpuff-t7b-enemies-scale-migration
+- 原因：18 怪的 popIn/wobble/呼吸/死亡壓縮直接寫 sprite scale——wobble 使地面怪碰撞箱每 360ms 脈動 ±8%、popIn 生成期物理箱僅 30%，皆屬 §77 家族耦合
+- 解法：瞬態演出遷入 visualScale（popIn/wobble/死亡→fx tween、spora 呼吸→mod），狀態性造型（縮殼/鑽地鰭/半潛/精英體型）改 setBase 顯式承載物理語意；vitest 886 綠＋e2e hotfix/smoke 19/19 綠
 
 - 日期：2026-07-26
 - ID：reward-starpuff-t7b-player-scale-migration


### PR DESCRIPTION
## Summary
- 新增 visualScale 物理視覺解耦通道與行為錨測試 (§117)
- 玩家縮放全數遷入 visualScale 解耦通道
- 全怪與五王縮放遷入 visualScale 解耦通道
- GAME_DESIGN.md 補齊 §117 章節與 §77.1 取代註記

## Test plan
- pnpm --filter @app/starpuff test:run (886/886 綠)
- pre-push check 完整跑過

Made with [Cursor](https://cursor.com)