### PR TITLE
test(starpuff): 直持設定案抑制殼層卡片，修 main E2E 紅燈

### DIFF
--- a/apps/starpuff/e2e/portrait.spec.ts
+++ b/apps/starpuff/e2e/portrait.spec.ts
@@ -228,6 +228,15 @@ test('直持 390×844（D1/D2）：預設 A/B 在右下拇指帶、真觸控點 
 // 短視窗則必須保留可操作的垂直 scroll container，避免完成/取消鈕落出畫面。
 test('直持設定：面板完整可見、短視窗可垂直滾動、按鈕配置不被旋轉殼擠出', async ({ page }) => {
   const errors = collectErrors(page);
+  // 殼層卡片抑制：本案驗設定面板版面，與 PWA／方向提示卡無關。卡片由
+  // whenShellIdle 於 Title 安靜時刻浮現，CI 慢機時會趕在點擊前蓋住設定鈕。
+  // 本案是全檔唯一用 .click()（做 actionability 檢查）者，因此只有它被攔截逾時；
+  // 其餘案走 dispatchEvent 繞過檢查故未曝光。沿 modal-landscape.spec 既有慣例。
+  await page.addInitScript(() => {
+    localStorage.setItem('sp-install-dismissed', '1');
+    localStorage.setItem('sp-orientation-landscape-seen', '1');
+    localStorage.setItem('sp-rotation-notice', '1');
+  });
   await page.goto('/');
   await expect(page.locator('#app canvas')).toBeVisible();
   await expect.poll(() => page.evaluate(() => window.__sp.scene())).toBe('Title');


### PR DESCRIPTION
## 問題

`E2E starpuff` 在 **main 上目前是紅的**：`e2e/portrait.spec.ts:229 直持設定` 連三次重試皆逾時失敗（60s）。

```
Error: locator.click: Test timeout of 60000ms exceeded.
  - locator resolved to <button aria-label="設定" data-menu="settings">
  - <button class="install-btn">知道了</button> from <div class="install-overlay">…</div>
    subtree intercepts pointer events
```

## 根因

該測試進站後直接點設定鈕，但**沒有抑制殼層提示卡**。卡片由 `whenShellIdle` 在 Title 安靜時刻浮現（1s 輪詢 + delay），CI 慢機時會趕在點擊前蓋住設定鈕。

為什麼**只有這一案**失敗：它是 `portrait.spec.ts` 全檔**唯一使用 `.click()`** 的案例——`.click()` 會做 actionability 檢查因而被浮層攔截；其餘案走 `dispatchEvent('pointerdown')` 繞過檢查，故同一 race 未被曝光。

本案驗的是設定面板版面，與 PWA／方向提示卡無關，卡片純屬干擾。

## 修法

沿 `modal-landscape.spec.ts` 既有慣例，進站前以 `addInitScript` 抑制三張殼層卡。**僅 9 行、不動被測邏輯**。

## 驗證

**A/B 對照實驗**（同樣等 4s 讓卡片有機會浮現）：

| | `install-overlay` 數量 |
|---|---|
| A：無抑制（main 現況） | **1**（卡片確實浮現） |
| B：有抑制（本 PR） | **0**（浮層消除） |

修法直接消除浮層的存在性，攔截因此不可能發生（不依賴時序賭博）。

本地 `Mobile Chrome Portrait` 該案通過。

## 備註

此紅燈**同時存在於 main 與 PR #982**，非任一 feature PR 引入——對照證據：main run `31067949694` 與 PR #982 run `31067449751` 皆在同一案失敗。本 PR 合併後可解除 #982 的阻塞。