### PR TITLE
fix(starpuff): backlog 收斂——telegraph 紅線改釘 WARN、宣告漂移守門、vx 實驗裁決（#903/#904/#905）

### DIFF
--- a/.changeset/starpuff-903-905-backlog.md
+++ b/.changeset/starpuff-903-905-backlog.md
@@ -1,0 +1,5 @@
+---
+'@app/starpuff': patch
+---
+
+守門強化與治理（#903/#904/#905）：票券蝠 FSM 紅線改釘 WARN 預警窗並補分支存續 mutation 守門；scripts 宣告檔與實作補結構漂移守門接入 test:root；預警期 vx 實驗依數據 revert 維持懸停 telegraph，無任何玩家可見行為變更。

--- a/apps/starpuff/src/game/logic/enemyFsm.test.ts
+++ b/apps/starpuff/src/game/logic/enemyFsm.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type Phaser from 'phaser';
 import { canInhale } from './combat';
+import { AUDIT_THRESHOLDS } from './difficulty';
+import type { EnemyUpdateContext } from '../systems/enemyUpdates';
+import { TICKETA_WARN_MS, updateTicketa } from '../systems/finaleEnemies';
 import {
   BOOMY_FSM,
   BUBBLA_FSM,
@@ -51,6 +55,9 @@ import {
   tickScanna,
   tickTicketa,
 } from './enemyFsm';
+
+// zzfx 於 import 期建 AudioContext（node 無此 API）；沿 finaleEnemies.test.ts 慣例替換。
+vi.mock('../audio/sfx', () => ({ playSfx: vi.fn(), stopSfx: vi.fn() }));
 
 describe('Shelly 三態時序（§30）', () => {
   it('巡邏恆持：walk 不自行轉移，計時持續累加', () => {
@@ -553,11 +560,55 @@ describe('Cometa 四態時序（§80 彗尾飛魚）', () => {
 });
 
 describe('§120 星海終局篇新怪 FSM', () => {
-  it('telegraph 紅線：ticketa/scanna/foamy/manta 前搖窗一律 ≥600ms', () => {
-    expect(TICKETA_FSM.shiftMs).toBeGreaterThanOrEqual(600);
-    expect(SCANNA_FSM.aimMs).toBeGreaterThanOrEqual(600);
-    expect(FOAMY_FSM.windupMs).toBeGreaterThanOrEqual(600);
-    expect(MANTA_FSM.aimMs).toBeGreaterThanOrEqual(600);
+  it('telegraph 紅線：ticketa/scanna/foamy/manta 可讀前搖窗一律 ≥ telegraphMinMs', () => {
+    // 票券蝠可讀前搖＝fly 尾段 WARN 預警（呈現層 TICKETA_WARN_MS）；shiftMs 為俯掠
+    // 位移時長而非前搖（#899/#904），其動力學釘點在 finaleEnemies.test.ts。
+    expect(TICKETA_WARN_MS).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.telegraphMinMs);
+    expect(SCANNA_FSM.aimMs).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.telegraphMinMs);
+    expect(FOAMY_FSM.windupMs).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.telegraphMinMs);
+    expect(MANTA_FSM.aimMs).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.telegraphMinMs);
+  });
+
+  it('WARN 預警分支存續守門（#904）：fly 尾段首幀必亮 telegraph 閃爍', () => {
+    // 刻意跨層驅動呈現層 updateTicketa：票券蝠可讀前搖住在 finaleEnemies 的 WARN
+    // 分支，若被移除或短路，僅釘常數的紅線仍綠——本案以行為斷言補上必紅守門，
+    // 防 #899 公平性缺陷靜默復活。僅斷言 tint 訊號，不綁懸停速度細節（速度語彙
+    // 與反應窗實測屬 finaleEnemies.test.ts）。
+    const data = new Map<string, unknown>([
+      ['state', 'fly'],
+      ['stateMs', TICKETA_FSM.flyMs - TICKETA_WARN_MS],
+      ['band', 'high'],
+      ['phase', 0],
+      ['eliteMul', 1],
+    ]);
+    const tintCalls: number[] = [];
+    const sprite = {
+      y: TICKETA_FSM.bandHighY,
+      body: {
+        velocity: { x: 0, y: 0 },
+        setVelocity(vx: number, vy: number) {
+          sprite.body.velocity.x = vx;
+          sprite.body.velocity.y = vy;
+        },
+      },
+      getData: (key: string) => data.get(key),
+      setData(key: string, value: unknown) {
+        data.set(key, value);
+        return sprite;
+      },
+      setTint(tint: number) {
+        tintCalls.push(tint);
+        return sprite;
+      },
+      clearTint: () => sprite,
+      setFlipX: () => sprite,
+    };
+    updateTicketa(
+      { elapsedMs: 0, target: null } as unknown as EnemyUpdateContext,
+      sprite as unknown as Phaser.Physics.Arcade.Sprite,
+      16,
+    );
+    expect(tintCalls.length).toBeGreaterThan(0);
   });
 
   it('cargoPatrolDirection：週期折返（flipMs 交替 ±1）', () => {

--- a/apps/starpuff/src/game/logic/enemyFsm.test.ts
+++ b/apps/starpuff/src/game/logic/enemyFsm.test.ts
@@ -3,7 +3,7 @@ import type Phaser from 'phaser';
 import { canInhale } from './combat';
 import { AUDIT_THRESHOLDS } from './difficulty';
 import type { EnemyUpdateContext } from '../systems/enemyUpdates';
-import { TICKETA_WARN_MS, updateTicketa } from '../systems/finaleEnemies';
+import { TICKETA_SHIFT_TINT, TICKETA_WARN_MS, updateTicketa } from '../systems/finaleEnemies';
 import {
   BOOMY_FSM,
   BUBBLA_FSM,
@@ -569,19 +569,21 @@ describe('§120 星海終局篇新怪 FSM', () => {
     expect(MANTA_FSM.aimMs).toBeGreaterThanOrEqual(AUDIT_THRESHOLDS.telegraphMinMs);
   });
 
-  it('WARN 預警分支存續守門（#904）：fly 尾段首幀必亮 telegraph 閃爍', () => {
+  it('WARN 預警分支存續守門（#904/#910）：WARN 窗內必亮 TICKETA_SHIFT_TINT 閃爍', () => {
     // 刻意跨層驅動呈現層 updateTicketa：票券蝠可讀前搖住在 finaleEnemies 的 WARN
-    // 分支，若被移除或短路，僅釘常數的紅線仍綠——本案以行為斷言補上必紅守門，
-    // 防 #899 公平性缺陷靜默復活。僅斷言 tint 訊號，不綁懸停速度細節（速度語彙
-    // 與反應窗實測屬 finaleEnemies.test.ts）。
+    // 分支，若被移除或短路，僅釘常數的紅線仍綠——本案逐幀走完 fly 期，斷言至少
+    // 一幀「落在 WARN 窗內」且「色值＝TICKETA_SHIFT_TINT（import 比對，禁硬編）」，
+    // 防 #899 公平性缺陷靜默復活，亦防假 setTint 或窗外提早閃爍矇混過關。
+    // 僅斷言 tint 訊號，不綁懸停速度細節（速度語彙與反應窗實測屬
+    // finaleEnemies.test.ts），維持與 #905 類 vx 調參的正交性。
     const data = new Map<string, unknown>([
       ['state', 'fly'],
-      ['stateMs', TICKETA_FSM.flyMs - TICKETA_WARN_MS],
+      ['stateMs', 0],
       ['band', 'high'],
       ['phase', 0],
       ['eliteMul', 1],
     ]);
-    const tintCalls: number[] = [];
+    const frameTints: number[] = [];
     const sprite = {
       y: TICKETA_FSM.bandHighY,
       body: {
@@ -597,18 +599,24 @@ describe('§120 星海終局篇新怪 FSM', () => {
         return sprite;
       },
       setTint(tint: number) {
-        tintCalls.push(tint);
+        frameTints.push(tint);
         return sprite;
       },
       clearTint: () => sprite,
       setFlipX: () => sprite,
     };
-    updateTicketa(
-      { elapsedMs: 0, target: null } as unknown as EnemyUpdateContext,
-      sprite as unknown as Phaser.Physics.Arcade.Sprite,
-      16,
-    );
-    expect(tintCalls.length).toBeGreaterThan(0);
+    const ctx = { elapsedMs: 0, target: null } as unknown as EnemyUpdateContext;
+    let inWindowShiftTintFrames = 0;
+    for (let i = 0; i < 200 && data.get('state') === 'fly'; i += 1) {
+      frameTints.length = 0;
+      updateTicketa(ctx, sprite as unknown as Phaser.Physics.Arcade.Sprite, 16);
+      // 轉入 shift 幀不計：俯掠期亦閃爍，計入會稀釋「WARN 窗內」語意。
+      if (data.get('state') !== 'fly') break;
+      const stateMs = data.get('stateMs') as number;
+      const inWarnWindow = TICKETA_FSM.flyMs - stateMs <= TICKETA_WARN_MS;
+      if (inWarnWindow && frameTints.includes(TICKETA_SHIFT_TINT)) inWindowShiftTintFrames += 1;
+    }
+    expect(inWindowShiftTintFrames).toBeGreaterThan(0);
   });
 
   it('cargoPatrolDirection：週期折返（flipMs 交替 ±1）', () => {

--- a/apps/starpuff/src/game/logic/enemyFsm.ts
+++ b/apps/starpuff/src/game/logic/enemyFsm.ts
@@ -590,8 +590,9 @@ export function cargoPatrolDirection(cycleMs: number): 1 | -1 {
   return Math.floor(cycleMs / CARGO_FSM.flipMs) % 2 === 0 ? 1 : -1;
 }
 
-// 票券蝠 Ticketa：雙軌飛行——fly 期沿當前軌帶漂移，shift 前搖（≥600ms 閃爍 telegraph）
-// 後換軌俯掠；換軌本身即攻擊語彙（穿越玩家空域），無投射物。
+// 票券蝠 Ticketa：雙軌飛行——fly 期沿當前軌帶漂移，尾段由呈現層 WARN 預警承載
+// 可讀前搖（finaleEnemies TICKETA_WARN_MS 懸停＋閃爍 telegraph，#899/#904）；
+// shift＝換軌俯掠位移本身（穿越玩家空域即攻擊語彙），非前搖，無投射物。
 export const TICKETA_FSM = {
   flyMs: 2400,
   shiftMs: 600,

--- a/apps/starpuff/src/game/systems/finaleEnemies.ts
+++ b/apps/starpuff/src/game/systems/finaleEnemies.ts
@@ -24,7 +24,8 @@ import type { EnemyUpdateContext } from './enemyUpdates';
 
 // 呈現層常數：ticketa 換軌閃爍節拍；scanna 鎖定著色；foamy 鼓脹抖動；manta 俯仰。
 const TICKETA_FLICKER_MS = 100;
-const TICKETA_SHIFT_TINT = 0xfff1c4;
+// export 供 FSM 層 WARN 守門比對閃爍色值，禁測試硬編色碼（#904/#910）。
+export const TICKETA_SHIFT_TINT = 0xfff1c4;
 // 換軌預警窗（#899）：fly 尾段懸停＋閃爍，shift 才開始位移——原 telegraph 與俯掠
 // 同幀啟動，反應窗為 0。取 700 對齊 spora windup（低於 scanna aim 800、高於
 // zappy 500），且離散幀（~16ms）量測下界仍 ≥ AUDIT_THRESHOLDS.telegraphMinMs（600）；

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+325
+> 本次分數變化：+3（reward 3、penalty 0、neutral 0）｜累計總分：+328
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,21 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-07-27
+- ID：reward-starpuff-ticketa-fsm-redline-warn-repin
+- 原因：#901 後票券蝠可讀前搖已由呈現層 TICKETA_WARN_MS 承載，enemyFsm 註解與紅線仍把 shiftMs 稱為前搖且只釘 shiftMs，刪除 WARN 分支時紅線仍綠、#899 公平性缺陷可靜默復活（#904）
+- 解法：註解改明 shift＝俯掠位移、紅線改釘 TICKETA_WARN_MS ≥ telegraphMinMs（SSOT），新增跨層行為守門（fly 尾段首幀必亮 tint）；mutation 實證移除 WARN 分支（保留常數）enemyFsm 層必紅
+
+- 日期：2026-07-27
+- ID：reward-scripts-declaration-drift-structural-gate
+- 原因：scripts/tsconfig 的 include 僅涵蓋 .ts，tsc 只驗「呼叫端 vs 手寫宣告」從不驗「宣告 vs 實作」，export 改名或簽章變更 typecheck 仍 0 錯誤（#903，#901 審查實測坐實）
+- 解法：新增 declaration-drift 結構測試（export 名單雙向一致＋函式必填 arity）接入 test:root；checkJs 全面補 JSDoc 實測 227 strict 錯誤改動面過大故棄；mutation A（頂層 export 改名）／B（加必填參數）為同類 tsc 盲區示範且均必紅，非 #901 深層回傳欄位改名的逐字重現——深層欄位漂移仍依賴各模組行為測試（殘餘缺口已明載測試檔頭與 scripts/README.md）
+
+- 日期：2026-07-27
+- ID：reward-starpuff-ticketa-warn-vx-experiment-revert
+- 原因：#905 質疑預警期 vx 歸零使俯掠近垂直，PM 裁決以受控實驗判定是否保留斜向動量（不為改而改）
+- 解法：實驗改為預警期不歸零 vx，四保留條件實測條件②崩潰（dodgeRateSignalAtWarn 100%→0%、hover 797ms→55ms、meetsThreshold 轉 false）而①③④成立；revert 改動並以數據 close #905 as not-planned（維持 scanna 定點語彙）
 
 - 日期：2026-07-27
 - ID：reward-starpuff-gamescene-strangler-split-w2prep

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format:fix": "prettier --write .",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r --workspace-concurrency 2 test && pnpm test:root",
-    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/build-commit-sha.test.ts scripts/__tests__/verify-002-log.test.ts",
+    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/build-commit-sha.test.ts scripts/__tests__/verify-002-log.test.ts scripts/__tests__/declaration-drift.test.ts",
     "test:unit": "pnpm -r test && pnpm test:root",
     "test:integration": "pnpm --filter @app/ratewise exec vitest run integration",
     "test:e2e": "pnpm --filter @app/ratewise exec playwright test && pnpm --filter @app/nihonname exec playwright test",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -327,12 +327,24 @@ lighthouse "$url" --max-wait-for-load 60000 ...
 
 ---
 
+## 🛡️ 宣告檔漂移守門（#903）
+
+scripts 內 `.js`/`.mjs` 實作以手寫 `.d.ts`/`.d.mts` 供 TS 消費端取得型別；
+`scripts/tsconfig.json` 只 include `**/*.ts`，tsc 從不驗證「宣告 vs 實作」。
+
+- **守門位置**: `scripts/__tests__/declaration-drift.test.ts`（經 `pnpm test:root` 接入 pre-push 與 CI）
+- **守備範圍**: export 名單雙向一致＋函式必填參數數（arity）一致
+- **維護契約**: 新增手寫宣告檔時必須同步登記該測試的 `MODULES` 表；深層回傳
+  物件欄位漂移由各模組行為測試承擔（`scripts/__tests__/*.test.ts`）
+
+---
+
 ## 🤝 貢獻
 
 發現 bug 或有改進建議？歡迎提交 Issue 或 PR！
 
 ---
 
-**最後更新**: 2026-04-28
+**最後更新**: 2026-07-27
 **維護者**: haotool
 **授權**: GPL-3.0

--- a/scripts/__tests__/declaration-drift.test.ts
+++ b/scripts/__tests__/declaration-drift.test.ts
@@ -65,7 +65,9 @@ function parseDeclaredValueExports(declarationRelativePath: string): DeclaredVal
 
 describe('scripts 宣告檔 ↔ 實作無漂移（#903）', () => {
   for (const { declaration, runtime } of MODULES) {
-    describe(declaration.replace('../', ''), () => {
+    // 顯示名去除固定 '../' 前綴：MODULES 為常數字面值非外部輸入，用 slice 而非
+    // replace 以避開 CodeQL js/incomplete-sanitization 對 replace 首匹配語意的誤判。
+    describe(declaration.slice('../'.length), () => {
       const declared = parseDeclaredValueExports(declaration);
       const runtimeExports = runtime as Record<string, unknown>;
 

--- a/scripts/__tests__/declaration-drift.test.ts
+++ b/scripts/__tests__/declaration-drift.test.ts
@@ -1,0 +1,92 @@
+// 宣告檔漂移守門（#903）：scripts/tsconfig.json 只 include **/*.ts，tsc 僅驗
+// 「呼叫端 vs 手寫宣告」，從不驗「宣告 vs 實作」——實作改 export 名稱或簽章時
+// typecheck 仍 0 錯誤（#901 審查實測坐實）。本檔以結構比對補上守門：
+// 1) export 名單雙向一致（宣告缺漏或實作偷加皆紅）；
+// 2) 函式必填參數數（arity）一致（fn.length vs 宣告非可選參數數）。
+// 維護契約：新增 scripts 手寫宣告檔（.d.ts/.d.mts）時必須同步登記 MODULES 表；
+// 深層回傳物件欄位漂移不在本檔守備範圍，由各模組行為測試承擔。
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import * as fetchMoneyboxRates from '../fetch-moneybox-rates.js';
+import * as fetchTaiwanBankRates from '../fetch-taiwan-bank-rates.js';
+import * as lighthouseDrift from '../lighthouse-drift.mjs';
+import * as monitorScheduleDrift from '../monitor-schedule-drift.mjs';
+import * as verify002Log from '../verify-002-log.mjs';
+import * as verifyProductionResources from '../verify-production-resources.mjs';
+
+const MODULES = [
+  { declaration: '../fetch-moneybox-rates.d.ts', runtime: fetchMoneyboxRates },
+  { declaration: '../fetch-taiwan-bank-rates.d.ts', runtime: fetchTaiwanBankRates },
+  { declaration: '../lighthouse-drift.d.mts', runtime: lighthouseDrift },
+  { declaration: '../monitor-schedule-drift.d.mts', runtime: monitorScheduleDrift },
+  { declaration: '../verify-002-log.d.mts', runtime: verify002Log },
+  { declaration: '../verify-production-resources.d.mts', runtime: verifyProductionResources },
+] as const;
+
+interface DeclaredValueExports {
+  // 具 runtime 存在性的 export 名單（function + const）；interface/type 為型別專屬故排除。
+  names: Set<string>;
+  // 函式名 → 必填參數數（第一個可選或 rest 參數之前的參數數，對齊 fn.length 語意）。
+  functionArity: Map<string, number>;
+}
+
+function parseDeclaredValueExports(declarationRelativePath: string): DeclaredValueExports {
+  const url = new URL(declarationRelativePath, import.meta.url);
+  const source = ts.createSourceFile(
+    declarationRelativePath,
+    readFileSync(url, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const names = new Set<string>();
+  const functionArity = new Map<string, number>();
+  for (const statement of source.statements) {
+    const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
+    if (!modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) continue;
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      const firstOptional = statement.parameters.findIndex(
+        (parameter) =>
+          parameter.questionToken !== undefined || parameter.dotDotDotToken !== undefined,
+      );
+      names.add(statement.name.text);
+      functionArity.set(
+        statement.name.text,
+        firstOptional === -1 ? statement.parameters.length : firstOptional,
+      );
+    } else if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) names.add(declaration.name.text);
+      }
+    }
+  }
+  return { names, functionArity };
+}
+
+describe('scripts 宣告檔 ↔ 實作無漂移（#903）', () => {
+  for (const { declaration, runtime } of MODULES) {
+    describe(declaration.replace('../', ''), () => {
+      const declared = parseDeclaredValueExports(declaration);
+      const runtimeExports = runtime as Record<string, unknown>;
+
+      it('export 名單雙向一致（改名、刪除、未登記新增皆必紅）', () => {
+        // ESM namespace 無 default 時 filter 為 no-op；防未來 CJS interop 噪音。
+        const runtimeNames = Object.keys(runtimeExports)
+          .filter((name) => name !== 'default')
+          .sort();
+        expect(runtimeNames).toEqual([...declared.names].sort());
+      });
+
+      it('函式必填參數數與宣告一致（簽章 arity 漂移必紅）', () => {
+        for (const [name, requiredParams] of declared.functionArity) {
+          const value = runtimeExports[name];
+          expect(typeof value, `${name} 宣告為 function`).toBe('function');
+          expect(
+            (value as (...args: unknown[]) => unknown).length,
+            `${name} 必填參數數（fn.length）`,
+          ).toBe(requiredParams);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
> ⚠️ **審查未收斂前請勿合併**（backlog 收斂車交付，等待多席審查）

Closes #903
Closes #904

（#905 已依實驗數據 close as not-planned，見 [實驗報告 comment](https://github.com/haotool/app/issues/905#issuecomment-5093252188)；本 PR 不含其行為改動）

基準 `origin/main` = `8da984833`（v0.25.3）。三卡處置與驗收證據如下。

> 📝 **審查輪次 2 修正**（Sonnet 席）：① `declaration-drift.test.ts` describe 顯示名由 `replace('../','')` 改為 `slice`，消除 CodeQL `js/incomplete-sanitization` high 告警（PM 裁決採程式碼修正不採 dismiss，alert 已轉 fixed）；② 變異 A 措辭精確化（見 #903 節）。
> 📝 **審查輪次 3 尾修**（Grok 席 LOW）：WARN tint 守門斷言強化——由單幀 `tintCalls.length>0` 改為全 fly 期逐幀走查，斷言至少一幀「落在 WARN 窗內」且「色值＝`TICKETA_SHIFT_TINT`（import 呈現層常數，禁硬編）」；假 setTint、窗外提早閃爍、色值改錯皆必紅，vx 調參仍正交（mutation ①②③ 實證見 #904 節）。歷史均以「drop 聚合→修復 commit→尾端重建聚合」重寫（`--force-with-lease`），002 維持單一聚合 commit 於尾端。

---

## #904（bug/p2）票券蝠 FSM 紅線改釘 WARN 預警窗

**改動**：`enemyFsm.ts` 註解改明「shift＝換軌俯掠位移本身、可讀前搖＝呈現層 WARN 預警」；`enemyFsm.test.ts` telegraph 紅線由誤釘 `shiftMs≥600` 改釘 `TICKETA_WARN_MS ≥ AUDIT_THRESHOLDS.telegraphMinMs`（scanna/foamy/manta 同步改引 SSOT 常數）；新增跨層行為守門——全 fly 期逐幀走查，WARN 窗內必亮 `TICKETA_SHIFT_TINT` 閃爍（輪次 3 強化：窗內時序＋色值比對，常數自呈現層 import）。

**mutation 實證**（輪次 1）：暫時移除 `finaleEnemies.ts` WARN 分支（**保留常數**——最刁鑽變異，僅釘常數防不住）：

```
FAIL enemyFsm.test.ts > WARN 預警分支存續守門
AssertionError: expected 0 to be greater than 0
Tests  1 failed | 58 passed (59)
```

**mutation 實證（輪次 3 強化後三連）**：

```
① tint 色值改錯（flickerTint 改 0x123456）    → 必紅：expected 0 to be greater than 0
② tint 移出 WARN 窗（提早到 fly 前段）        → 必紅：expected 0 to be greater than 0
③ WARN 窗 vx 邏輯調參（歸零改 0.9x 衰減）     → 守門保持綠：59/59 passed（#905 類正交）
```

均還原後回綠。守門只斷言 tint 訊號不綁懸停速度（速度語彙與反應窗實測屬 `finaleEnemies.test.ts`）。`shiftMs` 動力學釘點維持在 `finaleEnemies.test.ts`（`toBe(600)`）不重複。與 #890（宏觀 telegraph 治理）正交未越界。

## #903（debt/p3）scripts 宣告檔漂移守門

**方案評估**（卡面二擇一）：
- (b) `allowJs`+`checkJs`+JSDoc 實測爆炸半徑：**227 個 strict 錯誤**跨 6 模組（~2,300 行），波及 `verify-002-log.mjs`（002 守門本體）與匯率資料管線（`fetch-taiwan-bank-rates.js`/`fetch-moneybox-rates.js`）——P3 治理卡不成比例、回歸風險高，**棄**。
- (a) **採用**：新增 `scripts/__tests__/declaration-drift.test.ts`——以 TypeScript compiler API 解析 6 個手寫宣告檔，比對 runtime `Object.keys(import(...))`：①export 名單雙向一致（改名/刪除/未登記新增皆紅）②函式必填參數數（`fn.length` vs 宣告非可選參數數）一致。

**守備範圍的誠實邊界**：本守門守 **export 面**（名稱＋arity），是**同類 tsc 盲區的守門，非 #901 原始案例（深層回傳欄位 `delta` 改名）的逐字補洞**——深層欄位改名若無下游引用（如孤立欄位 `Entry002.lines`→`rawLines`）仍可全綠通過，該類漂移依賴各模組行為測試承擔。此殘餘缺口已明載於測試檔頭與 `scripts/README.md` 維護契約（驗收②）。

**mutation 實證**（驗收①，兩型變異，均附 tsc 盲區對照）：

變異 A＝頂層 export 改名（`parseStrictHeader`→`parseStrictHeaderRenamed`，同類 tsc 盲區示範）：
```
--- tsc: 0 errors (blind to drift)        ← 證明 tsc 對此類漂移盲
FAIL declaration-drift > verify-002-log.d.mts > export 名單雙向一致
FAIL declaration-drift > verify-002-log.d.mts > 函式必填參數數與宣告一致
Tests  2 failed | 10 passed (12)
```

變異 B＝簽章加必填參數（`isHardThresholdBreached` +1 param）：
```
--- tsc: 0 errors (blind to drift)
AssertionError: isHardThresholdBreached 必填參數數（fn.length）: expected 3 to be 2
Tests  1 failed | 11 passed (12)
```

均還原後回綠（12/12）。與 #608/#885 無功能重複（驗收③）。

**CodeQL 修正（輪次 2）**：describe 顯示名 `replace('../','')` 觸發 `js/incomplete-sanitization`（high）；輸入為 `MODULES` 常數字面值、僅用於顯示名，屬誤判，但依 repo 規則採程式碼修正——改 `slice('../'.length)` 徹底避開 replace 類規則（alert state: fixed）。

**⚠️ 白名單外最小偏離（請 PM 裁決）**：root `package.json` 的 `test:root` 加入一行新測試檔——這是讓守門真正接進 pre-push（`pnpm test`）與 CI（`test:coverage`）的既定唯一接點；不接線＝「看起來有測試」，違反驗收①。與 W2 車（starpuff 遊戲檔）零碰撞。若 PM 不同意此接法可只 revert 該行另議接點。

**順帶觀察（未處置，PM 已裁決不開卡）**：`monitor-schedule-drift.test.ts` 與 `verify-production-resources.test.ts` 不在 `test:root` 清單中（既有缺口，`git show 8da984833:package.json` 可核）；本守門已覆蓋該兩模組的 export 面。

## #905（enhancement/p3）預警期 vx 實驗——revert，close as not-planned

依 PM 裁決做受控實驗（改為預警期只閃爍不歸零 vx），量測環境：dev server SP_DEV_PORT=3037、`level-audit.mjs --probe ticketa`、L21 依 AGENTS v5.7 序列 ×7。

| 保留條件 | baseline | 實驗組 | 判定 |
|---------|----------|--------|------|
| ① AtMove 維持 0% | 0/0/0 | 0/0/0 | ✅ |
| ② AtWarn 仍 100% | 1.0/1.0/1.0 | **0/0/0** | ❌ **崩潰** |
| ③ 穿越/到帶/週期 | 361/299/3015ms | 360/298/3015ms | ✅ 噪音內 |
| ④ L21 clearRate（×7） | 1.0（7/7，81.1s，4.71死/次） | 1.0（7/7，82.5s，4.14死/次） | ✅ |

機制證據：hover 797ms→55ms（min 721→0）、`meetsThreshold` true→**false**（#899 驗收儀器直接轉紅）；懸停是唯一可由座標探針量測的前搖訊號（tint 不在 `__sp.enemies()` 觀測面）。依協議 revert（工作樹已還原、零殘留），數據與「刻意取捨維持 scanna 定點語彙」理由已附 #905 並關閉。**這也是卡面明訂的合法交付。**

---

## 閘門（本地全過，輪次 3 重跑）

| 閘門 | 結果 |
|------|------|
| starpuff `test:run` | 82 檔 **1107 案全綠**（基準 1106＋新守門 1） |
| root `test:root` | 6 檔 138 案全綠（含新 declaration-drift 12 案） |
| `pnpm typecheck` | 全 workspace Done |
| `tsc -p scripts/tsconfig.json` | **0 錯誤** |
| `pnpm lint` | 0 error（9 warning 為 ratewise 既有，非本車引入） |
| `verify-002-log.mjs --base-ref origin/main` | **exit 0**（002 檔頭 +3／累計 325→328） |

## 002

聚合檔頭：`> 本次分數變化：+3（reward 3、penalty 0、neutral 0）｜累計總分：+328`（單一聚合 commit `619a227fa` 於分支尾端，三條目 ID：`reward-starpuff-ticketa-fsm-redline-warn-repin`、`reward-scripts-declaration-drift-structural-gate`、`reward-starpuff-ticketa-warn-vx-experiment-revert`）。

changeset：`@app/starpuff` **patch**（守門強化＋治理，無玩家可見行為變更）。