### PR TITLE
fix(ci): Lighthouse 觸發判定改用 three-dot diff 修正誤觸發

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,7 +541,12 @@ jobs:
           #（pnpm workspace 共用單一 lockfile），足以改變 bundle 體積與執行期行為，
           # 故納入觸發條件——E2E 的 paths-filter 早已納入這兩者，此處補齊一致性。
           # 兩者以 $ 錨定為 repo 根檔案；apps/ratewise/package.json 已由第一條規則涵蓋。
-          if git diff --name-only "$BASE" "$HEAD" | grep -Eq '^(apps/ratewise/|scripts/lighthouse-|\.github/workflows/(ci|lighthouse-production)\.yml|\.lighthouserc\.cjs|package\.json$|pnpm-lock\.yaml$)'; then
+          #
+          # 必須用 three-dot（merge-base）而非 two-dot：two-dot 比較的是兩個 commit 的
+          # 端點狀態，會把「PR 開啟後 main 前進」的變更也算成差異。本 repo 每日有匯差 PR
+          # 寫入 apps/ratewise/src/config/generated/，實測 PR #1023（完全未碰 lighthouse
+          # 相關路徑）因此誤觸發並實際執行了 Lighthouse CI。three-dot 只取 PR 自身的變更。
+          if git diff --name-only "$BASE...$HEAD" | grep -Eq '^(apps/ratewise/|scripts/lighthouse-|\.github/workflows/(ci|lighthouse-production)\.yml|\.lighthouserc\.cjs|package\.json$|pnpm-lock\.yaml$)'; then
             echo "lighthouse=true" >> "$GITHUB_OUTPUT"
           else
             echo "lighthouse=false" >> "$GITHUB_OUTPUT"

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -14,6 +14,16 @@
 ## 條目（新→舊）
 
 - 日期：2026-08-23
+- ID：penalty-extended-unvalidated-filter-and-overclaimed-perf-gating
+- 原因：#1036 擴充 Lighthouse path filter 前未驗證該 filter 本身正確——其 `git diff "$BASE" "$HEAD"` 為 two-dot，會把 PR 開啟後 main 前進的變更算成差異而誤觸發；同時 PR 描述宣稱「換得效能回歸能被攔一次」，但 .lighthouserc.cjs 的 categories:performance 是 warn 不是 error，該說法不成立
+- 解法：改為 three-dot 並補守門測試；往後修改既有判定邏輯前，先用真實 SHA 重現其現行行為，且宣稱守門價值前必須先讀斷言等級（warn/error）而非只看斷言存在
+
+- 日期：2026-08-23
+- ID：reward-lighthouse-filter-two-dot-diff-fixed
+- 原因：lighthouse-changes 以 two-dot `git diff "$BASE" "$HEAD"` 判定變更範圍，比較的是兩端點狀態而非 PR 自身 diff；本 repo 每日匯差 PR 持續寫入 apps/ratewise/src/config/generated/，使任何在其後開啟的 PR 都可能誤觸發 Lighthouse CI，觸發行為長期不可預測
+- 解法：改用 three-dot `"$BASE...$HEAD"` 取 merge-base 差異，並以 PR #1023 的真實 BASE/HEAD SHA 重現（two-dot 命中兩個該 PR 未碰的 generated 檔、three-dot 零命中）；補 3 條守門測試並以還原 two-dot 的反向測試確認偵測力
+
+- 日期：2026-08-23
 - ID：penalty-stacked-pr-assumption-broken-by-squash-merge
 - 原因：為避開 002 記分表頭衝突而把 PR 疊在另一個未合併 PR 之上，卻沒考慮本 repo 一律使用 squash merge——上游 PR 合併後其原始 commit 不會進入 main 歷史，疊在其上的分支父 commit 成為孤兒，PR 直接變 DIRTY，反而製造了原本想避免的衝突
 - 解法：改以 origin/main 重建分支並只重新套用自身變更；往後 stacked PR 僅適用於 merge commit 或 rebase merge 的 repo，squash merge 下應直接開在 main 並接受 002 衝突、於 rebase 後手動補跑 verify-002-log.mjs

--- a/scripts/__tests__/lighthouse-production.test.ts
+++ b/scripts/__tests__/lighthouse-production.test.ts
@@ -98,3 +98,29 @@ describe('compareDirection behavioral drift checks', () => {
     expect(isHardThresholdBreached(250, { direction: 'lowerBetter', threshold: 200 })).toBe(true);
   });
 });
+
+describe('Lighthouse CI 觸發判定（ci.yml lighthouse-changes）', () => {
+  const workflow = readFileSync(join(ROOT_DIR, '.github/workflows/ci.yml'), 'utf-8');
+  const filterLine = workflow
+    .split('\n')
+    .find(
+      (line) => line.includes('git diff --name-only') && line.includes('lighthouse-production'),
+    );
+
+  it('存在 lighthouse 觸發判定行', () => {
+    expect(filterLine).toBeDefined();
+  });
+
+  // two-dot 比較兩個 commit 的端點狀態，會把「PR 開啟後 main 前進」的變更算成差異。
+  // 本 repo 每日匯差 PR 寫入 apps/ratewise/，實測 PR #1023 因此誤觸發 Lighthouse CI。
+  it('使用 three-dot（merge-base）而非 two-dot，避免 main 前進造成誤觸發', () => {
+    expect(filterLine).toContain('"$BASE...$HEAD"');
+    expect(filterLine).not.toMatch(/"\$BASE"\s+"\$HEAD"/);
+  });
+
+  it('觸發樣式涵蓋依賴變更，且根檔案以 $ 錨定避免誤中其他 app', () => {
+    expect(filterLine).toContain('package\\.json$');
+    expect(filterLine).toContain('pnpm-lock\\.yaml$');
+    expect(filterLine).toContain('^(apps/ratewise/');
+  });
+});


### PR DESCRIPTION
## 問題

`ci.yml` 的 `lighthouse-changes` job 用這行判定 Lighthouse CI 是否執行：

```bash
git diff --name-only "$BASE" "$HEAD"
```

**two-dot diff 比較的是兩個 commit 的端點狀態，不是 PR 自身的 diff。** 當 main 在 PR 開啟後前進，main 側的變更會被算成差異。

本 repo 每 5 分鐘～每日都有排程 PR 寫入 `apps/ratewise/src/config/generated/`，所以任何 PR 只要開得夠久，就會被 main 的匯差資料污染判定。

## 實測重現

用 PR #1023 的真實 `base.sha` / `head.sha`：

```
BASE=307284412e3c1eea32595867baa338d533fdd624
HEAD=b7a9ed6314fda55aed944e32ce3b34ed5c3a38bc
```

| 寫法 | 命中的檔案 |
|---|---|
| `git diff "$BASE" "$HEAD"`（現行） | `apps/ratewise/src/config/generated/build-time-rates.json`<br>`apps/ratewise/src/config/generated/seo-rate-examples.ts` |
| `git diff "$BASE...$HEAD"`（修正後） | **（無）** |

#1023 只改了 `.github/dependabot.yml`、workflow、CLAUDE.md、README 與 docs —— **完全沒碰任何 lighthouse 相關路徑**，卻因 two-dot 誤觸發並實際執行了 Lighthouse CI。

驗證這不是「skip 被誤讀」：同一個 SHA 上 `E2E Smoke (PR)`、`Security Scan`、`Monitor Dependabot Alerts` 等 6 個 job 都以 `conclusion=skipped` 回報，而 `Lighthouse CI` 是 `conclusion=success` —— 它真的跑了。

## 修改

```diff
-if git diff --name-only "$BASE" "$HEAD" | grep -Eq '...'; then
+if git diff --name-only "$BASE...$HEAD" | grep -Eq '...'; then
```

three-dot 取 merge-base 之後的變更，即 PR 自身的 diff。`fetch-depth: 0` 已存在，merge-base 可解析。

同時補 3 條守門測試（`scripts/__tests__/lighthouse-production.test.ts`）：

- 判定行存在
- 使用 `"$BASE...$HEAD"` 且**不**含 `"$BASE" "$HEAD"`
- 樣式涵蓋依賴變更且根檔案以 `$` 錨定

## 驗證

| 項目 | 結果 |
|---|---|
| 真實 SHA 重現 | two-dot 誤命中 2 檔、three-dot 零命中 |
| 反向測試（改回 two-dot） | 守門正確失敗 |
| `ci.yml` YAML 解析 | 通過（11 jobs） |
| `pnpm test:root` | 7 檔 146 測試通過 |
| pre-commit 六步 | 全綠 |

## 兩點更正

**1. #1036 的宣稱有誤。** 我在該 PR 寫「換得依賴升級造成的效能回歸能被攔一次」——**這是錯的**。`.lighthouserc.cjs` 的 `categories:performance` 是 `warn` 不是 `error`：

```js
'categories:performance': ['warn',  { minScore: 0.95 }],   // ← 不會失敗
'categories:seo':         ['error', { minScore: 0.98 }],
'categories:accessibility':['error',{ minScore: 0.95 }],
'cumulative-layout-shift':['error', { maxNumericValue: 0.1 }],
```

Lighthouse CI 實際守的是 **SEO / a11y / CLS**，不是效能分數。

**2. #1036 擴充了一個我沒先驗證過的 filter。** 本 PR 是補上那次遺漏的驗證。已記入 002（`penalty-extended-unvalidated-filter-and-overclaimed-perf-gating`）。

## 後續（本 PR 不做）

若要讓 Lighthouse CI 成為真正的守門，還需兩個獨立決策：

1. `categories:performance` 是否從 `warn` 提到 `error`
2. 是否將 `Lighthouse CI` 加入 branch protection 的 required checks（技術上安全——job-level `if:` 跳過會回報 Success，且 `ci.yml` 無 `on.paths` 過濾，不會卡住 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
