### PR TITLE
fix(starpuff): e2e 對齊拆鍵與手動結晶契約，修復 main 紅燈

### DIFF
--- a/apps/starpuff/e2e/smoke.spec.ts
+++ b/apps/starpuff/e2e/smoke.spec.ts
@@ -69,12 +69,15 @@ test('點開始進入 GameScene：遊戲運行且 HUD 狀態就緒', async ({ pa
   await startGame(page);
   // HUD 由 PLAYER_DAMAGED/AMMO_CHANGED 事件驅動；初始狀態以 debug hook 驗證。
   await expect.poll(() => page.evaluate(() => window.__sp.playerHp())).toBe(5);
-  // 橫式手柄：左搖桿區 + 右側 A/B 兩圓鍵 + SP 情境鍵（§109，預設隱藏；全數無文字節點）。
+  // 橫式手柄：左搖桿區 + 右側 A/B 兩圓鍵 + SP 情境鍵 + TF 變身鍵（#952 拆鍵，
+  // 兩情境鍵預設隱藏；全數無文字節點）。
   await expect(page.locator('#joy-zone')).toBeVisible();
   const buttons = page.locator('[data-btn]');
-  await expect(buttons).toHaveCount(3);
-  for (let i = 0; i < 3; i += 1) await expect(buttons.nth(i)).toHaveText('');
+  const CONTROL_BUTTON_COUNT = 4;
+  await expect(buttons).toHaveCount(CONTROL_BUTTON_COUNT);
+  for (let i = 0; i < CONTROL_BUTTON_COUNT; i += 1) await expect(buttons.nth(i)).toHaveText('');
   await expect(page.locator('[data-btn="sp"]')).not.toHaveClass(/is-sp-on/);
+  await expect(page.locator('[data-btn="tf"]')).not.toHaveClass(/is-sp-on/);
   await page.waitForTimeout(1500);
   expect(errors).toEqual([]);
 });
@@ -205,7 +208,7 @@ test('跳關直達第四關魔王，強制勝利結算總用時', async ({ page 
 
 // 舊語意（§23）：滿三槽長按 B 0.8s 觸發星暴 → 新語意（§109）：滿五槽自動結晶成
 // 蓄能星（彈匣清空），按 SP（鍵盤 C）點按引爆——B 長按不再觸發星暴（#812 誤放歸零）。
-test('星暴 2.0：吞滿五槽自動結晶，SP 點按引爆清場（§109）', async ({ page }) => {
+test('星暴 2.0：滿匣按 SP 結晶、再按 SP 引爆清場（§109／#954 手動結晶）', async ({ page }) => {
   const errors = collectErrors(page);
   await startGame(page);
   // 長按吸入期間依序餵怪吞滿五槽；jelly/zappy 交錯避開 §46 配方與同系連吞升級。
@@ -218,18 +221,21 @@ test('星暴 2.0：吞滿五槽自動結晶，SP 點按引爆清場（§109）',
       .poll(() => page.evaluate(() => window.__sp.ammo().ammo), { timeout: 8000 })
       .toBe(i + 1);
   }
-  // 第五槽入匣瞬間自動結晶：彈匣清空、蓄能星生成（不觸發星暴、場上不清場）。
+  // 第五槽入匣：#954 起滿匣**不再自動結晶**——彈匣維持滿匣成為穩定狀態。
   await page.evaluate(() => window.__sp.spawn('jelly', 188, 340));
-  await expect
-    .poll(() => page.evaluate(() => window.__sp.starburst().phase), { timeout: 8000 })
-    .toBe('charged');
-  expect(await page.evaluate(() => window.__sp.ammo().ammo)).toBe(0);
+  await expect.poll(() => page.evaluate(() => window.__sp.ammo().ammo), { timeout: 8000 }).toBe(5);
+  expect(await page.evaluate(() => window.__sp.starburst().phase)).toBe('none');
   await page.keyboard.up('X');
-  // SP（鍵盤 C）點按 → 0.3s 蓄爆 → 引爆清場；蓄能星消失。
-  await page.keyboard.press('C', { delay: 120 });
-  await expect
-    .poll(() => page.evaluate(() => window.__sp.starburst().phase), { timeout: 8000 })
-    .toBe('none');
+  // SP（鍵盤 C）點按＝結晶 → 再點按＝引爆。headless 低幀率下單次 press 可能落在
+  // 幀縫而被丟棄，故一律輪詢重按至觀測到目標相位（沿 t3/v9 的 tapKeyUntil 慣例）。
+  const pressCUntil = async (phase: string): Promise<boolean> => {
+    await page.keyboard.press('C', { delay: 120 });
+    await page.waitForTimeout(250);
+    return page.evaluate((p) => window.__sp.starburst().phase === p, phase);
+  };
+  await expect.poll(() => pressCUntil('charged'), { timeout: 12_000 }).toBe(true);
+  expect(await page.evaluate(() => window.__sp.ammo().ammo)).toBe(0);
+  await expect.poll(() => pressCUntil('none'), { timeout: 12_000 }).toBe(true);
   await page.waitForTimeout(800);
   expect(errors).toEqual([]);
 });

--- a/apps/starpuff/e2e/t3.spec.ts
+++ b/apps/starpuff/e2e/t3.spec.ts
@@ -44,21 +44,34 @@ async function startGame(page: Page): Promise<void> {
 }
 
 // 混味五槽注入（jelly/shelly 交錯：無配方、無同系變身資格）→ 滿匣自動結晶。
+// #954：結晶改手動——滿匣後需按 SP 才結晶（修前為滿匣自動）。
 async function grantChargedStar(page: Page): Promise<void> {
   for (const flavor of ['jelly', 'shelly', 'jelly', 'shelly', 'jelly']) {
     await page.evaluate((kind) => window.__sp.grantStar(kind), flavor);
   }
-  await expect
-    .poll(() => page.evaluate(() => window.__sp.starburst().phase), { timeout: 8000 })
-    .toBe('charged');
+  await expect.poll(() => page.evaluate(() => window.__sp.ammo().ammo), { timeout: 8000 }).toBe(5);
+  await tapSpUntil(page, () => page.evaluate(() => window.__sp.starburst().phase === 'charged'));
   expect(await page.evaluate(() => window.__sp.ammo().ammo)).toBe(0);
 }
 
 // SP 點按（鍵盤 C）：headless 幀取樣錯拍防護——週期重按直到觀測到預期條件。
 async function tapSpUntil(page: Page, predicate: () => Promise<boolean>): Promise<void> {
+  await tapKeyUntil(page, 'C', predicate);
+}
+
+// TF 點按（鍵盤 V，#952 拆鍵）：變身／解除專用鍵。
+async function tapTfUntil(page: Page, predicate: () => Promise<boolean>): Promise<void> {
+  await tapKeyUntil(page, 'V', predicate);
+}
+
+async function tapKeyUntil(
+  page: Page,
+  key: string,
+  predicate: () => Promise<boolean>,
+): Promise<void> {
   const deadline = Date.now() + 8000;
   while (Date.now() < deadline) {
-    await page.keyboard.press('C', { delay: 120 });
+    await page.keyboard.press(key, { delay: 120 });
     await page.waitForTimeout(250);
     if (await predicate()) return;
   }
@@ -103,26 +116,26 @@ test.describe('行動觸控情境', () => {
     '觸控情境於 Mobile Chrome project 執行',
   );
 
-  test('SP 三態與隱藏條件（§109）：無技能隱藏→變身徽→解除箭→引爆星→蓄爆後隱藏', async ({
-    page,
-  }) => {
+  test('SP／TF 兩鍵呈現（§109／#952 拆鍵）：各自單義，隱藏與浮現互不牽動', async ({ page }) => {
     test.setTimeout(120_000);
     const errors = collectErrors(page);
     await startGame(page);
     await page.evaluate(() => window.__sp.fillQuota());
     const spBtn = page.locator('[data-btn="sp"]');
-    // 無技能可用：SP 完全隱藏。
+    const tfBtn = page.locator('[data-btn="tf"]');
+    // 無技能可用：兩鍵皆隱藏。
     await expect(spBtn).not.toHaveClass(/is-sp-on/);
-    // 同系 x3（地面）：變身資格成立 → SP 浮現（形態色圓徽）。
+    await expect(tfBtn).not.toHaveClass(/is-sp-on/);
+    // 同系 x3：變身資格成立 → 只有 TF 浮現（形態色圓徽），SP 不受影響。
     for (let i = 0; i < 3; i += 1) await page.evaluate(() => window.__sp.grantStar('zappy'));
-    await expect(spBtn).toHaveClass(/is-sp-on/, { timeout: 8000 });
-    // SP 點按 → 立即變身；變身中 SP 仍可用（解除迴旋箭）。
-    await tapSpUntil(page, () => page.evaluate(() => window.__sp.transform().form === 'volt'));
-    await expect(spBtn).toHaveClass(/is-sp-on/);
-    // 再按 SP 提前解除；彈匣已空（變身消耗）→ 無技能 → SP 隱藏。
-    await tapSpUntil(page, () => page.evaluate(() => window.__sp.transform().form === null));
-    await expect(spBtn).not.toHaveClass(/is-sp-on/, { timeout: 8000 });
-    // 蓄能星存在 → SP 浮現（金色大星）；引爆完成後無技能 → 隱藏。
+    await expect(tfBtn).toHaveClass(/is-sp-on/, { timeout: 8000 });
+    await expect(spBtn).not.toHaveClass(/is-sp-on/);
+    // TF 點按 → 立即變身；變身中 TF 仍可用（解除迴旋箭）。
+    await tapTfUntil(page, () => page.evaluate(() => window.__sp.transform().form === 'volt'));
+    await expect(tfBtn).toHaveClass(/is-sp-on/);
+    // 再按 TF 提前解除；#953 起只扣 3 星單位，餘槽保留故資格可能仍成立。
+    await tapTfUntil(page, () => page.evaluate(() => window.__sp.transform().form === null));
+    // 蓄能星路線：滿匣 → SP 顯示結晶 → 按 SP 結晶 → 續顯示引爆 → 引爆後隱藏。
     await grantChargedStar(page);
     await expect(spBtn).toHaveClass(/is-sp-on/, { timeout: 8000 });
     await tapSpUntil(page, () => page.evaluate(() => window.__sp.starburst().phase === 'none'));
@@ -231,14 +244,14 @@ test.describe('鍵盤 C 桌機映射（§109）', () => {
     '桌機情境需寬視口 project（Desktop Chrome）',
   );
 
-  test('桌機：同系 x3 按 C 立即變身、再按 C 解除', async ({ page }) => {
+  test('桌機：同系 x3 按 V 立即變身、再按 V 解除（#952 拆鍵）', async ({ page }) => {
     test.setTimeout(120_000);
     const errors = collectErrors(page);
     await startGame(page);
     await page.evaluate(() => window.__sp.fillQuota());
     for (let i = 0; i < 3; i += 1) await page.evaluate(() => window.__sp.grantStar('floaty'));
-    await tapSpUntil(page, () => page.evaluate(() => window.__sp.transform().form === 'gale'));
-    await tapSpUntil(page, () => page.evaluate(() => window.__sp.transform().form === null));
+    await tapTfUntil(page, () => page.evaluate(() => window.__sp.transform().form === 'gale'));
+    await tapTfUntil(page, () => page.evaluate(() => window.__sp.transform().form === null));
     await page.waitForTimeout(400);
     expect(errors).toEqual([]);
   });

--- a/apps/starpuff/e2e/v9.spec.ts
+++ b/apps/starpuff/e2e/v9.spec.ts
@@ -63,10 +63,11 @@ async function gotoLevel(page: Page, levelId: number): Promise<void> {
 
 // SP 點按（§109 取代星化長按）：headless 低幀率下單次 keydown 的按下緣可能與
 // 幀取樣錯拍——週期重按（每拍跨至少一遊戲幀）直到觀測到目標形態（行為守門）。
+// #952 拆鍵：變身／解除移至 TF 鍵（鍵盤 V），SP 專責星暴。
 async function tapSpUntil(page: Page, expected: string | null): Promise<void> {
   const deadline = Date.now() + 8000;
   while (Date.now() < deadline) {
-    await page.keyboard.press('C', { delay: 120 });
+    await page.keyboard.press('V', { delay: 120 });
     await page.waitForTimeout(250);
     if ((await page.evaluate(() => window.__sp.transform().form)) === expected) return;
   }
@@ -117,12 +118,14 @@ async function seedClearedSave(page: Page, ids: readonly number[]): Promise<void
 
 // 舊語意（§57）：同系 x3 地面長按 0.6s 變身、變身中長按解除 → 新語意（§109）：
 // 同系 ≥3 地面 SP（鍵盤 C）點按立即變身、變身中 SP 點按提前解除。
-test('星化三形態（§109）：同系 x3 按 SP 變身、B 鍵改役、再按 SP 提前解除', async ({ page }) => {
+test('星化三形態（§109／#952）：同系 x3 按 TF 變身、B 鍵改役、再按 TF 提前解除', async ({
+  page,
+}) => {
   test.setTimeout(120_000);
   const errors = collectErrors(page);
   await startGame(page);
   await page.evaluate(() => window.__sp.fillQuota());
-  // 雷化：zappy x3 → SP 點按即時變身、彈匣清空。
+  // 雷化：zappy x3 → TF 點按即時變身；#953 起只扣 3 星單位。
   for (let i = 0; i < 3; i += 1) await page.evaluate(() => window.__sp.grantStar('zappy'));
   await tapSpUntil(page, 'volt');
   expect((await page.evaluate(() => window.__sp.ammo())).ammo).toBe(0);
@@ -139,7 +142,7 @@ test('星化三形態（§109）：同系 x3 按 SP 變身、B 鍵改役、再�
   await expect
     .poll(() => page.evaluate(() => window.__sp.alive().total), { timeout: 6000 })
     .toBe(0);
-  // 再按 SP 提前解除（不返彈）。
+  // 再按 TF 提前解除（不返彈）。
   await tapSpUntil(page, null);
   expect((await page.evaluate(() => window.__sp.ammo())).ammo).toBe(0);
   // 風化與殼化資格觸發。
@@ -296,14 +299,17 @@ test('慈悲補血（§62）：低血久戰觸發愛心生成，拾取後 HP +1'
   // L3 迴避 L1 reach-x 彩蛋（走左緣 +1 HP 會污染斷言）。
   await gotoLevel(page, 3);
   await page.evaluate(() => window.__sp.fillQuota());
-  // 清場護航（§109）：混味五槽（無配方、無同系資格）滿匣自動結晶 → SP 引爆清空
-  // 場上小怪；gate 已開不再補生，低血走位不被殘敵干擾（防死亡重試污染斷言）。
+  // 清場護航（§109／#954）：混味五槽（無配方、無同系資格）滿匣後按 SP 結晶
+  // → 再按 SP 引爆清空場上小怪；gate 已開不再補生，低血走位不被殘敵干擾。
   for (const flavor of ['jelly', 'shelly', 'jelly', 'shelly', 'jelly']) {
     await page.evaluate((kind) => window.__sp.grantStar(kind), flavor);
   }
-  await expect
-    .poll(() => page.evaluate(() => window.__sp.starburst().phase), { timeout: 8000 })
-    .toBe('charged');
+  const charged = async (): Promise<boolean> => {
+    await page.keyboard.press('C', { delay: 120 });
+    await page.waitForTimeout(250);
+    return page.evaluate(() => window.__sp.starburst().phase === 'charged');
+  };
+  await expect.poll(charged, { timeout: 10_000 }).toBe(true);
   const detonated = async (): Promise<boolean> => {
     await page.keyboard.press('C', { delay: 120 });
     await page.waitForTimeout(250);
@@ -435,13 +441,17 @@ test('星暴無敵（§64/§109）：引爆即 5s 無敵、期間零傷害、到
   const errors = collectErrors(page);
   await startGame(page);
   await page.evaluate(() => window.__sp.fillQuota());
-  // 異系五槽（jelly/zappy 交錯無配方、不同系不觸變身資格）→ 滿匣自動結晶。
+  // 異系五槽（jelly/zappy 交錯無配方）→ #954 起需按 SP 手動結晶。
   for (const flavor of ['jelly', 'zappy', 'jelly', 'zappy', 'jelly']) {
     await page.evaluate((kind) => window.__sp.grantStar(kind), flavor);
   }
-  await expect
-    .poll(() => page.evaluate(() => window.__sp.starburst().phase), { timeout: 8000 })
-    .toBe('charged');
+  await expect.poll(() => page.evaluate(() => window.__sp.ammo().ammo), { timeout: 8000 }).toBe(5);
+  const crystallized = async (): Promise<boolean> => {
+    await page.keyboard.press('C', { delay: 120 });
+    await page.waitForTimeout(250);
+    return page.evaluate(() => window.__sp.starburst().phase === 'charged');
+  };
+  await expect.poll(crystallized, { timeout: 10_000 }).toBe(true);
   expect((await page.evaluate(() => window.__sp.ammo())).ammo).toBe(0);
   // SP 點按 → 0.3s 蓄爆 → 引爆開 5s 無敵窗。
   const detonated = async (): Promise<boolean> => {

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：-2（reward 0、penalty 2、neutral 4）｜累計總分：+319
+> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+318
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-08-01
+- ID：penalty-starpuff-e2e-contract-drift-merged-red
+- 原因：#953 改動輸入契約（SP 拆兩鍵）與結晶機制（自動改手動），只更新單元測試而未掃 e2e，致 10 個 e2e 編碼舊契約而失效（按鈕數 3、按 C 變身、滿匣自動結晶）；更嚴重的是啟用 auto-merge 時 E2E job 仍在執行，而該 job 非 required check，遂在未驗證下合併並發版 0.29.0，main 轉紅
+- 解法：10 案全數對齊新契約——grantChargedStar 補按 SP 結晶（連帶解 4 案）、新增 tapTfUntil 走 V 鍵、SP 三態改寫為兩鍵各自單義並加互不牽動斷言；滿載下的按鍵錯拍一律改輪詢重按。根因是「契約變更的同步清單漏了 e2e」與「auto-merge 只等 required checks」兩件事疊加，後者應把 E2E 列為 required 或改為等全綠再合
 
 - 日期：2026-07-31
 - ID：penalty-starpuff-audit-transform-policy-loop


### PR DESCRIPTION
## 摘要

修復 #953 造成的 main 紅燈。該 PR 改動了輸入契約（SP 拆為 SP／TF 兩鍵）與結晶機制（滿匣自動 → 按 SP 手動），但**只更新了單元測試，未同步 e2e**，導致 10 個 e2e 編碼舊契約而失效。

**產品行為未變更**——本 PR 全部是測試對齊。已發布的 0.29.0 功能正常（1380 單元測試 + 逐項瀏覽器實測），紅燈代表的是這些契約當時失去 CI 保護。

## 失效清單與修法

| 檔案 | 案數 | 失效原因 | 修法 |
| --- | --- | --- | --- |
| `smoke.spec.ts` | 2 | 斷言控制鈕 3 顆；依賴滿匣自動結晶 | 改 4 顆並抽 `CONTROL_BUTTON_COUNT`；補按 SP 結晶 |
| `t3.spec.ts` | 5 | SP 三態契約；`grantChargedStar` 靠自動結晶；桌機按 C 變身 | 改寫為兩鍵各自單義；helper 補結晶；改按 V |
| `v9.spec.ts` | 3 | `tapSpUntil` 按 C 變身；星暴無敵與慈悲補血靠自動結晶 | helper 改按 V；補結晶步驟 |

`grantChargedStar` 一處修正即連帶解掉 4 案（跨關持有、EX 進場清除等）。

新增 `tapTfUntil`（V 鍵），與既有 `tapSpUntil` 共用 `tapKeyUntil` 底層，避免兩份重試邏輯漂移。

SP 三態測試改寫時加了一條新斷言：**TF 浮現時 SP 不受影響**——把 #952 的「兩鍵互不影響」從程式碼簽章保證延伸到 e2e 可觀測層。

## 一個非契約性的 flake 修正

`smoke.spec.ts` 的星暴案在滿載下失敗、單獨執行通過。原因是 headless 低幀率使單次 `keyboard.press` 落在幀縫被丟棄。改為輪詢重按（沿 `t3`/`v9` 既有慣例）。

## 根因與後續

兩件事疊加造成紅燈進入生產：

1. **契約變更的同步清單漏了 e2e**——單元測試有更新，e2e 沒掃
2. **auto-merge 只等 required checks**，而 `E2E starpuff` 非 required，遂在該 job 仍執行中即合併並觸發發版

建議把 `E2E starpuff` 列為 required check，或改為等全綠再合併。

## 驗證

`npx playwright test` 完整套件：**138 案 / 122 passed / 15 skipped / 0 failed**（19 分鐘）

本 PR 待所有檢查完成才合併，不再使用 auto-merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)