### PR TITLE
fix(starpuff): 完成教學後停用舊版提示

### DIFF
--- a/apps/starpuff/src/controlHints.ts
+++ b/apps/starpuff/src/controlHints.ts
@@ -53,7 +53,14 @@ function appendHintItem(list: HTMLOListElement, text: string): void {
 
 function consumeSession(): boolean {
   const settings = loadSettings();
-  if (!hasTouchInput() || !shouldShowControlHints(settings)) return false;
+  // 完整互動教學已實際教過相同操作；即使是舊存檔只保存 completed、尚未
+  // 耗盡舊提示場次，也不可在回主選單或進入世界地圖時再次彈出短提示。
+  if (
+    !hasTouchInput() ||
+    settings.guidedTutorialStatus === 'completed' ||
+    !shouldShowControlHints(settings)
+  )
+    return false;
   updateSettings({
     controlHintsPlayCount: Math.min(CONTROL_HINT_MAX_SESSIONS, settings.controlHintsPlayCount + 1),
   });

--- a/apps/starpuff/src/game/core/settings.test.ts
+++ b/apps/starpuff/src/game/core/settings.test.ts
@@ -194,6 +194,15 @@ describe('loadSettings（v19 卡 4：預設與 migration）', () => {
     );
   });
 
+  it('完成完整教學時同步耗盡舊版操作提示場次', async () => {
+    const { CONTROL_HINT_MAX_SESSIONS, loadSettings, markGuidedTutorialCompleted } =
+      await loadSettingsModule();
+    loadSettings();
+    const settings = markGuidedTutorialCompleted();
+    expect(settings.guidedTutorialStatus).toBe('completed');
+    expect(settings.controlHintsPlayCount).toBe(CONTROL_HINT_MAX_SESSIONS);
+  });
+
   it('localStorage 不可用：回預設不拋錯，updateSettings 仍更新記憶體快取', async () => {
     vi.stubGlobal('localStorage', {
       getItem: () => {

--- a/apps/starpuff/src/game/core/settings.ts
+++ b/apps/starpuff/src/game/core/settings.ts
@@ -215,6 +215,15 @@ export function updateSettings(patch: Partial<Omit<UserSettings, 'schemaVersion'
   return next;
 }
 
+// 完整互動教學已涵蓋舊版短提示；一次同步標記兩種狀態，避免完成後
+// 從主選單或世界地圖再次進入遊戲時被舊提示卡攔住。
+export function markGuidedTutorialCompleted(): UserSettings {
+  return updateSettings({
+    guidedTutorialStatus: 'completed',
+    controlHintsPlayCount: CONTROL_HINT_MAX_SESSIONS,
+  });
+}
+
 // 變更訂閱（wakeLock 等需即時重同步的消費者）；回傳退訂函式。
 export function onSettingsChanged(listener: (settings: UserSettings) => void): () => void {
   listeners.add(listener);

--- a/apps/starpuff/src/game/systems/guidedTutorial.ts
+++ b/apps/starpuff/src/game/systems/guidedTutorial.ts
@@ -9,7 +9,7 @@ import {
   observeTutorial,
   type TutorialStep,
 } from '../core/tutorial';
-import { updateSettings } from '../core/settings';
+import { markGuidedTutorialCompleted, updateSettings } from '../core/settings';
 import { SceneKeys } from '../core/types';
 import type { EnemySystem } from './enemies';
 import type { ControlsSystem } from './controls';
@@ -187,7 +187,7 @@ export function createGuidedTutorial(
           makeButton(
             '開始正式 L1',
             () => {
-              updateSettings({ guidedTutorialStatus: 'completed' });
+              markGuidedTutorialCompleted();
               scene.scene.start(SceneKeys.Game, { levelId: 1, deaths: 0, newSession: false });
             },
             'guided-tutorial-primary',
@@ -195,7 +195,7 @@ export function createGuidedTutorial(
         );
         actions.appendChild(
           makeButton('回主選單', () => {
-            updateSettings({ guidedTutorialStatus: 'completed' });
+            markGuidedTutorialCompleted();
             scene.scene.start(SceneKeys.Title);
           }),
         );


### PR DESCRIPTION
- 完成完整教學時同步耗盡舊版操作提示場次
- 兼容既有 completed 存檔，避免回主選單後再次彈出短提示
- follow-up release metadata 由後續 PR 補上 changeset 與 002 稽核條目

測試：StarPuff typecheck、workspace tests、root 143 tests、RateWise build、pre-push 通過；E2E 依需求未等待