### PR TITLE
fix(ci): MoneyBox 遷移至新 endpoint 並修正欄位反轉與單位差

### DIFF
--- a/docs/dev/002_development_reward_penalty_log.md
+++ b/docs/dev/002_development_reward_penalty_log.md
@@ -2,7 +2,7 @@
 
 > 版本：outline-v2-ultra
 > 原則：每筆只保留日期、ID、原因、解法。
-> 本次分數變化：+5（reward 5、penalty 0、neutral 1）｜累計總分：+332
+> 本次分數變化：+0（reward 1、penalty 1、neutral 0）｜累計總分：+332
 
 ## 新增模板（4 行）
 
@@ -12,6 +12,16 @@
 - 解法：<一句話修正>
 
 ## 條目（新→舊）
+
+- 日期：2026-08-26
+- ID：penalty-per100-rescale-introduced-float-noise
+- 原因：將上游 per-1 報價還原為既有 per-100 慣例時直接乘 100，使 8.72×100 得 872.0000000000001、0.056×100 得 5.6000000000000005，中點 (42.15+42.3)/2 得 42.224999999999994——這些值上游原本直接提供且乾淨，我的換算反而讓公開產物出現浮點雜訊
+- 解法：以輸入位數推導輸出位數收斂（×100 減兩位、中點取較多者加一位），並補守門測試斷言輸出字串不得含浮點尾數；完整 decimal 算術遷移仍列 PR 2
+
+- 日期：2026-08-26
+- ID：reward-moneybox-endpoint-migration-with-inversion-guard
+- 原因：MoneyBox 遷移至自有 endpoint 且 buy/sell 語意與舊 API 相反，照字面把 sell 對到 sellRate 會取到價差的錯誤那一側；舊 endpoint 半殘（回 200 但 sell 恆 0）使純 API 探測無法察覺搬家
+- 解法：改打新 endpoint 並以具名常數表達反向對應，補 9 條守門測試涵蓋映射方向、價差方向、per-100 還原、0 與非有限值處理；以反轉映射的反向測試確認守門會擋，並驗證對外欄位集合零變化
 
 - 日期：2026-08-26
 - ID：reward-starpuff-shelly-guidance-event

--- a/scripts/__tests__/fetch-moneybox-rates.test.ts
+++ b/scripts/__tests__/fetch-moneybox-rates.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assertMoneyBoxRatesIntegrity,
+  deriveMidpoint,
+  mapUpstreamRow,
   shouldRefreshLatestSnapshot,
+  toLegacyQuoteUnit,
 } from '../fetch-moneybox-rates.js';
 
 const baseRates = {
@@ -131,5 +134,77 @@ describe('fetch-moneybox-rates / assertMoneyBoxRatesIntegrity', () => {
 
   it('舊檔不存在（previousRates=null）時跳過突變檢查', () => {
     expect(() => assertMoneyBoxRatesIntegrity(makeMoneyBoxRates(10, 60.5), null)).not.toThrow();
+  });
+});
+
+describe('fetch-moneybox-rates / 新 API 欄位對應（PRD 049 §2.2）', () => {
+  it('legacy sell 來自上游 buyRate、legacy buy 來自上游 sellRate——語意相反不可照字面對接', () => {
+    const mapped = mapUpstreamRow({ currencyCode: 'TWD', buyRate: 42.15, sellRate: 42.3 });
+
+    expect(mapped).not.toBeNull();
+    const [code, quote] = mapped!;
+    expect(code).toBe('TWD');
+    // 換匯所買入 TWD ＝ 旅客持 TWD 換 KRW 的到手匯率 ＝ 我方 sell
+    expect(quote.sell).toBe(42.15);
+    expect(quote.buy).toBe(42.3);
+    // 反向對接會取到價差的錯誤那一側
+    expect(quote.sell).not.toBe(42.3);
+  });
+
+  it('價差方向維持 sell < buy（店家低買高賣）', () => {
+    const [, quote] = mapUpstreamRow({ currencyCode: 'TWD', buyRate: 42.15, sellRate: 42.3 })!;
+
+    expect(quote.sell!).toBeLessThan(quote.buy!);
+  });
+
+  it('上游無 base / spbuy / spsell：base 由兩側中點推導，其餘一律 null 不得填補', () => {
+    const [, quote] = mapUpstreamRow({ currencyCode: 'TWD', buyRate: 42.15, sellRate: 42.3 })!;
+
+    expect(quote.base).toBe(42.225);
+    expect(quote.spbuy).toBeNull();
+    expect(quote.spsell).toBeNull();
+  });
+
+  it('0 與非有限值視為上游未報價（null），不得當成有效匯率', () => {
+    const [, zero] = mapUpstreamRow({ currencyCode: 'USD', buyRate: 0, sellRate: 0 })!;
+    expect(zero.sell).toBeNull();
+    expect(zero.buy).toBeNull();
+    expect(zero.base).toBeNull();
+
+    const [, nan] = mapUpstreamRow({ currencyCode: 'USD', buyRate: 'x', sellRate: null })!;
+    expect(nan.sell).toBeNull();
+    expect(nan.buy).toBeNull();
+  });
+
+  it('缺 currencyCode 的列被丟棄', () => {
+    expect(mapUpstreamRow({ buyRate: 1, sellRate: 2 })).toBeNull();
+    expect(mapUpstreamRow({ currencyCode: '  ', buyRate: 1, sellRate: 2 })).toBeNull();
+  });
+});
+
+describe('fetch-moneybox-rates / per-100 單位還原（PRD 049 §2.3）', () => {
+  it('JPY / IDR / VND 由上游 per-1 還原為既有 per-100 慣例', () => {
+    expect(toLegacyQuoteUnit('JPY', 8.72)).toBe(872);
+    expect(toLegacyQuoteUnit('IDR', 0.09)).toBe(9);
+    expect(toLegacyQuoteUnit('VND', 0.056)).toBe(5.6);
+  });
+
+  it('其餘幣別不縮放', () => {
+    expect(toLegacyQuoteUnit('TWD', 42.15)).toBe(42.15);
+    expect(toLegacyQuoteUnit('USD', 1383)).toBe(1383);
+  });
+
+  // 8.72 * 100 在 JS 得 872.0000000000001；(42.15+42.3)/2 得 42.224999999999994。
+  // 上游原本直接提供乾淨值，換算後若不收斂會使公開產物出現浮點雜訊。
+  it('換算結果不得帶二進位浮點雜訊', () => {
+    expect(String(toLegacyQuoteUnit('JPY', 8.72))).toBe('872');
+    expect(String(toLegacyQuoteUnit('VND', 0.056))).toBe('5.6');
+    expect(String(deriveMidpoint(42.3, 42.15))).toBe('42.225');
+    expect(String(deriveMidpoint(872, 868))).toBe('870');
+  });
+
+  it('中點在任一側缺報價時為 null', () => {
+    expect(deriveMidpoint(null, 42.15)).toBeNull();
+    expect(deriveMidpoint(42.3, null)).toBeNull();
   });
 });

--- a/scripts/fetch-moneybox-rates.d.ts
+++ b/scripts/fetch-moneybox-rates.d.ts
@@ -48,3 +48,12 @@ export function assertMoneyBoxRatesIntegrity(
   options?: { minCurrencyCount?: number; mutationThreshold?: number },
 ): void;
 export function resolveMutationThreshold(env?: Record<string, string | undefined>): number;
+
+/** 將新 API 的一列轉為 legacy 欄位結構；無效列回傳 null。 */
+export function mapUpstreamRow(item: unknown): [string, MoneyBoxRateQuote] | null;
+
+/** 將上游每 1 單位報價還原為既有 per-100 慣例（僅 JPY/IDR/VND）。 */
+export function toLegacyQuoteUnit(code: string, value: number | null): number | null;
+
+/** 兩側牌告價的算術中點。 */
+export function deriveMidpoint(buy: number | null, sell: number | null): number | null;

--- a/scripts/fetch-moneybox-rates.js
+++ b/scripts/fetch-moneybox-rates.js
@@ -1,6 +1,6 @@
 /**
  * 明洞換匯所（MoneyBox）匯率抓取腳本
- * 資料來源: https://cems.moneybox.or.kr/api/cmd.php?cmd=C011&key=U1D8I4W7V6S1L3U4F3I4
+ * 資料來源: https://moneybox-exchange.com/api/rates（2026-08 上游遷移，見 PRD 049 §2.1）
  * 更新頻率: 每5分鐘（由 GitHub Actions cron 觸發，見 .github/workflows/update-moneybox-rates.yml）
  */
 
@@ -48,9 +48,19 @@ class AbortError extends Error {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// MoneyBox 公開 API（韓國官方換匯所聯盟）
-const MONEYBOX_API_URL =
-  'https://cems.moneybox.or.kr/api/cmd.php?cmd=C011&key=U1D8I4W7V6S1L3U4F3I4';
+// MoneyBox 公開 API。
+// 2026-08 上游遷移：官網已完全改打自有 endpoint，舊 cems.moneybox.or.kr 雖仍回 200
+// 但 18/20 幣別的 sell 恆為 0（半殘）。以瀏覽器攔截官網請求確認新端點（PRD 049 §2.1）。
+const MONEYBOX_API_URL = 'https://moneybox-exchange.com/api/rates';
+
+// 新舊 API 的 buy/sell 語意**相反**：新 buyRate ≡ 舊 sell、新 sellRate ≡ 舊 buy。
+// 以官網買入/賣出欄位對照與價差方向三重驗證（PRD 049 §2.2）。
+// 照字面把 sell 對到 sellRate 會取到價差的錯誤那一側。
+const NEW_TO_LEGACY_FIELD = Object.freeze({ sell: 'buyRate', buy: 'sellRate' });
+
+// 舊 API 對小面額幣別採每 100 單位報價，新 API 一律每 1 單位。
+// 維持既有 per-100 慣例以保歷史資料連續（PRD 049 §2.3 / §4.1 軌道 A）。
+const PER_100_CURRENCIES = Object.freeze(new Set(['JPY', 'IDR', 'VND']));
 
 function writeCurrentFetchSnapshot(ratesData) {
   const output = process.env.MONEYBOX_FETCH_OUTPUT_FILE;
@@ -81,15 +91,76 @@ function isRetryableError(error) {
 }
 
 /**
- * 從 MoneyBox API 抓取所有貨幣匯率（帶重試機制）
- * 回應格式：{ result: true, data: [{ currency, base, buy, sell, spbuy, spsell }] }
- * - currency: 外幣代碼（如 "TWD"）
- * - base: 標準牌告中間價（1 KRW = X currency）
- * - buy: 換匯所買入價（客戶賣出，即客戶持外幣換 KRW 的匯率）
- * - sell: 換匯所賣出價（客戶買入，即客戶持外幣換取 KRW 的實際到手匯率）
- * - spbuy/spsell: 特殊買賣價（高額換匯）
+ * 二進位浮點防護：`8.72 * 100` 得 `872.0000000000001`、`(42.15+42.3)/2` 得
+ * `42.224999999999994`。上游原本直接提供這些值且乾淨，換算後若不收斂會使公開產物
+ * 出現浮點雜訊。此處以輸入位數推導輸出位數；完整 decimal 算術遷移見 PRD 049 §18.4（PR 2）。
+ */
+function countDecimals(value) {
+  const text = String(value);
+  const dot = text.indexOf('.');
+  return dot === -1 ? 0 : text.length - dot - 1;
+}
+
+function roundTo(value, decimals) {
+  return Number(value.toFixed(Math.max(0, Math.min(12, decimals))));
+}
+
+/** 將上游每 1 單位報價還原為既有的 per-100 慣例（僅 JPY/IDR/VND）。 */
+function toLegacyQuoteUnit(code, value) {
+  if (value === null) return null;
+  if (!PER_100_CURRENCIES.has(code)) return value;
+  // ×100 使小數點左移兩位，故輸出位數為輸入位數減 2
+  return roundTo(value * 100, countDecimals(value) - 2);
+}
+
+/** 兩側牌告價的算術中點；位數取兩者較多者加 1，避免除以 2 產生無盡尾數。 */
+function deriveMidpoint(buy, sell) {
+  if (buy === null || sell === null) return null;
+  return roundTo((buy + sell) / 2, Math.max(countDecimals(buy), countDecimals(sell)) + 1);
+}
+
+/**
+ * 將新 API 的一列轉為既有 legacy 欄位結構。
  *
- * 對台灣旅客而言：持 TWD 現金換 KRW，適用 sell 欄位（46.5 表示 1 TWD 可換 46.5 KRW）
+ * 新 API 每列僅 `currencyCode` / `buyRate` / `sellRate`，無 base 與 spbuy/spsell：
+ * - `base` 改由兩側牌告價的算術中點推導（上游不再提供市場參考價）
+ * - `spbuy` / `spsell` 上游已無此概念，一律 null——不得以其他欄位推導填補
+ */
+function mapUpstreamRow(item) {
+  const code = typeof item?.currencyCode === 'string' ? item.currencyCode.trim() : '';
+  if (!code) return null;
+
+  const readRate = (field) => {
+    const parsed = Number.parseFloat(item?.[field]);
+    // 0 與非有限值皆視為「上游未報價」，交由熔斷判定，不可當成有效匯率
+    return Number.isFinite(parsed) && parsed > 0 ? toLegacyQuoteUnit(code, parsed) : null;
+  };
+
+  const sell = readRate(NEW_TO_LEGACY_FIELD.sell);
+  const buy = readRate(NEW_TO_LEGACY_FIELD.buy);
+
+  return [
+    code,
+    {
+      currency: code,
+      base: deriveMidpoint(buy, sell),
+      buy,
+      sell,
+      spbuy: null,
+      spsell: null,
+    },
+  ];
+}
+
+/**
+ * 從 MoneyBox API 抓取所有貨幣匯率（帶重試機制）
+ * 回應格式：{ success: true, data: { publishedAt, rates: [{ currencyCode, buyRate, sellRate }] } }
+ *
+ * 欄位對應（**語意相反，勿照字面對接**）：
+ * - legacy `sell` ← 上游 `buyRate`（換匯所買入外幣＝旅客持外幣換 KRW 的到手匯率）
+ * - legacy `buy`  ← 上游 `sellRate`（換匯所賣出外幣）
+ *
+ * 對台灣旅客而言：持 TWD 現金換 KRW，適用 sell 欄位（42.15 表示 1 TWD 可換 42.15 KRW）
  */
 async function fetchMoneyBoxRates() {
   console.log('🔄 Fetching exchange rates from MoneyBox (明洞換匯所)...');
@@ -125,28 +196,16 @@ async function fetchMoneyBoxRates() {
       }
 
       const data = await response.json();
+      const upstreamRows = data?.data?.rates;
 
-      if (!data.result || !Array.isArray(data.data) || data.data.length === 0) {
+      if (data?.success !== true || !Array.isArray(upstreamRows) || upstreamRows.length === 0) {
         throw new AbortError(
-          `Invalid response format: result=${data.result}, data length=${data.data?.length ?? 0}`,
+          `Invalid response format: success=${data?.success}, rates length=${upstreamRows?.length ?? 0}`,
         );
       }
 
       // 解析所有幣別，以 currency 代碼為 key
-      const rates = {};
-      for (const item of data.data) {
-        const code = item.currency?.trim();
-        if (!code) continue;
-
-        rates[code] = {
-          currency: code,
-          base: parseFloat(item.base) || null,
-          buy: parseFloat(item.buy) || null,
-          sell: parseFloat(item.sell) || null,
-          spbuy: parseFloat(item.spbuy) || null,
-          spsell: parseFloat(item.spsell) || null,
-        };
-      }
+      const rates = Object.fromEntries(upstreamRows.map(mapUpstreamRow).filter(Boolean));
 
       if (Object.keys(rates).length === 0) {
         throw new AbortError('No valid rates found in response');
@@ -477,3 +536,4 @@ export { listRateChanges };
 export { needsSchemaMigration };
 export { extractSeoulSnapshotDate, shouldRefreshLatestSnapshot };
 export { assertMoneyBoxRatesIntegrity, resolveMutationThreshold };
+export { mapUpstreamRow, toLegacyQuoteUnit, deriveMidpoint };


### PR DESCRIPTION
## 修什麼

MoneyBox 匯率抓取自 2026-08-22 起持續失敗，已停更 4 天。**根因不是上游壞掉，是上游搬家。**

以瀏覽器載入官網並攔截網路請求確認：

```
GET https://moneybox-exchange.com/api/rates           → 200  ← 官網現在打這個
     https://cems.moneybox.or.kr/api/cmd.php?cmd=C011  → 完全沒有被呼叫
```

舊端點**半殘**（仍回 200、`base` 持續更新，但 18/20 幣別 `sell` 恆為 0），所以純 API 探測分不出「壞掉」與「搬家」。

## 三個陷阱

### 1. buy / sell 語意**相反**

**新 `buyRate` ≡ 舊 `sell`；新 `sellRate` ≡ 舊 `buy`。** 三重驗證：

| 驗證 | 證據 |
|---|---|
| 舊官網欄位 | CAD 買入 1,015 = 舊 `sell`；賣出 1,028 = 舊 `buy` |
| 新官網欄位 | CAD 買入 1,004 = 新 `buyRate`；賣出 1,015 = 新 `sellRate` |
| 價差方向 | 舊 `sell` < `buy`；新 `buyRate` < `sellRate` — 店家低買高賣，順序一致 |

照字面把 `sell` 對到 `sellRate` 會取到**價差的錯誤那一側**。程式碼以具名常數表達這個反向對應，避免後人重蹈：

```js
const NEW_TO_LEGACY_FIELD = Object.freeze({ sell: 'buyRate', buy: 'sellRate' });
```

### 2. JPY / IDR / VND 單位差 100 倍

新 API 一律 per-1，舊 API 對小面額幣別為 per-100。維持既有慣例以保歷史連續。

實跑結果**與官網顯示完全一致**：JPY 868/872、VND 5.1/5.6、IDR 7.8/9。

### 3. 上游移除 `base` / `spbuy` / `spsell`

新 API 每列**僅 3 欄位**（`currencyCode` / `buyRate` / `sellRate`）。端點探查確認 `/api/rates/latest`、`/history`、`/currencies`、`/config`、`/branches` 皆 404。

- `base` 改由兩側牌告價的算術中點推導
- `spbuy` / `spsell` 一律 `null`，**不得以其他欄位推導填補**

## 我自己引入又修掉的一個回歸

per-100 換算直接乘 100 會產生浮點雜訊：

```
8.72  × 100        → 872.0000000000001
0.056 × 100        → 5.6000000000000005
(42.15 + 42.3) / 2 → 42.224999999999994
```

這些值**上游原本直接提供且乾淨**，我的換算反而讓公開產物變糟。已改為以輸入位數推導輸出位數收斂（×100 減兩位、中點取較多者加一位），並加守門測試斷言輸出不得帶浮點尾數。

> 完整 decimal 算術遷移仍列 PR 2（見 PRD 049 §18.4）。這裡只做「不比原本更糟」的最小收斂。

## 驗證

**對外零變化**（PR 1 的核心驗收標準）：

```
頂層欄位 新-舊：（無）      TWD 欄位 新-舊：（無）
頂層欄位 舊-新：（無）      TWD 欄位 舊-新：（無）
schemaVersion: 2.0  quoteUnit: KRW_PER_TWD
customerBuyForeignRate: 42.15  ← v2 語意欄位仍正確衍生
```

**守門測試**：新增 9 條，涵蓋映射方向、價差方向、per-100 還原、0 與非有限值、缺 currencyCode。

**反向測試**：把映射改回「照字面對接」後，2 條測試立即失敗 —— 守門確實會擋。

| 項目 | 結果 |
|---|---|
| `scripts` typecheck | 通過 |
| `pnpm test:root` | 7 檔 **157 測試**通過 |
| 實跑對比官網 | 19 幣別數值一致 |
| pre-commit 六步 | 全綠 |

## 刻意不放進這個 PR

**輪詢頻率調整。** 上游標頭自宣 `cache-control: max-age=14400`（4 小時），我方 cron 每 5 分鐘（288 次/日，48 倍）。PRD §18.2 已裁決應改依上游快取契約並帶 `If-Modified-Since`。

但那會改變對外更新節奏，與本 PR 的「對外零變化」驗收標準衝突，依 PRD §3.2「不混合關注點」原則另開 PR。

## 關聯

- PRD：#1050（`docs/dev/049`）
- 中斷期間的診斷與節流機制：#1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)
