### PR TITLE
fix(ci): MoneyBox 上游停供改為可診斷錯誤並加入中斷升級節流

### DIFF
--- a/.github/workflows/update-moneybox-rates.yml
+++ b/.github/workflows/update-moneybox-rates.yml
@@ -30,6 +30,8 @@ jobs:
 
     permissions:
       contents: write
+      # 持續中斷時建立／更新／關閉 outage 追蹤 issue（見 staleness gate 的升級節流）。
+      issues: write
 
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -90,6 +92,22 @@ jobs:
         run: |
           echo "🔄 Fetching latest exchange rates from MoneyBox (明洞換匯所)..."
           node scripts/fetch-moneybox-rates.js
+
+      # 恢復後必須關閉追蹤 issue：否則它會永久 open，使下一次中斷從第一次執行就被節流，
+      # 失去「首次偵測大聲失敗」的曝光。關閉失敗不阻斷本次資料更新。
+      - name: Close outage tracking issue on recovery
+        if: steps.fetch-rates.outcome == 'success'
+        env:
+          OUTAGE_LABEL: 'outage:moneybox'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        run: |
+          ISSUE_NUMBER="$(gh issue list --state open --label "$OUTAGE_LABEL" \
+            --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue close "$ISSUE_NUMBER" \
+              --comment "上游已恢復：本次抓取成功（run ${GITHUB_RUN_ID}），自動關閉。"
+          fi
 
       - name: Save MoneyBox daily history snapshot
         id: save-history
@@ -359,10 +377,19 @@ jobs:
       # 健康狀態下每日 rollover 至少寫一次、timestamp 最舊約 24h，30h 額外容忍時差與排程延遲。
       # fetch 失敗的 summary 統一由本 step 輸出（transient / persistent 兩種），
       # 不得另設宣稱「一切正常」的 API-failure summary step 掩蓋紅燈語意。
+      #
+      # 升級節流（2026-08-23）：本 workflow 每 5 分鐘執行一次（288 次/日），持續性中斷時
+      # 每一次都失敗會產生 288 筆同質失敗通知，實際降低了事故的可見度（alert fatigue）。
+      # 改為以 GitHub issue 作為持久信號，並每 ESCALATION_INTERVAL_HOURS 才紅一次。
+      # 這不是綠燈掩蓋：中斷期間仍有常駐 open issue + 每小時一次 workflow 失敗。
+      # 任何 gh 查詢失敗一律 fallback 到 exit 1——fail-safe 方向只會更常失敗，不會更少。
       - name: Data staleness gate (fail on persistent outage)
         if: steps.fetch-rates.outcome != 'success'
         env:
           STALENESS_THRESHOLD_HOURS: '30'
+          ESCALATION_INTERVAL_HOURS: '1'
+          OUTAGE_LABEL: 'outage:moneybox'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           AGE_HOURS=$(node -e "
             const { readFileSync } = require('fs');
@@ -386,8 +413,62 @@ jobs:
             echo "## ❌ Persistent outage detected" >> $GITHUB_STEP_SUMMARY
             echo "MoneyBox rates have been stale for over ${STALENESS_THRESHOLD_HOURS}h — manual investigation required." >> $GITHUB_STEP_SUMMARY
             echo "Check whether the MoneyBox API endpoint or response format changed." >> $GITHUB_STEP_SUMMARY
-            echo "::error::MoneyBox exchange rates stale for ${AGE_HOURS}h and fetch failed"
-            exit 1
+
+            # 標籤冪等建立；失敗不阻斷（後續查詢失敗才是硬失敗）。
+            gh label create "$OUTAGE_LABEL" --color 'B60205' \
+              --description 'MoneyBox 匯率來源持續中斷' --force || true
+
+            # 查既有 open 追蹤 issue。查詢本身失敗 → fail-safe 走 exit 1。
+            if ! ISSUE_JSON="$(gh issue list --state open --label "$OUTAGE_LABEL" \
+              --limit 1 --json number,updatedAt)"; then
+              echo "::error::Cannot query outage tracking issue; escalating (fail-safe)"
+              exit 1
+            fi
+
+            ISSUE_NUMBER="$(echo "$ISSUE_JSON" | jq -r '.[0].number // empty')"
+
+            if [ -z "$ISSUE_NUMBER" ]; then
+              # 首次偵測：建立常駐追蹤 issue，並讓本次 run 失敗（大聲曝光一次）。
+              # body 以 --body-file 傳入：多行字串直接寫在 YAML block scalar 內會頂到第 0 欄而破壞縮排。
+              BODY_FILE="$(mktemp)"
+              {
+                echo "自動偵測：committed \`latest.json\` 已 ${AGE_HOURS}h 未更新（門檻 ${STALENESS_THRESHOLD_HOURS}h），且抓取持續失敗。"
+                echo ""
+                echo "- API: https://cems.moneybox.or.kr/api/cmd.php?cmd=C011"
+                echo "- 首次偵測 run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                echo ""
+                echo "中斷期間本 workflow 每 ${ESCALATION_INTERVAL_HOURS}h 失敗一次並在此留言更新資料年齡。"
+                echo "上游恢復後由 workflow 自動關閉本 issue。"
+              } > "$BODY_FILE"
+              gh issue create --label "$OUTAGE_LABEL" --label 'severity:p1' \
+                --title "[outage] MoneyBox 匯率來源持續停更" \
+                --body-file "$BODY_FILE" || true
+              echo "::error::MoneyBox exchange rates stale for ${AGE_HOURS}h and fetch failed"
+              exit 1
+            fi
+
+            echo "- Tracking issue: #${ISSUE_NUMBER}" >> $GITHUB_STEP_SUMMARY
+
+            UPDATED_AT="$(echo "$ISSUE_JSON" | jq -r '.[0].updatedAt // empty')"
+            SINCE_HOURS="$(node -e "
+              const updatedAt = process.argv[1];
+              const parsed = updatedAt ? Date.parse(updatedAt) : NaN;
+              // 無法解析 → 回 999 使其落入升級分支（fail-safe）。
+              console.log(Number.isNaN(parsed) ? 999 : Math.floor((Date.now() - parsed) / 3600000));
+            " "$UPDATED_AT")"
+
+            if [ "$SINCE_HOURS" -ge "$ESCALATION_INTERVAL_HOURS" ]; then
+              gh issue comment "$ISSUE_NUMBER" \
+                --body "仍未恢復：\`latest.json\` 已 ${AGE_HOURS}h 未更新（run ${GITHUB_RUN_ID}）。" || true
+              echo "::error::MoneyBox exchange rates stale for ${AGE_HOURS}h and fetch failed"
+              exit 1
+            fi
+
+            # 節流視窗內：不重複紅燈，但事故仍由 open issue 常駐曝光。
+            echo "## ⏳ Outage already escalated" >> $GITHUB_STEP_SUMMARY
+            echo "Tracked in #${ISSUE_NUMBER} (last escalated ${SINCE_HOURS}h ago); next escalation in <= ${ESCALATION_INTERVAL_HOURS}h." >> $GITHUB_STEP_SUMMARY
+            echo "::warning::MoneyBox outage ongoing (${AGE_HOURS}h stale), throttled — see issue #${ISSUE_NUMBER}"
+            exit 0
           fi
 
           echo "## Transient failure tolerated" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,10 @@ gh pr merge <PR_NUMBER> --squash --delete-branch=false
 
 **台銀牌告匯率停更（bot challenge）**：`rate.bot.com.tw` 對非瀏覽器請求回傳 Challenge Validation HTML（2026-06-29 起），純 fetch 與 headless/Playwright request context 均被擋。修法：direct fetch 偵測 challenge 後改走 `scripts/fetch-taiwan-bank-rates-browser.mjs`（xvfb headed Chrome，於頁面內 fetch CSV 沿用瀏覽器指紋），再以 `CSV_INPUT_FILE` 模式解析寫檔；抓取全數失敗且 latest.json 超過 6 小時未更新時 workflow 必須 fail 曝光事故，禁止綠燈掩蓋持續停更。
 
+**MoneyBox `sell` 欄位全面回 0（上游停供）**：`cems.moneybox.or.kr` 自 2026-08-22 起對多數幣別回傳 `"sell": "0.0000"`（`parseFloat(...) || null` 會轉成 `null`）。腳本先判「上游停供」再判 TWD 個別數值，錯誤訊息為 `Upstream sell-quote outage: only N/M currencies carry a positive sell rate`；**不得**為了讓 CI 變綠而放寬 `TWD_SELL_MIN/MAX` 或由 `spbuy`／`spsell` 推導 `sell`——那等於對使用者輸出捏造的匯率。
+
+**排程資料 workflow 的持續中斷升級節流（SSOT）**：高頻排程（MoneyBox 每 5 分鐘、288 次/日）在持續中斷時若每次都 fail，會產生同質失敗通知洪水而降低事故可見度。標準做法是**以 GitHub issue 作為持久信號**：首次偵測建立帶 `outage:*` 標籤的 issue 並 fail；其後每 `ESCALATION_INTERVAL_HOURS` 才留言＋fail 一次，節流視窗內輸出 `::warning::` 並 `exit 0`；抓取恢復時由 workflow 自動關閉該 issue。**此節流不等於綠燈掩蓋**——中斷期間必須同時存在常駐 open issue 與週期性紅燈，兩者缺一即回到原本「每次都 fail」的行為。所有 issue 查詢失敗一律 fallback 到 `exit 1`（fail-safe 只能更常失敗，不能更少）。恢復時未關閉 issue 會使下一次中斷從第一次執行就被節流，失去首次曝光，故自動關閉是必要環節而非優化。
+
 **Release workflow 顯示 success 但沒有語意升版**：先查 `.changeset/*.md` 是否仍存在，再查 release run log。若 `Create Release Pull Request` 在 `git commit` 階段被 commitlint 擋下，將 `changesets/action` 的 `commit` / `title` 改為 `chore(release): 更新版本套件`，且失敗回報步驟必須 `exit 1`，避免 release PR 未建立卻顯示綠燈。
 
 **Release workflow 卡在 Create release tags**：取消卡住 run 後檢查是否在 CI 內呼叫 `pnpm changeset tag`，或 tag push 是否觸發 `.husky/pre-push`。修法是移除互動式 changeset tag 呼叫，改由 `scripts/get-release-metadata.mjs --changed` 顯式輸出 package tag 與 app tag，先驗證 `git check-ref-format`，再用完整 refspec 一次推送全部 tag；CI tag push 必須設定 `HUSKY=0` 並為步驟設定 timeout。

--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+0（reward 1、penalty 1、neutral 0）｜累計總分：+322
+> 本次分數變化：+2（reward 2、penalty 0、neutral 0）｜累計總分：+324
 
 ## 新增模板（4 行）
 
@@ -22,6 +22,16 @@
 - ID：reward-lighthouse-filter-two-dot-diff-fixed
 - 原因：lighthouse-changes 以 two-dot `git diff "$BASE" "$HEAD"` 判定變更範圍，比較的是兩端點狀態而非 PR 自身 diff；本 repo 每日匯差 PR 持續寫入 apps/ratewise/src/config/generated/，使任何在其後開啟的 PR 都可能誤觸發 Lighthouse CI，觸發行為長期不可預測
 - 解法：改用 three-dot `"$BASE...$HEAD"` 取 merge-base 差異，並以 PR #1023 的真實 BASE/HEAD SHA 重現（two-dot 命中兩個該 PR 未碰的 generated 檔、three-dot 零命中）；補 3 條守門測試並以還原 two-dot 的反向測試確認偵測力
+
+- 日期：2026-08-23
+- ID：reward-moneybox-upstream-outage-diagnosable-error
+- 原因：上游對 18/20 幣別回傳 sell="0.0000"，經 `parseFloat(...) || null` 轉成 null 後只被 TWD.sell 區間檢查攔下，錯誤訊息「TWD.sell null is outside plausible range 30-70」讀起來像 TWD 單一幣別數值異常，會把後續除錯導向錯誤方向
+- 解法：在 TWD 檢查之前加入上游停供偵測（正 sell 幣別佔比 < 50% 即判定 source-side outage），錯誤訊息明確報出 N/M 比例與查證入口；以真實上游 payload 驗證輸出為 only 2/20，並補正反兩向單元測試
+
+- 日期：2026-08-23
+- ID：reward-moneybox-outage-escalation-throttle
+- 原因：workflow 每 5 分鐘執行（288 次/日），持續中斷時每次都 fail 產生同質失敗通知洪水，反而降低事故可見度；但直接改成 exit 0 會違反「禁止綠燈掩蓋持續停更」的既有治理規則
+- 解法：改以 outage issue 作持久信號——首次偵測建 issue 並 fail、其後每小時留言＋fail 一次、節流視窗內僅 warning，恢復時自動關閉 issue；所有 issue 查詢失敗一律 fallback exit 1，並以 stub gh 模擬六個分支（含兩條 fail-safe）驗證後同步更新 CLAUDE.md 治理條文
 
 - 日期：2026-08-23
 - ID：penalty-stacked-pr-assumption-broken-by-squash-merge

--- a/scripts/__tests__/fetch-moneybox-rates.test.ts
+++ b/scripts/__tests__/fetch-moneybox-rates.test.ts
@@ -87,6 +87,30 @@ describe('fetch-moneybox-rates / assertMoneyBoxRatesIntegrity', () => {
     );
   });
 
+  it('上游對多數幣別停供 sell（回傳 0）時，報為來源停供而非 TWD 個案異常', () => {
+    // 2026-08-22 實際事故：上游對 18/20 幣別回傳 "0.0000"，parseFloat 後經 `|| null` 轉成 null。
+    const rates = makeMoneyBoxRates(20);
+    for (const [code, rate] of Object.entries(rates)) {
+      if (code !== 'CAD') rate.sell = null;
+    }
+
+    expect(() => assertMoneyBoxRatesIntegrity(rates, null)).toThrow(/Upstream sell-quote outage/);
+    // 不得再誤報成 TWD 單一幣別的數值區間問題
+    expect(() => assertMoneyBoxRatesIntegrity(rates, null)).not.toThrow(
+      /TWD\.sell sanity circuit breaker/,
+    );
+  });
+
+  it('少數幣別缺 sell 時不誤判為上游停供，仍走既有的 TWD 檢查', () => {
+    const rates = makeMoneyBoxRates(20);
+    for (const code of ['C01', 'C02']) {
+      const rate = rates[code];
+      if (rate) rate.sell = null;
+    }
+
+    expect(() => assertMoneyBoxRatesIntegrity(rates, null)).not.toThrow();
+  });
+
   it('TWD.sell 超出 30-70 KRW/TWD 合理區間時拋出 AbortError', () => {
     expect(() => assertMoneyBoxRatesIntegrity(makeMoneyBoxRates(10, 4.59), null)).toThrow(
       /TWD\.sell sanity circuit breaker/,

--- a/scripts/fetch-moneybox-rates.js
+++ b/scripts/fetch-moneybox-rates.js
@@ -33,6 +33,10 @@ const TWD_SELL_MIN = 30;
 const TWD_SELL_MAX = 70;
 // 突變熔斷預設閾值：TWD.sell 單次變動超過 15% 視為垃圾資料（可由 env 覆寫）。
 const DEFAULT_MUTATION_THRESHOLD = 0.15;
+// 上游停供 sell 報價的偵測門檻：健康狀態下 20 種幣別全數帶正的 sell。
+// 2026-08-22 起上游對 18/20 幣別回傳 "0.0000"（parseFloat 後經 `|| null` 轉成 null）。
+// 若只靠 TWD.sell 檢查，錯誤訊息會誤導成「TWD 單一幣別數值異常」，讓後續除錯往錯的方向查。
+const SELL_QUOTE_MIN_RATIO = 0.5;
 
 class AbortError extends Error {
   constructor(message, status) {
@@ -222,6 +226,18 @@ function assertMoneyBoxRatesIntegrity(
   if (currencyCount < minCurrencyCount) {
     throw new AbortError(
       `Currency count circuit breaker: parsed ${currencyCount} currencies (< ${minCurrencyCount}); refusing to write suspicious data`,
+    );
+  }
+
+  // 先判上游全面停供，再判單一幣別數值——否則系統性事故會被報成 TWD 個案而誤導除錯方向。
+  const quotedSellCount = Object.values(newRates ?? {}).filter(
+    (rate) => typeof rate?.sell === 'number' && rate.sell > 0,
+  ).length;
+  if (quotedSellCount < currencyCount * SELL_QUOTE_MIN_RATIO) {
+    throw new AbortError(
+      `Upstream sell-quote outage: only ${quotedSellCount}/${currencyCount} currencies carry a positive sell rate ` +
+        `(upstream returns "0.0000"); this is a source-side outage, not a per-currency anomaly. ` +
+        `Verify https://cems.moneybox.or.kr/ before touching sanity thresholds; refusing to write suspicious data`,
     );
   }
 


### PR DESCRIPTION
## 事故現況

`Update MoneyBox Exchange Rates` 自 2026-08-23 06:16Z 起持續失敗（[run 32646042935](https://github.com/haotool/app/actions/runs/32646042935)）。

**根因不在我們這側，也不是 CI 設定問題**：上游 `cems.moneybox.or.kr` 自 2026-08-22 首爾時間約 09:00 起，對 **18/20 幣別**回傳 `"sell": "0.0000"`。

```json
{"currency":"TWD","base":"43.59","buy":"43.5000","sell":"0.0000","spbuy":"49.30","spsell":"39.24"}
```

只有 CAD 與 GFT 例外，而 CAD 的值與 38 小時前的快照**完全相同** —— 是殘留而非新報價。

已排除「週末休市」假設：

| 日期 | 星期 | `sell` 為 0 的幣別 |
|---|---|---|
| 08-08 / 08-09 | Sat / Sun | 0/20 |
| 08-15 / 08-16 | Sat / Sun | 0/20 |
| **08-22 起** | Sat | **18/20** |

**熔斷與 staleness gate 都按設計正確運作，沒有東西壞掉。** 本 PR 修的是兩個被這次事故暴露出來的缺陷。

## 缺陷 A：錯誤訊息會誤導除錯方向

`parseFloat("0.0000") || null` 把 0 轉成 `null`，於是只被 TWD 區間檢查攔下：

```
TWD.sell sanity circuit breaker: null is outside plausible range 30-70 KRW/TWD
```

讀起來像 TWD 單一幣別的數值異常，實際是上游對 18 個幣別集體停供。下一個接手的人會往錯的方向查，甚至可能誤以為調寬 `TWD_SELL_MIN/MAX` 就能解決。

**修法**：在 TWD 檢查**之前**加入上游停供偵測（正 `sell` 幣別佔比 < 50%）。以真實上游 payload 驗證輸出：

```
Upstream sell-quote outage: only 2/20 currencies carry a positive sell rate
(upstream returns "0.0000"); this is a source-side outage, not a per-currency anomaly.
Verify https://cems.moneybox.or.kr/ before touching sanity thresholds
```

> **明確不做**：不放寬 `TWD_SELL_MIN/MAX`，也不由 `spbuy` / `spsell` 推導 `sell`。這是匯率工具，推導出來的數字會被使用者當成真實報價帶去換錢。守門擋下壞資料是正確行為，不該為了讓 CI 變綠而拆掉它。此立場已寫入 CLAUDE.md。

## 缺陷 B：288 次/日的同質失敗反而降低可見度

cron 是 `4,9,14,...,59 * * * *` —— 每 5 分鐘一次、**每日 288 次**，持續中斷時全數失敗。這種通知洪水造成 alert fatigue，實際效果與被忽略無異。

但直接改成 `exit 0` 會違反 workflow 內既有的明文規則：「**禁止用綠燈掩蓋持續性故障**」。

**修法**：以 GitHub issue 作為持久信號，週期性紅燈保留。

| 情境 | 行為 |
|---|---|
| 暫時性失敗（age < 30h） | 容忍，`exit 0`（原有行為不變） |
| 持續中斷 + 無追蹤 issue | 建立 `outage:moneybox` issue → **`exit 1`** |
| 持續中斷 + issue ≥1h 未更新 | 留言更新資料年齡 → **`exit 1`** |
| 持續中斷 + issue <1h 內更新 | `::warning::` + `exit 0`（節流） |
| **issue 查詢失敗** | **`exit 1`**（fail-safe） |
| **`latest.json` 無法解析** | age=999 → **`exit 1`** |
| 抓取恢復 | 自動關閉追蹤 issue |

**這不是綠燈掩蓋**：中斷期間同時存在常駐 open issue **與**每小時一次的 workflow 失敗，兩者缺一即回到原本每次都 fail 的行為。失敗數從 288/日降到 24/日，紅燈依然不可能被忽略。

**恢復時自動關閉 issue 是必要環節而非優化**：若不關閉，issue 會永久 open，使下一次中斷從第一次執行就被節流，失去「首次偵測大聲曝光」。

**fail-safe 方向**：所有 issue 查詢失敗一律 fallback 到 `exit 1` —— 這段程式碼的 bug 只會讓它更常失敗，不會更少。

## 驗證

失敗路徑平常觀察不到，所以用 stub `gh` 做分支模擬：

```
✅ 暫時性失敗（age 5h < 30h）→ 容忍                exit=0
✅ 持續中斷 + 無追蹤 issue → 建 issue 並失敗        exit=1（CREATE_CALLED）
✅ 持續中斷 + issue 3h 前更新 → 留言並失敗          exit=1（COMMENT_CALLED）
✅ 持續中斷 + issue 10 分鐘前更新 → 節流不重複紅燈   exit=0
✅ gh 查詢失敗 → fail-safe 升級                    exit=1
✅ latest.json 無法解析（age=999）→ 升級            exit=1
```

| 其他項目 | 結果 |
|---|---|
| 以真實上游 payload 驗證 A 的訊息 | `only 2/20` ✓ |
| 新增單元測試（正向 + 反向） | 通過 |
| `bash -n` 兩個新／改動 step | 通過 |
| workflow YAML 解析 | 通過 |
| `pnpm test:root` | 7 檔 148 測試通過 |

## 文件同步

依 Documentation Sync Map 更新 `CLAUDE.md`：新增「MoneyBox `sell` 欄位全面回 0」故障排除條目，以及「排程資料 workflow 的持續中斷升級節流（SSOT）」治理條文 —— 後者明確界定節流與綠燈掩蓋的差別，避免日後被當成放寬守門的先例。

## 尚未解決

**上游仍未恢復**（撰寫時仍為 18/20 幣別 `sell=0`）。本 PR 不會讓 workflow 變綠，也不應該 —— 它只讓事故變得可診斷、可追蹤，且不再淹沒通知。正式站目前仍提供週六早上的 MoneyBox 匯率，是否要對使用者揭露資料年齡是獨立的產品決策，未包含在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
