### PR TITLE
chore(deps): @types/node 鎖定 ^24 對齊 Node 24 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
     # 2025-12-26: 改為每週，避免與 Renovate 衝突（Renovate 週一執行）
     # Dependabot 作為備援，僅處理 Renovate 遺漏的更新
     versioning-strategy: increase-if-necessary
+    ignore:
+      # 2026-08-08: runtime 鎖在 Node 24（engines ^24.0.0 / .nvmrc / CI node-version 24）。
+      # 型別 major 先行會描述執行期不存在的 API，型別檢查綠燈也擋不住執行期失敗。
+      # 待 runtime 整體升版後再一併解除（PR #969 因此關閉）。
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,15 @@ git push origin main            # pre-push 自動跑 typecheck + test + build
 4. 執行 `pnpm install --no-frozen-lockfile` 套用 override
 5. 提交安全修復：`fix(security): 修復 <package> 安全漏洞`
 
+**執行環境型別套件版本政策**（`@types/*` runtime 對齊）：
+
+- `@types/node` **必須**跟隨實際 runtime major，SSOT 為 `package.json engines`、`.nvmrc`、workflow `node-version` 三者一致值（現為 **24**）。
+- 型別 major 先行（例如 `@types/node` 升 26 但 runtime 仍 24）會描述執行期不存在的 API；`pnpm typecheck` 綠燈**不構成**安全證據，故障會延後到執行期才顯現。
+- 攔截設定為雙層，新增機器人或調整 runtime 時兩處都要同步：
+  - `package.json` 的 `pnpm.overrides`：`"@types/node": "^24"`（同時收斂間接依賴）
+  - `.github/dependabot.yml` `ignore` + `renovate.json` `allowedVersions`
+- runtime 升 major 時**必須**同批解除上述三處鎖定，不得只改其中之一。
+
 **PR Rebase 與合併**（處理版本衝突）：
 
 1. 檢查 PR 狀態：`gh pr view <NUMBER> --json mergeStateStatus,mergeable`

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+0（reward 0、penalty 0、neutral 1）｜累計總分：+318
+> 本次分數變化：-1（reward 0、penalty 1、neutral 0）｜累計總分：+317
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,11 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-08-08
+- ID：penalty-types-node-major-misjudged-as-patch
+- 原因：盤點 dependabot PR 時只看 mergeStateStatus=CLEAN 與 checks 全綠，未讀版本號就把 @types/node 24→26 判為「patch 級可直接合」，忽略 runtime 鎖在 Node 24（engines/.nvmrc/CI 三處一致）
+- 解法：關閉 #969，以 pnpm.overrides `"@types/node": "^24"` + dependabot ignore + renovate allowedVersions 三層鎖定，並在 CLAUDE.md 補「型別 major 先行時 typecheck 綠燈不構成安全證據」政策
 
 - 日期：2026-08-08
 - ID：neutral-ratewise-trend-basis-badge-opt-in

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
       "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": "7.29.4",
       "react-router": "^6.30.4",
       "react-router-dom": "^6.30.4",
+      "@types/node": "^24",
       "uuid": ">=11.1.1",
       "ajv@>=7.0.0 <8.18.0": ">=8.18.0",
       "minimatch@<3.1.4": "3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': 7.29.4
   react-router: ^6.30.4
   react-router-dom: ^6.30.4
+  '@types/node': ^24
   uuid: '>=11.1.1'
   ajv@>=7.0.0 <8.18.0: '>=8.18.0'
   minimatch@<3.1.4: 3.1.4
@@ -86,7 +87,7 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/xml2js':
         specifier: ^0.4.14
@@ -183,7 +184,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -253,7 +254,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -347,7 +348,7 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -456,7 +457,7 @@ importers:
         specifier: ^1.9.21
         version: 1.9.21
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -553,7 +554,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -674,7 +675,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -834,7 +835,7 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@types/react':
         specifier: ^19.2.17
@@ -910,7 +911,7 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@types/node':
-        specifier: ^24.13.3
+        specifier: ^24
         version: 24.13.3
       '@vitest/coverage-v8':
         specifier: 4.1.10
@@ -2137,7 +2138,7 @@ packages:
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3758,9 +3759,6 @@ packages:
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -4692,7 +4690,7 @@ packages:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^24
       cosmiconfig: '>=9'
       typescript: '>=5'
 
@@ -6240,7 +6238,7 @@ packages:
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24
       typescript: '>=5.0.4 <7'
 
   knitwork@1.3.0:
@@ -8562,7 +8560,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^24
       '@vitejs/devtools': ^0.3.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
@@ -8607,7 +8605,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': ^24
       '@vitest/browser-playwright': 4.1.10
       '@vitest/browser-preview': 4.1.10
       '@vitest/browser-webdriverio': 4.1.10
@@ -10517,7 +10515,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@types/node': 12.20.55
+      '@types/node': 24.13.3
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -12213,8 +12211,6 @@ snapshots:
   '@types/mysql@2.15.26':
     dependencies:
       '@types/node': 24.13.3
-
-  '@types/node@12.20.55': {}
 
   '@types/node@24.13.3':
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,11 @@
       "matchPackageNames": ["vitest", "@vitest/coverage-v8", "playwright", "@playwright/test"],
       "groupName": "test tools",
       "automerge": true
+    },
+    {
+      "description": "🔒 @types/node - 跟隨 runtime 鎖在 Node 24，不接受 major 型別先行",
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "^24"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
取代並關閉 #969（`@types/node` 24.13.3 → 26.1.2）。

## 問題

repo 的 runtime 三處一致鎖在 Node 24：

| SSOT | 值 |
| --- | --- |
| `package.json` engines | `^24.0.0` |
| `.nvmrc` | `24.0.0` |
| CI workflows `node-version` | `24`（5 處） |

`@types/node` 升到 **26** 會讓型別描述 Node 24 執行期**不存在**的 API。`pnpm typecheck` 綠燈只代表目前程式碼還沒引用到 Node 26 專屬 API，不構成安全證據——故障會延後到執行期才出現。

## 改法

三層鎖定，任一層單獨存在都會被另一個機器人繞過：

1. **`package.json` `pnpm.overrides`** — `"@types/node": "^24"`，同時把間接依賴一併收斂（沿用既有 `react-router` 壓 v6 的同款手法）
2. **`.github/dependabot.yml`** — `ignore` `@types/node` 的 `version-update:semver-major`
3. **`renovate.json`** — 新增 packageRule `allowedVersions: "^24"`（Renovate 週一也會跑，只設 dependabot 擋不住）

另在 `CLAUDE.md` 補「執行環境型別套件版本政策」，明訂 runtime 升 major 時三處鎖定必須同批解除。

## 驗證

- `pnpm list @types/node -r` → 全 workspace 單一版本 **24.13.3**（原本會被拉出多版本）
- `pnpm typecheck` → 8 個 workspace 全通過
- `pnpm test` → 9 個 package、**6481 tests** 全通過

## 後續

`#980 react-router-dom v6 → v7` 同為 major 且直接動到 ratewise SSG 路由核心，需單獨開一輪評估，不在本 PR 範圍。