### PR TITLE
ci(lighthouse): path filter 補齊 lockfile 與根 package.json 觸發條件

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,11 @@ jobs:
           fi
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          if git diff --name-only "$BASE" "$HEAD" | grep -Eq '^(apps/ratewise/|scripts/lighthouse-|\.github/workflows/(ci|lighthouse-production)\.yml|\.lighthouserc\.cjs)'; then
+          # 根 package.json 與 pnpm-lock.yaml 會改變 ratewise 實際解析到的依賴樹
+          #（pnpm workspace 共用單一 lockfile），足以改變 bundle 體積與執行期行為，
+          # 故納入觸發條件——E2E 的 paths-filter 早已納入這兩者，此處補齊一致性。
+          # 兩者以 $ 錨定為 repo 根檔案；apps/ratewise/package.json 已由第一條規則涵蓋。
+          if git diff --name-only "$BASE" "$HEAD" | grep -Eq '^(apps/ratewise/|scripts/lighthouse-|\.github/workflows/(ci|lighthouse-production)\.yml|\.lighthouserc\.cjs|package\.json$|pnpm-lock\.yaml$)'; then
             echo "lighthouse=true" >> "$GITHUB_OUTPUT"
           else
             echo "lighthouse=false" >> "$GITHUB_OUTPUT"

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+1（reward 1、penalty 0、neutral 0）｜累計總分：+322
+> 本次分數變化：+0（reward 1、penalty 1、neutral 0）｜累計總分：+322
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,16 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-08-23
+- ID：penalty-stacked-pr-assumption-broken-by-squash-merge
+- 原因：為避開 002 記分表頭衝突而把 PR 疊在另一個未合併 PR 之上，卻沒考慮本 repo 一律使用 squash merge——上游 PR 合併後其原始 commit 不會進入 main 歷史，疊在其上的分支父 commit 成為孤兒，PR 直接變 DIRTY，反而製造了原本想避免的衝突
+- 解法：改以 origin/main 重建分支並只重新套用自身變更；往後 stacked PR 僅適用於 merge commit 或 rebase merge 的 repo，squash merge 下應直接開在 main 並接受 002 衝突、於 rebase 後手動補跑 verify-002-log.mjs
+
+- 日期：2026-08-23
+- ID：reward-lighthouse-filter-lockfile-parity
+- 原因：Lighthouse CI 的 path filter 只匹配 apps/ratewise 與 lighthouse 相關檔，未含根 package.json 與 pnpm-lock.yaml——依賴變更會改變 ratewise 實際解析到的依賴樹與 bundle 體積卻不觸發效能守門；同一份 ci.yml 的 E2E paths-filter 早已納入這兩者，屬既有不一致而非刻意設計
+- 解法：在 lighthouse-changes 的 grep 樣式補上以 `$` 錨定的 `package\.json` 與 `pnpm-lock\.yaml`，並以 15 個路徑案例實測確認 apps/starpuff/package.json、security-headers/package.json、package.json.bak 等不誤觸發
 
 - 日期：2026-08-23
 - ID：reward-extract-zip-eliminated-via-puppeteer-browsers-3


### PR DESCRIPTION
> **Stacked on #1034** — 本 PR 疊在 #1034 之上以避開 `002` 記分衝突。#1034 合併後，本 PR 對 main 的差異將只剩 `ci.yml` 與自身的 002 條目。

## 問題

`ci.yml` 的 `lighthouse-changes` job 決定 Lighthouse CI 是否執行，其判定樣式為：

```
^(apps/ratewise/|scripts/lighthouse-|\.github/workflows/(ci|lighthouse-production)\.yml|\.lighthouserc\.cjs)
```

**不含根 `package.json` 與 `pnpm-lock.yaml`。**

但 pnpm workspace 共用單一 lockfile —— 依賴變更會直接改變 ratewise 實際解析到的依賴樹、bundle 體積與執行期行為，卻完全不會觸發效能守門。

這在 #1034 具體發生了：該 PR 把 `@puppeteer/browsers` 從 2.x 升到 3.0.6（鎖檔淨減 254 行），Lighthouse CI 一次都沒跑。

## 這是既有不一致，不是新政策

**同一份 `ci.yml` 的 E2E paths-filter 早就納入這兩者**：

```yaml
e2e:
  - 'apps/ratewise/**'
  - 'apps/nihonname/**'
  - 'apps/shared/**'
  - 'pnpm-lock.yaml'      # ← 已納入
  - 'package.json'        # ← 已納入
  - '.github/workflows/ci.yml'
```

per-app filter（starpuff / park-keeper / papertrade / split-meow）也都納入 `pnpm-lock.yaml`。只有 Lighthouse 是例外。本 PR 補齊一致性。

## 修改

在 grep 樣式尾端加入兩條**以 `$` 錨定**的規則：

```diff
-|\.lighthouserc\.cjs)'
+|\.lighthouserc\.cjs|package\.json$|pnpm-lock\.yaml$)'
```

`$` 錨定是刻意的：只匹配 repo 根的兩個檔案。`apps/ratewise/package.json` 已由第一條 `^apps/ratewise/` 涵蓋，不需重複。

## 驗證

以 15 個真實路徑案例實測正則行為：

**應觸發（7/7 正確）**
`package.json`、`pnpm-lock.yaml`、`apps/ratewise/src/App.tsx`、`apps/ratewise/package.json`、`.github/workflows/ci.yml`、`.lighthouserc.cjs`、`scripts/lighthouse-production.mjs`

**不應觸發（8/8 正確）**
`apps/starpuff/package.json`、`security-headers/package.json`、`apps/park-keeper/src/pages/Home.tsx`、`docs/dev/002_...md`、`package.json.bak`、`pnpm-lock.yaml.orig`、`README.md`、`.github/workflows/release.yml`

`ci.yml` YAML 解析通過，`lighthouse-changes` 的 outputs 與 `lighthouse` job 的 `if` 條件未變動。

**本 PR 自我驗證**：它修改了 `ci.yml`，因此會命中既有的第三條規則而觸發 Lighthouse CI —— 可直接觀察該 job 是否正常執行。

## 成本

Lighthouse CI 從此會在依賴變更的 PR 上執行（timeout 20 分鐘）。以目前 Dependabot grouping 後的節奏，約每週 1–2 次，換得的是依賴升級造成的效能回歸能被攔一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
