### PR TITLE
fix(ci): 修復匯率 PR 與 SEO 生產驗證 pipeline 阻塞

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,62 +151,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          HEAD_SHA="${{ steps.release_pr.outputs.head_sha }}"
-
-          PENDING_IDS=""
-          for i in {1..12}; do
-            sleep 5
-            PENDING_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | join(\" \")")
-            if [ -n "$PENDING_IDS" ]; then
-              break
-            fi
-          done
-
-          if [ -z "$PENDING_IDS" ]; then
-            # 沒有 pending run 時必須確認已有任一 pull_request run 存在，否則 QC 永遠不會出現。
-            ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
-            if [ "$ANY_RUN" -gt 0 ]; then
-              echo "No approval-required pull_request runs for ${HEAD_SHA}; CI already runs natively."
-              exit 0
-            fi
-            PR_NUMBER="${{ steps.release_pr.outputs.pr_number }}"
-            echo "No pull_request runs for ${HEAD_SHA}; close/reopen release PR #${PR_NUMBER} to trigger CI..."
-            gh pr close "$PR_NUMBER"
-            gh pr reopen "$PR_NUMBER"
-            sleep 15
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
-            for i in {1..12}; do
-              sleep 5
-              PENDING_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
-                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | join(\" \")")
-              ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
-                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
-              if [ -n "$PENDING_IDS" ] || [ "$ANY_RUN" -gt 0 ]; then
-                break
-              fi
-            done
-            if [ -z "$PENDING_IDS" ] && [ "$ANY_RUN" -eq 0 ]; then
-              echo "::error::No pull_request runs exist for ${HEAD_SHA}; Quality Checks will never start."
-              echo "::error::Fix: add repo secret RELEASE_PAT (fine-grained PAT, this repo, permissions: Actions/Contents/Pull requests Read&Write) — see issue #771."
-              exit 1
-            fi
-            if [ -z "$PENDING_IDS" ]; then
-              echo "pull_request runs exist after close/reopen; no approval required."
-              exit 0
-            fi
-          fi
-
-          for RUN in $PENDING_IDS; do
-            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN}/approve" >/dev/null; then
-              echo "Approved pull_request run ${RUN}"
-            else
-              echo "::error::Failed to approve pull_request run ${RUN}. GITHUB_TOKEN cannot approve approval-required runs."
-              echo "::error::Fix: add repo secret RELEASE_PAT (fine-grained PAT, this repo, permissions: Actions/Contents/Pull requests Read&Write) — see issue #771. Interim SOP: close/reopen the release PR to trigger native CI."
-              exit 1
-            fi
-          done
+          bash scripts/approve-bot-pr-workflows.sh changeset-release/main \
+            "${{ steps.release_pr.outputs.head_sha }}" \
+            "${{ steps.release_pr.outputs.pr_number }}"
 
       # 只等必要檢查 Quality Checks；e2e / lighthouse 等非必要 job 不阻擋合併（與人工流程一致）。
       # 以 head SHA 的 check-runs 為準，同名取最新（與 GitHub merge box 相同語意）。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,9 +171,31 @@ jobs:
               echo "No approval-required pull_request runs for ${HEAD_SHA}; CI already runs natively."
               exit 0
             fi
-            echo "::error::No pull_request runs exist for ${HEAD_SHA}; Quality Checks will never start."
-            echo "::error::Fix: add repo secret RELEASE_PAT (fine-grained PAT, this repo, permissions: Actions/Contents/Pull requests Read&Write) — see issue #771. Interim SOP: close/reopen the release PR."
-            exit 1
+            PR_NUMBER="${{ steps.release_pr.outputs.pr_number }}"
+            echo "No pull_request runs for ${HEAD_SHA}; close/reopen release PR #${PR_NUMBER} to trigger CI..."
+            gh pr close "$PR_NUMBER"
+            gh pr reopen "$PR_NUMBER"
+            sleep 15
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+            for i in {1..12}; do
+              sleep 5
+              PENDING_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
+                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | join(\" \")")
+              ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=changeset-release%2Fmain&event=pull_request&per_page=30" \
+                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
+              if [ -n "$PENDING_IDS" ] || [ "$ANY_RUN" -gt 0 ]; then
+                break
+              fi
+            done
+            if [ -z "$PENDING_IDS" ] && [ "$ANY_RUN" -eq 0 ]; then
+              echo "::error::No pull_request runs exist for ${HEAD_SHA}; Quality Checks will never start."
+              echo "::error::Fix: add repo secret RELEASE_PAT (fine-grained PAT, this repo, permissions: Actions/Contents/Pull requests Read&Write) — see issue #771."
+              exit 1
+            fi
+            if [ -z "$PENDING_IDS" ]; then
+              echo "pull_request runs exist after close/reopen; no approval required."
+              exit 0
+            fi
           fi
 
           for RUN in $PENDING_IDS; do

--- a/.github/workflows/update-seo-rate-examples.yml
+++ b/.github/workflows/update-seo-rate-examples.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   update:
@@ -35,6 +36,8 @@ jobs:
 
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      HAS_RELEASE_PAT: ${{ secrets.RELEASE_PAT != '' }}
+      BOT_PR_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v7
@@ -63,7 +66,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.BOT_PR_TOKEN }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: |
@@ -107,6 +110,68 @@ jobs:
           add-paths: |
             apps/ratewise/src/config/generated/build-time-rates.json
             apps/ratewise/src/config/generated/seo-rate-examples.ts
+
+      # GITHUB_TOKEN 建立的 PR 其 pull_request workflow 常停在 action_required；
+      # RELEASE_PAT 存在時原生觸發，否則嘗試 Approve API（同 release.yml #771 補償鏈）。
+      - name: 核准匯差 PR 的 workflow runs
+        if: steps.create-pr.outputs.pull-request-number != '' && env.HAS_RELEASE_PAT != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          PR_BRANCH: chore/daily-seo-rate-update
+        run: |
+          set -euo pipefail
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+          BRANCH_ENC=$(node -e "console.log(encodeURIComponent(process.argv[1]))" "$PR_BRANCH")
+
+          approve_pending_runs() {
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | .[]"
+          }
+
+          PENDING_IDS=""
+          for i in {1..12}; do
+            sleep 5
+            PENDING_IDS=$(approve_pending_runs | tr '\n' ' ' | xargs echo -n || true)
+            if [ -n "$PENDING_IDS" ]; then
+              break
+            fi
+          done
+
+          if [ -z "$PENDING_IDS" ]; then
+            ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
+            if [ "$ANY_RUN" -gt 0 ]; then
+              echo "No approval-required runs for ${HEAD_SHA}; CI already active."
+              exit 0
+            fi
+            echo "No pull_request runs for ${HEAD_SHA}; close/reopen PR #${PR_NUMBER} to trigger CI..."
+            gh pr close "$PR_NUMBER"
+            gh pr reopen "$PR_NUMBER"
+            sleep 15
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+            for i in {1..12}; do
+              sleep 5
+              PENDING_IDS=$(approve_pending_runs | tr '\n' ' ' | xargs echo -n || true)
+              ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
+                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
+              if [ -n "$PENDING_IDS" ] || [ "$ANY_RUN" -gt 0 ]; then
+                break
+              fi
+            done
+            if [ -z "$PENDING_IDS" ] && [ "$ANY_RUN" -eq 0 ]; then
+              echo "::error::No pull_request runs after close/reopen for ${HEAD_SHA}; add RELEASE_PAT secret (issue #771)."
+              exit 1
+            fi
+            if [ -z "$PENDING_IDS" ]; then
+              exit 0
+            fi
+          fi
+
+          for RUN in $PENDING_IDS; do
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN}/approve" >/dev/null
+            echo "Approved pull_request run ${RUN}"
+          done
 
       # 啟用 GitHub auto-merge（squash）：合併仍由 branch protection + required checks 把關，
       # checks 未通過不會合併；此步驟只是免除人工點擊，非繞過審查控制。

--- a/.github/workflows/update-seo-rate-examples.yml
+++ b/.github/workflows/update-seo-rate-examples.yml
@@ -118,60 +118,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-          PR_BRANCH: chore/daily-seo-rate-update
         run: |
           set -euo pipefail
           HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
-          BRANCH_ENC=$(node -e "console.log(encodeURIComponent(process.argv[1]))" "$PR_BRANCH")
-
-          approve_pending_runs() {
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | .[]"
-          }
-
-          PENDING_IDS=""
-          for i in {1..12}; do
-            sleep 5
-            PENDING_IDS=$(approve_pending_runs | tr '\n' ' ' | xargs echo -n || true)
-            if [ -n "$PENDING_IDS" ]; then
-              break
-            fi
-          done
-
-          if [ -z "$PENDING_IDS" ]; then
-            ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
-            if [ "$ANY_RUN" -gt 0 ]; then
-              echo "No approval-required runs for ${HEAD_SHA}; CI already active."
-              exit 0
-            fi
-            echo "No pull_request runs for ${HEAD_SHA}; close/reopen PR #${PR_NUMBER} to trigger CI..."
-            gh pr close "$PR_NUMBER"
-            gh pr reopen "$PR_NUMBER"
-            sleep 15
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
-            for i in {1..12}; do
-              sleep 5
-              PENDING_IDS=$(approve_pending_runs | tr '\n' ' ' | xargs echo -n || true)
-              ANY_RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
-                --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length")
-              if [ -n "$PENDING_IDS" ] || [ "$ANY_RUN" -gt 0 ]; then
-                break
-              fi
-            done
-            if [ -z "$PENDING_IDS" ] && [ "$ANY_RUN" -eq 0 ]; then
-              echo "::error::No pull_request runs after close/reopen for ${HEAD_SHA}; add RELEASE_PAT secret (issue #771)."
-              exit 1
-            fi
-            if [ -z "$PENDING_IDS" ]; then
-              exit 0
-            fi
-          fi
-
-          for RUN in $PENDING_IDS; do
-            gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN}/approve" >/dev/null
-            echo "Approved pull_request run ${RUN}"
-          done
+          bash scripts/approve-bot-pr-workflows.sh chore/daily-seo-rate-update "$HEAD_SHA" "$PR_NUMBER"
 
       # 啟用 GitHub auto-merge（squash）：合併仍由 branch protection + required checks 把關，
       # checks 未通過不會合併；此步驟只是免除人工點擊，非繞過審查控制。

--- a/apps/haotool/app.config.mjs
+++ b/apps/haotool/app.config.mjs
@@ -94,6 +94,11 @@ export const APP_CONFIG = {
     pwa: true,
   },
 
+  // 單語 zh-TW 站 v2.1：sitemap 不輸出 hreflang（見 scripts/generate-sitemap.js）。
+  seoValidation: {
+    sitemapHreflang: false,
+  },
+
   // 資源配置
   resources: {
     seoFiles: SEO_FILES,

--- a/apps/papertrade/app.config.mjs
+++ b/apps/papertrade/app.config.mjs
@@ -37,6 +37,11 @@ export const APP_CONFIG = {
     pwa: true,
   },
 
+  // client-side routing：nginx 對未知路徑 fallback 至 index.html（見 nginx.conf papertrade 區塊）。
+  seoValidation: {
+    requireTrue404: false,
+  },
+
   resources: {
     seoFiles: SEO_FILES,
     images: IMAGE_RESOURCES,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format:fix": "prettier --write .",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r --workspace-concurrency 2 test && pnpm test:root",
-    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/build-commit-sha.test.ts scripts/__tests__/verify-002-log.test.ts scripts/__tests__/declaration-drift.test.ts",
+    "test:root": "vitest run scripts/__tests__/lighthouse-production.test.ts scripts/__tests__/fetch-moneybox-rates.test.ts scripts/__tests__/fetch-taiwan-bank-rates.test.ts scripts/__tests__/build-commit-sha.test.ts scripts/__tests__/verify-002-log.test.ts scripts/__tests__/declaration-drift.test.ts scripts/__tests__/seo-health-utils.test.ts",
     "test:unit": "pnpm -r test && pnpm test:root",
     "test:integration": "pnpm --filter @app/ratewise exec vitest run integration",
     "test:e2e": "pnpm --filter @app/ratewise exec playwright test && pnpm --filter @app/nihonname exec playwright test",

--- a/scripts/__tests__/declaration-drift.test.ts
+++ b/scripts/__tests__/declaration-drift.test.ts
@@ -14,6 +14,7 @@ import * as lighthouseDrift from '../lighthouse-drift.mjs';
 import * as monitorScheduleDrift from '../monitor-schedule-drift.mjs';
 import * as verify002Log from '../verify-002-log.mjs';
 import * as verifyProductionResources from '../verify-production-resources.mjs';
+import * as seoHealthUtils from '../lib/seo-health-utils.mjs';
 
 const MODULES = [
   { declaration: '../fetch-moneybox-rates.d.ts', runtime: fetchMoneyboxRates },
@@ -22,6 +23,7 @@ const MODULES = [
   { declaration: '../monitor-schedule-drift.d.mts', runtime: monitorScheduleDrift },
   { declaration: '../verify-002-log.d.mts', runtime: verify002Log },
   { declaration: '../verify-production-resources.d.mts', runtime: verifyProductionResources },
+  { declaration: '../lib/seo-health-utils.d.mts', runtime: seoHealthUtils },
 ] as const;
 
 interface DeclaredValueExports {

--- a/scripts/__tests__/seo-health-utils.test.ts
+++ b/scripts/__tests__/seo-health-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSeoValidationFlags } from '../lib/seo-health-utils.mjs';
+
+describe('resolveSeoValidationFlags', () => {
+  it('預設啟用 sitemap hreflang 與真 404 檢查', () => {
+    expect(resolveSeoValidationFlags({})).toEqual({
+      expectSitemapHreflang: true,
+      requireTrue404: true,
+    });
+  });
+
+  it('HaoTool 單語站可關閉 sitemap hreflang', () => {
+    expect(
+      resolveSeoValidationFlags({
+        seoValidation: { sitemapHreflang: false },
+      }),
+    ).toEqual({
+      expectSitemapHreflang: false,
+      requireTrue404: true,
+    });
+  });
+
+  it('PaperTrade SPA 可關閉真 404 檢查', () => {
+    expect(
+      resolveSeoValidationFlags({
+        seoValidation: { requireTrue404: false },
+      }),
+    ).toEqual({
+      expectSitemapHreflang: true,
+      requireTrue404: false,
+    });
+  });
+});

--- a/scripts/approve-bot-pr-workflows.sh
+++ b/scripts/approve-bot-pr-workflows.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# bot PR（GITHUB_TOKEN 建立）的 pull_request workflow 補償鏈 SSOT。
+# 用法：approve-bot-pr-workflows.sh <branch> <head_sha> [pr_number]
+# 需 env：GH_TOKEN、GITHUB_REPOSITORY
+set -euo pipefail
+
+BRANCH="$1"
+HEAD_SHA="$2"
+PR_NUMBER="${3:-}"
+BRANCH_ENC=$(node -e "console.log(encodeURIComponent(process.argv[1]))" "$BRANCH")
+
+fetch_pending_ids() {
+  gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
+    --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\" and (.status == \"action_required\" or .conclusion == \"action_required\"))] | map(.id) | join(\" \")"
+}
+
+fetch_any_run_count() {
+  gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BRANCH_ENC}&event=pull_request&per_page=30" \
+    --jq "[.workflow_runs[] | select(.head_sha == \"${HEAD_SHA}\")] | length"
+}
+
+PENDING_IDS=""
+for _ in {1..12}; do
+  sleep 5
+  PENDING_IDS=$(fetch_pending_ids)
+  if [ -n "$PENDING_IDS" ]; then
+    break
+  fi
+done
+
+if [ -z "$PENDING_IDS" ]; then
+  ANY_RUN=$(fetch_any_run_count)
+  if [ "$ANY_RUN" -gt 0 ]; then
+    echo "No approval-required pull_request runs for ${HEAD_SHA}; CI already active."
+    exit 0
+  fi
+  if [ -z "$PR_NUMBER" ]; then
+    echo "::error::No pull_request runs for ${HEAD_SHA} and no PR number for close/reopen."
+    exit 1
+  fi
+  echo "No pull_request runs for ${HEAD_SHA}; close/reopen PR #${PR_NUMBER} to trigger CI..."
+  gh pr close "$PR_NUMBER"
+  gh pr reopen "$PR_NUMBER"
+  sleep 15
+  HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+  for _ in {1..12}; do
+    sleep 5
+    PENDING_IDS=$(fetch_pending_ids)
+    ANY_RUN=$(fetch_any_run_count)
+    if [ -n "$PENDING_IDS" ] || [ "$ANY_RUN" -gt 0 ]; then
+      break
+    fi
+  done
+  if [ -z "$PENDING_IDS" ] && [ "$ANY_RUN" -eq 0 ]; then
+    echo "::error::No pull_request runs after close/reopen for ${HEAD_SHA}; add RELEASE_PAT secret (issue #771)."
+    exit 1
+  fi
+  if [ -z "$PENDING_IDS" ]; then
+    echo "pull_request runs exist after close/reopen; no approval required."
+    exit 0
+  fi
+fi
+
+for RUN in $PENDING_IDS; do
+  if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN}/approve" >/dev/null; then
+    echo "Approved pull_request run ${RUN}"
+  else
+    echo "::error::Failed to approve pull_request run ${RUN}. GITHUB_TOKEN may lack permission; add RELEASE_PAT — issue #771."
+    exit 1
+  fi
+done

--- a/scripts/lib/seo-health-utils.d.mts
+++ b/scripts/lib/seo-health-utils.d.mts
@@ -1,0 +1,17 @@
+// seo-health-utils.mjs 型別宣告（#900）：實作以 .mjs 為 SSOT，本檔僅描述既有 export 形狀。
+
+export interface SeoValidationFlags {
+  expectSitemapHreflang: boolean;
+  requireTrue404: boolean;
+}
+
+export function stripTrailingSlash(value: string): string;
+export function joinUrl(baseUrl: string, path: string): string;
+export function getExpectedCanonicalUrl(canonicalBaseUrl: string, path: string): string;
+export function resolveAuditBaseUrls(
+  config: { siteUrl: string },
+  customBaseUrl?: string,
+): { canonicalBaseUrl: string; requestBaseUrl: string };
+export function resolveSeoValidationFlags(config: {
+  seoValidation?: { sitemapHreflang?: boolean; requireTrue404?: boolean };
+}): SeoValidationFlags;

--- a/scripts/lib/seo-health-utils.mjs
+++ b/scripts/lib/seo-health-utils.mjs
@@ -25,3 +25,11 @@ export function resolveAuditBaseUrls(config, customBaseUrl) {
     requestBaseUrl,
   };
 }
+
+/** 從 app.config APP_CONFIG.seoValidation 解析生產 SEO 驗證旗標（預設全開）。 */
+export function resolveSeoValidationFlags(config) {
+  return {
+    expectSitemapHreflang: config.seoValidation?.sitemapHreflang !== false,
+    requireTrue404: config.seoValidation?.requireTrue404 !== false,
+  };
+}

--- a/scripts/lib/seo-health-utils.mjs
+++ b/scripts/lib/seo-health-utils.mjs
@@ -16,7 +16,7 @@ export function getExpectedCanonicalUrl(canonicalBaseUrl, path) {
     : joinUrl(canonicalBaseUrl, path);
 }
 
-export function resolveAuditBaseUrls(config, customBaseUrl) {
+export function resolveAuditBaseUrls(config, customBaseUrl = undefined) {
   const canonicalBaseUrl = stripTrailingSlash(config.siteUrl);
   const requestBaseUrl = stripTrailingSlash(customBaseUrl || config.siteUrl);
 

--- a/scripts/verify-production-seo.mjs
+++ b/scripts/verify-production-seo.mjs
@@ -18,7 +18,12 @@
  */
 
 import { discoverApps, loadAppConfig } from './lib/workspace-utils.mjs';
-import { getExpectedCanonicalUrl, joinUrl, resolveAuditBaseUrls } from './lib/seo-health-utils.mjs';
+import {
+  getExpectedCanonicalUrl,
+  joinUrl,
+  resolveAuditBaseUrls,
+  resolveSeoValidationFlags,
+} from './lib/seo-health-utils.mjs';
 
 const appName = process.argv[2] || 'ratewise';
 const customBaseUrl = process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
@@ -344,7 +349,7 @@ async function main() {
   }
 
   console.log('\n🗺️ Sitemap 內容驗證:');
-  const expectSitemapHreflang = config.seoValidation?.sitemapHreflang !== false;
+  const { expectSitemapHreflang, requireTrue404 } = resolveSeoValidationFlags(config);
   const sitemapResult = await verifySitemapContent(
     requestBaseUrl,
     canonicalBaseUrl,
@@ -394,7 +399,6 @@ async function main() {
     }
   }
 
-  const requireTrue404 = config.seoValidation?.requireTrue404 !== false;
   if (requireTrue404) {
     console.log('\n🚫 真 404 驗證:');
     const notFoundResult = await verify404(requestBaseUrl);

--- a/scripts/verify-production-seo.mjs
+++ b/scripts/verify-production-seo.mjs
@@ -149,6 +149,7 @@ async function verifySitemapContent(
   seoPaths,
   appShellPaths = [],
   imageResources = [],
+  expectSitemapHreflang = true,
 ) {
   const response = await fetchSitemap(requestBaseUrl);
   if (!response.ok || response.body == null) {
@@ -178,10 +179,12 @@ async function verifySitemapContent(
     }
   }
 
-  const hreflangMatches = response.body.match(/<xhtml:link/g) || [];
-  const expectedCount = seoPaths.length * 2;
-  if (hreflangMatches.length !== expectedCount) {
-    errors.push(`hreflang 數量錯誤: 期望 ${expectedCount}, 實際 ${hreflangMatches.length}`);
+  if (expectSitemapHreflang) {
+    const hreflangMatches = response.body.match(/<xhtml:link/g) || [];
+    const expectedCount = seoPaths.length * 2;
+    if (hreflangMatches.length !== expectedCount) {
+      errors.push(`hreflang 數量錯誤: 期望 ${expectedCount}, 實際 ${hreflangMatches.length}`);
+    }
   }
 
   return { ok: errors.length === 0, errors };
@@ -341,12 +344,14 @@ async function main() {
   }
 
   console.log('\n🗺️ Sitemap 內容驗證:');
+  const expectSitemapHreflang = config.seoValidation?.sitemapHreflang !== false;
   const sitemapResult = await verifySitemapContent(
     requestBaseUrl,
     canonicalBaseUrl,
     config.seoPaths,
     config.appShellPaths,
     config.resources?.images ?? [],
+    expectSitemapHreflang,
   );
   if (sitemapResult.ok) {
     log(colors.green, '✓', 'sitemap.xml 內容正確');
@@ -389,13 +394,19 @@ async function main() {
     }
   }
 
-  console.log('\n🚫 真 404 驗證:');
-  const notFoundResult = await verify404(requestBaseUrl);
-  if (notFoundResult.ok) {
-    log(colors.green, '✓', '未知路徑正確回傳 404');
+  const requireTrue404 = config.seoValidation?.requireTrue404 !== false;
+  if (requireTrue404) {
+    console.log('\n🚫 真 404 驗證:');
+    const notFoundResult = await verify404(requestBaseUrl);
+    if (notFoundResult.ok) {
+      log(colors.green, '✓', '未知路徑正確回傳 404');
+    } else {
+      notFoundResult.errors.forEach((error) => log(colors.red, '✗', error));
+      hasErrors = true;
+    }
   } else {
-    notFoundResult.errors.forEach((error) => log(colors.red, '✗', error));
-    hasErrors = true;
+    console.log('\n🚫 真 404 驗證:');
+    log(colors.yellow, 'ℹ', '此 app 使用 SPA fallback，略過未知路徑 404 檢查');
   }
 
   if (config.legacyAssetRedirects) {


### PR DESCRIPTION
## Summary
- `verify-production-seo.mjs` 改為讀取 `app.config` 的 `seoValidation` 旗標，對齊 HaoTool v2.1（無 sitemap hreflang）與 PaperTrade SPA fallback（不強制真 404）
- `update-seo-rate-examples.yml` 優先使用 `RELEASE_PAT` 建 PR，並加入 bot PR 的 workflow approve / close-reopen 補償鏈（同 release.yml #771）
- `release.yml` 在 release PR 完全無 `pull_request` run 時自動 close/reopen 觸發 CI，避免永久空等

## Test plan
- [ ] PR CI（Quality Checks / E2E smoke）通過
- [ ] 合併後 SEO Production Validation 8/8 apps 通過
- [ ] PR #952 匯差範例可 auto-merge 進 main
- [ ] Release workflow 不再因缺少 pull_request run 失敗


Made with [Cursor](https://cursor.com)